### PR TITLE
fix(approval): 🐛 Fix approval UI race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,115 @@ npm run typecheck
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
 
+## Shell Environment Setup
+
+TiyCode's built-in agent shell may launch as a **non-interactive, non-login** shell. In this mode, only minimal system paths (e.g. `/usr/bin:/bin`) are available. Tools installed via version managers — such as `node`, `npm`, `bun`, `cargo`, or `go` — will not be found unless you configure your shell startup files correctly.
+
+### How Shell Config Files Are Loaded
+
+Different shell invocation modes load different config files. The table below shows which files are sourced in each mode:
+
+**Zsh (macOS default / Linux)**
+
+| File | Non-interactive | Login | Interactive | Interactive + Login |
+|------|:-:|:-:|:-:|:-:|
+| `~/.zshenv` | ✅ | ✅ | ✅ | ✅ |
+| `~/.zprofile` | ❌ | ✅ | ❌ | ✅ |
+| `~/.zshrc` | ❌ | ❌ | ✅ | ✅ |
+
+**Bash (Linux default)**
+
+| File | Non-interactive | Login | Interactive | Interactive + Login |
+|------|:-:|:-:|:-:|:-:|
+| `~/.bashrc` | ❌ | ❌ | ✅ | ❌ ¹ |
+| `~/.bash_profile` | ❌ | ✅ | ❌ | ✅ |
+| `$BASH_ENV` | ✅ | ❌ | ❌ | ❌ |
+
+<sub>¹ Most distros source `~/.bashrc` from `~/.bash_profile`, so in practice it runs for login shells too.</sub>
+
+TiyCode's agent shell falls into the **non-interactive** column — only `~/.zshenv` (zsh) or `$BASH_ENV` (bash) is guaranteed to load.
+
+### Fix: Ensure Environment Variables Load for All Shell Modes
+
+<details>
+<summary><strong>macOS / Linux (Zsh)</strong></summary>
+
+1. **Move all `export` statements and PATH modifications** from `~/.zshrc` into `~/.zprofile`. Keep interactive-only settings (aliases, completions, oh-my-zsh, themes, prompt) in `~/.zshrc`.
+
+2. **Source `~/.zprofile` from `~/.zshenv`** so that non-interactive shells also get the environment:
+
+```bash
+# ~/.zshenv
+if [ -z "$__ZPROFILE_LOADED" ] && [ -f "$HOME/.zprofile" ]; then
+  export __ZPROFILE_LOADED=1
+  source "$HOME/.zprofile"
+fi
+```
+
+The `__ZPROFILE_LOADED` guard prevents double-loading in login + interactive shells.
+
+Common items to move into `~/.zprofile`:
+
+```bash
+# ~/.zprofile — examples
+eval "$(/opt/homebrew/bin/brew shellenv)"           # Homebrew (macOS)
+export NVM_DIR="$HOME/.nvm"                         # nvm (Node.js)
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+export BUN_INSTALL="$HOME/.bun"                     # Bun
+export PATH="$BUN_INSTALL/bin:$PATH"
+. "$HOME/.local/bin/env"                            # Rust / Cargo
+export PATH="/usr/local/go/bin:$PATH"               # Go
+```
+
+</details>
+
+<details>
+<summary><strong>Linux (Bash)</strong></summary>
+
+1. Keep environment variables in `~/.bash_profile` (or `~/.profile`).
+2. Set `BASH_ENV` to point to a file that sources your profile:
+
+```bash
+# ~/.bash_profile — add at the top:
+export BASH_ENV="$HOME/.bash_env"
+```
+
+```bash
+# ~/.bash_env — new file
+if [ -z "$__BASH_PROFILE_LOADED" ] && [ -f "$HOME/.bash_profile" ]; then
+  export __BASH_PROFILE_LOADED=1
+  source "$HOME/.bash_profile"
+fi
+```
+
+</details>
+
+<details>
+<summary><strong>Windows (PowerShell)</strong></summary>
+
+On Windows, TiyCode typically inherits the system and user environment variables set via **System Settings > Environment Variables**. If you installed Node.js, Rust, or other tools via their official installers, they should already be on PATH.
+
+If you use a version manager like **nvm-windows**, **fnm**, or **volta**, make sure the shim directory is added to your **User PATH** in system environment variables — not only in a PowerShell profile.
+
+To verify your current PATH in PowerShell:
+
+```powershell
+$env:PATH -split ';'
+```
+
+</details>
+
+### Verify After Configuration
+
+After updating your shell config files, **restart TiyCode** (a full quit + relaunch, not just a new thread) and ask the agent to run:
+
+```
+echo $PATH
+which <your-tool>   # e.g. node, cargo, go, bun, python ...
+```
+
+If the output includes the expected paths and the tool is found, your environment is correctly configured.
+
 ## Architecture at a Glance
 
 TiyCode separates UI rendering, desktop orchestration, and agent execution into distinct layers:

--- a/README_zh.md
+++ b/README_zh.md
@@ -101,6 +101,115 @@ npm run typecheck
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
 
+## Shell 环境配置
+
+TiyCode 内置的 Agent Shell 可能以 **非交互、非登录** 模式启动。在该模式下，只有最基础的系统路径（如 `/usr/bin:/bin`）可用。通过版本管理器安装的工具（如 `node`、`npm`、`bun`、`cargo`、`go`）将无法被识别，需要正确配置 Shell 启动文件才能解决。
+
+### Shell 配置文件加载规则
+
+不同的 Shell 调用模式会加载不同的配置文件。下表列出了各模式下的加载情况：
+
+**Zsh（macOS 默认 / Linux）**
+
+| 文件 | 非交互 | 登录 | 交互 | 交互 + 登录 |
+|------|:-:|:-:|:-:|:-:|
+| `~/.zshenv` | ✅ | ✅ | ✅ | ✅ |
+| `~/.zprofile` | ❌ | ✅ | ❌ | ✅ |
+| `~/.zshrc` | ❌ | ❌ | ✅ | ✅ |
+
+**Bash（Linux 默认）**
+
+| 文件 | 非交互 | 登录 | 交互 | 交互 + 登录 |
+|------|:-:|:-:|:-:|:-:|
+| `~/.bashrc` | ❌ | ❌ | ✅ | ❌ ¹ |
+| `~/.bash_profile` | ❌ | ✅ | ❌ | ✅ |
+| `$BASH_ENV` | ✅ | ❌ | ❌ | ❌ |
+
+<sub>¹ 大多数发行版会在 `~/.bash_profile` 中 source `~/.bashrc`，因此实际上登录 shell 也会执行它。</sub>
+
+TiyCode 的 Agent Shell 属于 **非交互** 一列 —— 只有 `~/.zshenv`（zsh）或 `$BASH_ENV`（bash）能保证被加载。
+
+### 解决方法：确保所有 Shell 模式都能加载环境变量
+
+<details>
+<summary><strong>macOS / Linux（Zsh）</strong></summary>
+
+1. **将所有 `export` 语句和 PATH 修改** 从 `~/.zshrc` 移到 `~/.zprofile`。仅将交互式配置（alias、补全、oh-my-zsh、主题、提示符）留在 `~/.zshrc` 中。
+
+2. **在 `~/.zshenv` 中 source `~/.zprofile`**，使非交互式 shell 也能获取环境变量：
+
+```bash
+# ~/.zshenv
+if [ -z "$__ZPROFILE_LOADED" ] && [ -f "$HOME/.zprofile" ]; then
+  export __ZPROFILE_LOADED=1
+  source "$HOME/.zprofile"
+fi
+```
+
+`__ZPROFILE_LOADED` 守卫变量可防止在「登录 + 交互」模式下重复加载。
+
+常见需要移入 `~/.zprofile` 的内容：
+
+```bash
+# ~/.zprofile — 示例
+eval "$(/opt/homebrew/bin/brew shellenv)"           # Homebrew（macOS）
+export NVM_DIR="$HOME/.nvm"                         # nvm（Node.js）
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+export BUN_INSTALL="$HOME/.bun"                     # Bun
+export PATH="$BUN_INSTALL/bin:$PATH"
+. "$HOME/.local/bin/env"                            # Rust / Cargo
+export PATH="/usr/local/go/bin:$PATH"               # Go
+```
+
+</details>
+
+<details>
+<summary><strong>Linux（Bash）</strong></summary>
+
+1. 将环境变量保留在 `~/.bash_profile`（或 `~/.profile`）中。
+2. 设置 `BASH_ENV` 指向一个会 source 你的 profile 的文件：
+
+```bash
+# ~/.bash_profile — 在顶部添加：
+export BASH_ENV="$HOME/.bash_env"
+```
+
+```bash
+# ~/.bash_env — 新文件
+if [ -z "$__BASH_PROFILE_LOADED" ] && [ -f "$HOME/.bash_profile" ]; then
+  export __BASH_PROFILE_LOADED=1
+  source "$HOME/.bash_profile"
+fi
+```
+
+</details>
+
+<details>
+<summary><strong>Windows（PowerShell）</strong></summary>
+
+在 Windows 上，TiyCode 通常会继承通过 **系统设置 > 环境变量** 配置的系统和用户环境变量。如果你通过官方安装器安装了 Node.js、Rust 等工具，它们应该已经在 PATH 中。
+
+如果你使用的是版本管理器（如 **nvm-windows**、**fnm** 或 **volta**），请确保 shim 目录已添加到系统环境变量中的 **用户 PATH**，而不是仅在 PowerShell profile 中设置。
+
+验证当前 PATH：
+
+```powershell
+$env:PATH -split ';'
+```
+
+</details>
+
+### 配置后验证
+
+更新 Shell 配置文件后，**重启 TiyCode**（完全退出后重新启动，而非仅开启新会话），然后让 Agent 执行：
+
+```
+echo $PATH
+which <你的工具>   # 例如 node、cargo、go、bun、python ...
+```
+
+如果输出中包含预期的路径且工具能被找到，说明环境配置已生效。
+
 ## 架构速览
 
 TiyCode 将界面渲染、桌面编排和 Agent 执行拆分为清晰的几层：

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -58,6 +58,28 @@ fn forward_thread_stream_events(
     });
 }
 
+async fn handle_tool_approval_response(
+    tool_gateway: &crate::core::tool_gateway::ToolGateway,
+    tool_call_id: &str,
+    run_id: &str,
+    approved: bool,
+) -> Result<(), AppError> {
+    let found = tool_gateway
+        .resolve_approval(tool_call_id, approved)
+        .await?;
+
+    if !found {
+        // Silently ignore duplicate approval responses (e.g. user double-clicked the button).
+        tracing::warn!(
+            tool_call_id = %tool_call_id,
+            run_id = %run_id,
+            "Ignoring duplicate tool approval response — no pending approval found"
+        );
+    }
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn thread_start_run(
     state: State<'_, AppState>,
@@ -143,9 +165,124 @@ pub async fn thread_execute_approved_plan(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use std::str::FromStr;
+    use std::sync::Arc;
 
-    use super::extract_run_model_refs;
+    use serde_json::json;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use sqlx::Row;
+
+    use super::{extract_run_model_refs, handle_tool_approval_response};
+    use crate::core::terminal_manager::TerminalManager;
+    use crate::core::tool_gateway::{
+        ToolExecutionOptions, ToolExecutionRequest, ToolGateway, ToolGatewayResult,
+    };
+
+    async fn setup_test_pool() -> sqlx::SqlitePool {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("invalid sqlite options")
+            .foreign_keys(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to create in-memory pool");
+
+        crate::persistence::sqlite::run_migrations(&pool)
+            .await
+            .expect("migrations failed");
+
+        pool
+    }
+
+    async fn seed_workspace(pool: &sqlx::SqlitePool, id: &str, canonical_path: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
+                    is_default, is_git, auto_work_tree, status, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, 0, 0, 0, 'ready', ?, ?)",
+        )
+        .bind(id)
+        .bind("Test Workspace")
+        .bind(canonical_path)
+        .bind(canonical_path)
+        .bind(canonical_path)
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .expect("failed to seed workspace");
+    }
+
+    async fn seed_thread(pool: &sqlx::SqlitePool, thread_id: &str, workspace_id: &str) {
+        let now = chrono::Utc::now().to_rfc3339();
+        sqlx::query(
+            "INSERT INTO threads (id, workspace_id, title, status, last_active_at, created_at, updated_at)
+             VALUES (?, ?, 'Test Thread', 'idle', ?, ?, ?)",
+        )
+        .bind(thread_id)
+        .bind(workspace_id)
+        .bind(&now)
+        .bind(&now)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .expect("failed to seed thread");
+    }
+
+    async fn seed_run(
+        pool: &sqlx::SqlitePool,
+        run_id: &str,
+        thread_id: &str,
+        status: &str,
+        run_mode: &str,
+    ) {
+        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+        sqlx::query(
+            "INSERT INTO thread_runs (id, thread_id, run_mode, status, started_at)
+             VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(run_id)
+        .bind(thread_id)
+        .bind(run_mode)
+        .bind(status)
+        .bind(&now)
+        .execute(pool)
+        .await
+        .expect("failed to seed run");
+    }
+
+    async fn seed_tool_call(
+        pool: &sqlx::SqlitePool,
+        tool_call_id: &str,
+        run_id: &str,
+        thread_id: &str,
+        tool_name: &str,
+        status: &str,
+    ) {
+        sqlx::query(
+            "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, tool_input_json, status, started_at)
+             VALUES (?, ?, ?, ?, '{}', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+        )
+        .bind(tool_call_id)
+        .bind(run_id)
+        .bind(thread_id)
+        .bind(tool_name)
+        .bind(status)
+        .execute(pool)
+        .await
+        .expect("failed to seed tool call");
+    }
+
+    async fn seed_policy(pool: &sqlx::SqlitePool, key: &str, value_json: &str) {
+        sqlx::query("INSERT OR REPLACE INTO policies (key, value_json) VALUES (?, ?)")
+            .bind(key)
+            .bind(value_json)
+            .execute(pool)
+            .await
+            .expect("failed to seed policy");
+    }
 
     #[test]
     fn extracts_profile_and_primary_refs_from_model_plan() {
@@ -178,6 +315,122 @@ mod tests {
 
         assert_eq!(provider_id.as_deref(), Some("provider-1"));
         assert_eq!(model_id.as_deref(), Some("gpt-5"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_tool_approval_responses_are_ignored_after_first_success() {
+        let pool = setup_test_pool().await;
+        let workspace_root = tempfile::tempdir().expect("failed to create temp dir");
+        let workspace_path = workspace_root.path().join("workspace");
+        std::fs::create_dir_all(&workspace_path).expect("failed to create workspace directory");
+
+        let target_file = workspace_path.join("README.md");
+        std::fs::write(&target_file, "hello\n").expect("failed to write test file");
+
+        let workspace_path =
+            std::fs::canonicalize(&workspace_path).expect("failed to canonicalize workspace");
+        let target_file =
+            std::fs::canonicalize(&target_file).expect("failed to canonicalize test file");
+
+        seed_workspace(&pool, "ws-dup-approval", workspace_path.to_str().unwrap()).await;
+        seed_thread(&pool, "t-dup-approval", "ws-dup-approval").await;
+        seed_run(
+            &pool,
+            "r-dup-approval",
+            "t-dup-approval",
+            "running",
+            "default",
+        )
+        .await;
+        seed_tool_call(
+            &pool,
+            "tc-dup-approval",
+            "r-dup-approval",
+            "t-dup-approval",
+            "write",
+            "requested",
+        )
+        .await;
+        seed_policy(&pool, "approval_policy", r#""require_all""#).await;
+
+        let terminal_manager = Arc::new(TerminalManager::new(pool.clone()));
+        let gateway = Arc::new(ToolGateway::new(pool.clone(), terminal_manager));
+        let (approval_requested_tx, approval_requested_rx) = tokio::sync::oneshot::channel();
+
+        let execution_gateway = Arc::clone(&gateway);
+        let workspace_path_text = workspace_path.display().to_string();
+        let target_file_text = target_file.display().to_string();
+        let execution = tokio::spawn(async move {
+            execution_gateway
+                .execute_tool_call(
+                    ToolExecutionRequest {
+                        run_id: "r-dup-approval".into(),
+                        thread_id: "t-dup-approval".into(),
+                        tool_call_id: "tc-dup-approval".into(),
+                        tool_name: "write".into(),
+                        tool_input: serde_json::json!({
+                            "path": target_file_text,
+                            "content": "updated by approval\n",
+                        }),
+                        workspace_path: workspace_path_text,
+                        run_mode: "default".into(),
+                    },
+                    tiycore::agent::AbortSignal::new(),
+                    ToolExecutionOptions::default(),
+                    {
+                        let mut approval_requested_tx = Some(approval_requested_tx);
+                        move |_| {
+                            if let Some(tx) = approval_requested_tx.take() {
+                                let _ = tx.send(());
+                            }
+                        }
+                    },
+                    || {},
+                )
+                .await
+        });
+
+        approval_requested_rx
+            .await
+            .expect("approval should have been requested");
+
+        handle_tool_approval_response(gateway.as_ref(), "tc-dup-approval", "r-dup-approval", true)
+            .await
+            .expect("first approval response should succeed");
+
+        handle_tool_approval_response(gateway.as_ref(), "tc-dup-approval", "r-dup-approval", true)
+            .await
+            .expect("duplicate approval response should be ignored");
+
+        let outcome = execution
+            .await
+            .expect("execution task should join")
+            .expect("tool execution should succeed");
+
+        match outcome.result {
+            ToolGatewayResult::Executed { .. } => {}
+            other => panic!(
+                "expected executed outcome after approval, got {:?}",
+                std::mem::discriminant(&other)
+            ),
+        }
+
+        let row = sqlx::query(
+            "SELECT status, approval_status FROM tool_calls WHERE id = 'tc-dup-approval'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("tool call row should exist");
+
+        assert_eq!(row.get::<String, _>("status"), "completed");
+        assert_eq!(
+            row.get::<Option<String>, _>("approval_status").unwrap(),
+            "approved"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target_file).expect("failed to read updated file"),
+            "updated by approval\n"
+        );
     }
 }
 
@@ -220,21 +473,13 @@ pub async fn tool_approval_respond(
     run_id: String,
     approved: bool,
 ) -> Result<(), AppError> {
-    let found = state
-        .tool_gateway
-        .resolve_approval(&tool_call_id, approved)
-        .await?;
-
-    if !found {
-        // Silently ignore duplicate approval responses (e.g. user double-clicked the button).
-        tracing::warn!(
-            tool_call_id = %tool_call_id,
-            run_id = %run_id,
-            "Ignoring duplicate tool approval response — no pending approval found"
-        );
-    }
-
-    Ok(())
+    handle_tool_approval_response(
+        state.tool_gateway.as_ref(),
+        &tool_call_id,
+        &run_id,
+        approved,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -226,13 +226,12 @@ pub async fn tool_approval_respond(
         .await?;
 
     if !found {
-        return Err(AppError::recoverable(
-            crate::model::errors::ErrorSource::Tool,
-            "tool.approval.not_found",
-            format!(
-                "No pending approval was found for tool call '{tool_call_id}' in run '{run_id}'"
-            ),
-        ));
+        // Silently ignore duplicate approval responses (e.g. user double-clicked the button).
+        tracing::warn!(
+            tool_call_id = %tool_call_id,
+            run_id = %run_id,
+            "Ignoring duplicate tool approval response — no pending approval found"
+        );
     }
 
     Ok(())

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -1071,6 +1071,48 @@ function isMoreAdvancedToolState(
   return TOOL_STATE_ORDER[liveState] > TOOL_STATE_ORDER[snapshotState];
 }
 
+/**
+ * Merge snapshot tools with live tools.  Uses the snapshot as the base but:
+ * 1. Preserves any live tool whose state is more advanced than its snapshot
+ *    counterpart (avoids regressing state from a stale snapshot).
+ * 2. Appends live-only tools that are not yet present in the snapshot (e.g.
+ *    a tool_requested / approval_required event arrived via the stream while
+ *    the async snapshot fetch was in flight).
+ */
+function mergeSnapshotTools(
+  snapshotTools: Array<SurfaceToolEntry>,
+  liveTools: Array<SurfaceToolEntry>,
+): Array<SurfaceToolEntry> {
+  if (liveTools.length === 0) {
+    return snapshotTools;
+  }
+
+  const snapshotIds = new Set(snapshotTools.map((t) => t.id));
+
+  const merged = snapshotTools.map((snapshotTool) => {
+    const liveTool = liveTools.find((t) => t.id === snapshotTool.id);
+
+    if (!liveTool) {
+      return snapshotTool;
+    }
+
+    if (isMoreAdvancedToolState(liveTool.state, snapshotTool.state)) {
+      return liveTool;
+    }
+
+    return snapshotTool;
+  });
+
+  // Append tools that exist in the live state but not in the snapshot.
+  for (const liveTool of liveTools) {
+    if (!snapshotIds.has(liveTool.id)) {
+      merged.push(liveTool);
+    }
+  }
+
+  return merged;
+}
+
 function stringifyToolValue(value: unknown) {
   if (typeof value === "string") {
     return value;
@@ -2231,29 +2273,7 @@ export function RuntimeThreadSurface({
       setApprovingPlanMessageId(null);
       setTools((currentTools) => {
         const snapshotTools = (snapshot.toolCalls ?? []).map(mapSnapshotTool);
-
-        // On fresh mount (no current tools), use snapshot directly.
-        if (currentTools.length === 0) {
-          return snapshotTools;
-        }
-
-        // Merge: use snapshot as base but preserve any tool that the live
-        // stream has already advanced further in its lifecycle.  This avoids
-        // a stale snapshot overwriting an approval-requested state that was
-        // set by a stream event while the async snapshot fetch was in flight.
-        return snapshotTools.map((snapshotTool) => {
-          const liveTool = currentTools.find((t) => t.id === snapshotTool.id);
-
-          if (!liveTool) {
-            return snapshotTool;
-          }
-
-          if (isMoreAdvancedToolState(liveTool.state, snapshotTool.state)) {
-            return liveTool;
-          }
-
-          return snapshotTool;
-        });
+        return mergeSnapshotTools(snapshotTools, currentTools);
       });
       setHelpers((snapshot.helpers ?? []).map((helper) => mapSnapshotHelper(helper, snapshot.toolCalls ?? [])));
       setTaskBoards(taskBoardsFromSnapshot(snapshot.taskBoards ?? [], snapshot.activeTaskBoardId ?? null));
@@ -2362,24 +2382,7 @@ export function RuntimeThreadSurface({
       const nextState = mapSnapshotToRunState(snapshot);
       setTools((currentTools) => {
         const snapshotTools = (snapshot.toolCalls ?? []).map(mapSnapshotTool);
-
-        if (currentTools.length === 0) {
-          return snapshotTools;
-        }
-
-        return snapshotTools.map((snapshotTool) => {
-          const liveTool = currentTools.find((t) => t.id === snapshotTool.id);
-
-          if (!liveTool) {
-            return snapshotTool;
-          }
-
-          if (isMoreAdvancedToolState(liveTool.state, snapshotTool.state)) {
-            return liveTool;
-          }
-
-          return snapshotTool;
-        });
+        return mergeSnapshotTools(snapshotTools, currentTools);
       });
       setHelpers((snapshot.helpers ?? []).map((helper) => mapSnapshotHelper(helper, snapshot.toolCalls ?? [])));
       setTaskBoards(taskBoardsFromSnapshot(snapshot.taskBoards ?? [], snapshot.activeTaskBoardId ?? null));


### PR DESCRIPTION
## Summary
- **Make `tool_approval_respond` idempotent**: when no pending approval is found (e.g. user double-clicked the button), log a warning instead of returning an error — eliminates the `tool.approval.not_found` error on duplicate clicks
- **Fix snapshot merge dropping live-only tools**: extract `mergeSnapshotTools()` that appends tools existing in live state but not yet in the snapshot, preventing approval buttons from disappearing when an async snapshot fetch races with stream events (`tool_requested` / `approval_required`)

## Test Plan
- [ ] Trigger a tool requiring approval, rapidly double-click the Approve button — no error should appear
- [ ] During a run with multiple tool calls, verify the approval UI consistently appears when a tool enters `waiting_approval` state
- [ ] Verify that after snapshot resync (e.g. `resyncCompletedMessage`), live-only tools with `approval-requested` state are preserved in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)