### PR TITLE
feat(workspaces): ensure default thread workspace on dashboard init

### DIFF
--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -22,6 +22,17 @@ pub async fn workspace_add(
 }
 
 #[tauri::command]
+pub async fn workspace_ensure_default(
+    state: State<'_, AppState>,
+) -> Result<WorkspaceDto, AppError> {
+    let record = state
+        .workspace_manager
+        .ensure_default_thread_workspace()
+        .await?;
+    Ok(WorkspaceDto::from(record))
+}
+
+#[tauri::command]
 pub async fn workspace_remove(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
     state.workspace_manager.remove(&id).await
 }

--- a/src-tauri/src/core/executors/filesystem.rs
+++ b/src-tauri/src/core/executors/filesystem.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use tokio::fs;
 
+#[cfg(target_os = "windows")]
 use crate::core::windows_process::configure_background_tokio_command;
 use crate::core::workspace_paths::{
     canonicalize_workspace_root, normalize_additional_roots, resolve_path_within_roots,

--- a/src-tauri/src/core/executors/process.rs
+++ b/src-tauri/src/core/executors/process.rs
@@ -2,6 +2,7 @@ use tokio::process::Command;
 
 use super::truncation::{truncate_tail_bytes, COMMAND_MAX_BYTES, COMMAND_MAX_LINES};
 use super::ToolOutput;
+#[cfg(target_os = "windows")]
 use crate::core::windows_process::configure_background_tokio_command;
 use crate::model::errors::AppError;
 

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use sqlx::SqlitePool;
-use std::path::Path;
+use std::fs;
+use std::path::{Path, PathBuf};
 
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::workspace::{WorkspaceAddInput, WorkspaceRecord, WorkspaceStatus};
@@ -93,6 +94,17 @@ impl WorkspaceManager {
         Ok(record)
     }
 
+    /// Ensure the built-in default workspace exists at `~/.tiy/workspace/Default`.
+    pub async fn ensure_default_thread_workspace(&self) -> Result<WorkspaceRecord, AppError> {
+        let home_dir = dirs::home_dir().ok_or_else(|| {
+            AppError::internal(ErrorSource::Workspace, "cannot resolve HOME directory")
+        })?;
+        let workspace_path = default_thread_workspace_path_for_home(&home_dir);
+
+        self.ensure_workspace_at_path(&workspace_path, DEFAULT_THREAD_WORKSPACE_NAME)
+            .await
+    }
+
     /// Remove a workspace by ID.
     pub async fn remove(&self, id: &str) -> Result<(), AppError> {
         let deleted = workspace_repo::delete(&self.pool, id).await?;
@@ -160,6 +172,79 @@ impl WorkspaceManager {
         }
         Ok(())
     }
+
+    async fn ensure_workspace_at_path(
+        &self,
+        workspace_path: &Path,
+        name: &str,
+    ) -> Result<WorkspaceRecord, AppError> {
+        if workspace_path.exists() && !workspace_path.is_dir() {
+            return Err(AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.path.not_directory",
+                format!("'{}' is not a directory", workspace_path.display()),
+            ));
+        }
+
+        fs::create_dir_all(workspace_path).map_err(|error| {
+            AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.path.create_failed",
+                format!(
+                    "Cannot create workspace '{}': {error}",
+                    workspace_path.display()
+                ),
+            )
+        })?;
+
+        let canonical = workspace_path.canonicalize().map_err(|error| {
+            AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.path.invalid",
+                format!(
+                    "Cannot resolve path '{}': {error}",
+                    workspace_path.display()
+                ),
+            )
+        })?;
+        let canonical_str = canonical.to_string_lossy().to_string();
+
+        if let Some(existing) =
+            workspace_repo::find_by_canonical_path(&self.pool, &canonical_str).await?
+        {
+            return Ok(existing);
+        }
+
+        match self
+            .add(WorkspaceAddInput {
+                path: workspace_path.to_string_lossy().to_string(),
+                name: Some(name.to_string()),
+            })
+            .await
+        {
+            Ok(record) => Ok(record),
+            Err(error) if error.error_code == "workspace.duplicate" => {
+                workspace_repo::find_by_canonical_path(&self.pool, &canonical_str)
+                    .await?
+                    .ok_or_else(|| {
+                        AppError::internal(
+                            ErrorSource::Workspace,
+                            "workspace already exists but could not be loaded",
+                        )
+                    })
+            }
+            Err(error) => Err(error),
+        }
+    }
+}
+
+const DEFAULT_THREAD_WORKSPACE_NAME: &str = "Default";
+
+fn default_thread_workspace_path_for_home(home_dir: &Path) -> PathBuf {
+    home_dir
+        .join(".tiy")
+        .join("workspace")
+        .join(DEFAULT_THREAD_WORKSPACE_NAME)
 }
 
 /// Derive a human-readable name from the last path component.
@@ -178,4 +263,20 @@ fn derive_display_path(path: &Path) -> String {
         }
     }
     path.display().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builds_default_thread_workspace_path_under_tiy_workspace_directory() {
+        let home_dir = Path::new("/tmp/jorben");
+        let workspace_path = default_thread_workspace_path_for_home(home_dir);
+
+        assert_eq!(
+            workspace_path,
+            PathBuf::from("/tmp/jorben/.tiy/workspace/Default")
+        );
+    }
 }

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -1,7 +1,8 @@
 use chrono::Utc;
 use sqlx::SqlitePool;
-use std::fs;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use tokio::{fs, task};
 
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::workspace::{WorkspaceAddInput, WorkspaceRecord, WorkspaceStatus};
@@ -27,13 +28,23 @@ impl WorkspaceManager {
 
         // Canonicalize the path (resolves symlinks, makes absolute).
         // Use dunce to avoid Windows extended-length path prefix (\\?\).
-        let canonical = dunce::canonicalize(raw_path).map_err(|e| {
-            AppError::recoverable(
-                ErrorSource::Workspace,
-                "workspace.path.invalid",
-                format!("Cannot resolve path '{}': {e}", input.path),
-            )
-        })?;
+        let raw_path_buf = raw_path.to_path_buf();
+        let input_path_for_error = input.path.clone();
+        let canonical = task::spawn_blocking(move || dunce::canonicalize(&raw_path_buf))
+            .await
+            .map_err(|error| {
+                AppError::internal(
+                    ErrorSource::Workspace,
+                    format!("workspace path canonicalization task failed: {error}"),
+                )
+            })?
+            .map_err(|error| {
+                AppError::recoverable(
+                    ErrorSource::Workspace,
+                    "workspace.path.invalid",
+                    format!("Cannot resolve path '{}': {error}", input_path_for_error),
+                )
+            })?;
 
         let canonical_str = canonical.to_string_lossy().to_string();
 
@@ -50,7 +61,14 @@ impl WorkspaceManager {
         }
 
         // Validate path is a directory
-        if !canonical.is_dir() {
+        let metadata = fs::metadata(&canonical).await.map_err(|error| {
+            AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.path.invalid",
+                format!("Cannot inspect path '{}': {error}", input.path),
+            )
+        })?;
+        if !metadata.is_dir() {
             return Err(AppError::recoverable(
                 ErrorSource::Workspace,
                 "workspace.path.not_directory",
@@ -62,10 +80,10 @@ impl WorkspaceManager {
         let name = input
             .name
             .unwrap_or_else(|| derive_name_from_path(&canonical));
-        let display_path = derive_display_path(&canonical);
+        let display_path = derive_display_path(&canonical).await;
 
         // Detect git repository
-        let is_git = canonical.join(".git").exists();
+        let is_git = fs::metadata(canonical.join(".git")).await.is_ok();
 
         let record = WorkspaceRecord {
             id: uuid::Uuid::now_v7().to_string(),
@@ -131,18 +149,21 @@ impl WorkspaceManager {
         let canonical = Path::new(&record.canonical_path);
         let now = Utc::now();
 
-        let new_status = if !canonical.exists() {
-            WorkspaceStatus::Missing
-        } else if !canonical.is_dir() {
-            WorkspaceStatus::Invalid
-        } else if std::fs::read_dir(canonical).is_err() {
-            WorkspaceStatus::Inaccessible
-        } else {
-            WorkspaceStatus::Ready
+        let new_status = match fs::metadata(canonical).await {
+            Ok(metadata) if !metadata.is_dir() => WorkspaceStatus::Invalid,
+            Ok(_) => {
+                if fs::read_dir(canonical).await.is_err() {
+                    WorkspaceStatus::Inaccessible
+                } else {
+                    WorkspaceStatus::Ready
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::NotFound => WorkspaceStatus::Missing,
+            Err(_) => WorkspaceStatus::Inaccessible,
         };
 
         // Update git detection as well
-        let is_git = canonical.join(".git").exists();
+        let is_git = fs::metadata(canonical.join(".git")).await.is_ok();
         if is_git != record.is_git {
             workspace_repo::update_is_git(&self.pool, id, is_git).await?;
         }
@@ -178,15 +199,29 @@ impl WorkspaceManager {
         workspace_path: &Path,
         name: &str,
     ) -> Result<WorkspaceRecord, AppError> {
-        if workspace_path.exists() && !workspace_path.is_dir() {
-            return Err(AppError::recoverable(
-                ErrorSource::Workspace,
-                "workspace.path.not_directory",
-                format!("'{}' is not a directory", workspace_path.display()),
-            ));
+        match fs::metadata(workspace_path).await {
+            Ok(metadata) if !metadata.is_dir() => {
+                return Err(AppError::recoverable(
+                    ErrorSource::Workspace,
+                    "workspace.path.not_directory",
+                    format!("'{}' is not a directory", workspace_path.display()),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(AppError::recoverable(
+                    ErrorSource::Workspace,
+                    "workspace.path.invalid",
+                    format!(
+                        "Cannot inspect path '{}': {error}",
+                        workspace_path.display()
+                    ),
+                ));
+            }
         }
 
-        fs::create_dir_all(workspace_path).map_err(|error| {
+        fs::create_dir_all(workspace_path).await.map_err(|error| {
             AppError::recoverable(
                 ErrorSource::Workspace,
                 "workspace.path.create_failed",
@@ -197,16 +232,23 @@ impl WorkspaceManager {
             )
         })?;
 
-        let canonical = workspace_path.canonicalize().map_err(|error| {
-            AppError::recoverable(
-                ErrorSource::Workspace,
-                "workspace.path.invalid",
-                format!(
-                    "Cannot resolve path '{}': {error}",
-                    workspace_path.display()
-                ),
-            )
-        })?;
+        let workspace_path_buf = workspace_path.to_path_buf();
+        let workspace_path_display = workspace_path.display().to_string();
+        let canonical = task::spawn_blocking(move || dunce::canonicalize(&workspace_path_buf))
+            .await
+            .map_err(|error| {
+                AppError::internal(
+                    ErrorSource::Workspace,
+                    format!("workspace path canonicalization task failed: {error}"),
+                )
+            })?
+            .map_err(|error| {
+                AppError::recoverable(
+                    ErrorSource::Workspace,
+                    "workspace.path.invalid",
+                    format!("Cannot resolve path '{}': {error}", workspace_path_display),
+                )
+            })?;
         let canonical_str = canonical.to_string_lossy().to_string();
 
         if let Some(existing) =
@@ -256,10 +298,19 @@ fn derive_name_from_path(path: &Path) -> String {
 }
 
 /// Derive a display-friendly path using `~` for the home directory.
-fn derive_display_path(path: &Path) -> String {
+async fn derive_display_path(path: &Path) -> String {
     if let Some(home) = dirs::home_dir() {
         if let Ok(relative) = path.strip_prefix(&home) {
             return format!("~/{}", relative.display());
+        }
+
+        let home_for_canonicalize = home.clone();
+        if let Ok(Ok(canonical_home)) =
+            task::spawn_blocking(move || dunce::canonicalize(&home_for_canonicalize)).await
+        {
+            if let Ok(relative) = path.strip_prefix(&canonical_home) {
+                return format!("~/{}", relative.display());
+            }
         }
     }
     path.display().to_string()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ fn init_directories(base: &PathBuf) -> std::io::Result<()> {
         base.join("prompts"),
         base.join("plugins"),
         base.join("automations"),
+        base.join("workspace"),
         base.join("cache"),
         base.join("cache/index"),
         base.join("catalog"),
@@ -257,6 +258,7 @@ pub fn run() {
             // Workspace
             commands::workspace::workspace_list,
             commands::workspace::workspace_add,
+            commands::workspace::workspace_ensure_default,
             commands::workspace::workspace_remove,
             commands::workspace::workspace_set_default,
             commands::workspace::workspace_validate,

--- a/src-tauri/tests/m1_2_workspace.rs
+++ b/src-tauri/tests/m1_2_workspace.rs
@@ -9,7 +9,36 @@
 mod test_helpers;
 
 use sqlx::Row;
+use std::ffi::OsString;
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 use tiycode::core::workspace_manager::WorkspaceManager;
+
+fn home_env_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+struct HomeEnvGuard {
+    original_home: Option<OsString>,
+}
+
+impl HomeEnvGuard {
+    fn set(home: &Path) -> Self {
+        let original_home = std::env::var_os("HOME");
+        std::env::set_var("HOME", home);
+        Self { original_home }
+    }
+}
+
+impl Drop for HomeEnvGuard {
+    fn drop(&mut self) {
+        match &self.original_home {
+            Some(home) => std::env::set_var("HOME", home),
+            None => std::env::remove_var("HOME"),
+        }
+    }
+}
 
 // =========================================================================
 // T1.2.1 — Workspace CRUD operations (repo layer)
@@ -52,6 +81,82 @@ async fn test_workspace_duplicate_canonical_path_rejected() {
         result.is_err(),
         "Duplicate canonical_path should be rejected by UNIQUE constraint"
     );
+}
+
+#[tokio::test]
+async fn test_workspace_ensure_default_creates_and_reuses_default_workspace() {
+    let _home_lock = home_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp_home = tempfile::tempdir().expect("should create temp home");
+    let _home_guard = HomeEnvGuard::set(temp_home.path());
+
+    let pool = test_helpers::setup_test_pool().await;
+    let manager = WorkspaceManager::new(pool.clone());
+
+    let record = manager.ensure_default_thread_workspace().await.unwrap();
+    let expected_path = temp_home
+        .path()
+        .join(".tiy")
+        .join("workspace")
+        .join("Default");
+    let expected_canonical = dunce::canonicalize(&expected_path)
+        .unwrap()
+        .to_string_lossy()
+        .to_string();
+    let expected_display = format!(
+        "~/{}",
+        Path::new(".tiy")
+            .join("workspace")
+            .join("Default")
+            .display()
+    );
+
+    assert_eq!(record.name, "Default");
+    assert_eq!(record.path, expected_path.to_string_lossy().to_string());
+    assert_eq!(record.canonical_path, expected_canonical);
+    assert_eq!(record.display_path, expected_display);
+    assert!(expected_path.is_dir());
+
+    let reused = manager.ensure_default_thread_workspace().await.unwrap();
+    assert_eq!(reused.id, record.id);
+
+    let row = sqlx::query("SELECT COUNT(*) as count FROM workspaces WHERE canonical_path = ?")
+        .bind(&expected_canonical)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<i64, _>("count"), 1);
+}
+
+#[tokio::test]
+async fn test_workspace_ensure_default_rejects_file_at_default_path() {
+    let _home_lock = home_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+    let temp_home = tempfile::tempdir().expect("should create temp home");
+    let _home_guard = HomeEnvGuard::set(temp_home.path());
+
+    let default_path = temp_home
+        .path()
+        .join(".tiy")
+        .join("workspace")
+        .join("Default");
+    tokio::fs::create_dir_all(default_path.parent().unwrap())
+        .await
+        .unwrap();
+    tokio::fs::write(&default_path, b"not-a-directory")
+        .await
+        .unwrap();
+
+    let pool = test_helpers::setup_test_pool().await;
+    let manager = WorkspaceManager::new(pool.clone());
+
+    let error = manager.ensure_default_thread_workspace().await.unwrap_err();
+    assert_eq!(error.error_code, "workspace.path.not_directory");
+
+    let row = sqlx::query("SELECT COUNT(*) as count FROM workspaces")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("count"), 0);
 }
 
 #[tokio::test]

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -182,9 +182,9 @@ const en: Record<TranslationKey, string> = {
 
   // ── New Thread Empty State ─────────────────────────────────
   "newThread.headline": "Whenever you need, Tiy is here.",
-  "newThread.description": "Choose a local workspace and start your next goal here.",
+  "newThread.description": "Start chatting right away, or pick a local workspace first.",
   "newThread.chooseProject": "Choose project",
-  "newThread.selectFolderHint": "Select a folder to start a workspace-backed thread",
+  "newThread.selectFolderHint": "Pick a folder as a workspace, or start without one",
   "newThread.recentProjects": "Recent projects",
   "newThread.current": "Current",
   "newThread.chooseNewFolder": "Choose new folder",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -181,7 +181,7 @@ const en: Record<TranslationKey, string> = {
   "sidebar.deleting": "Deleting",
 
   // ── New Thread Empty State ─────────────────────────────────
-  "newThread.headline": "Anything you need, just ask.",
+  "newThread.headline": "Whenever you need, Tiy is here.",
   "newThread.description": "Choose a local workspace and start your next goal here.",
   "newThread.chooseProject": "Choose project",
   "newThread.selectFolderHint": "Select a folder to start a workspace-backed thread",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -185,7 +185,7 @@ const zhCN = {
   "newThread.description":
     "直接开始对话，或选择一个本地工作区后开启对话",
   "newThread.chooseProject": "选择项目",
-  "newThread.selectFolderHint": "选择一个文件夹以启动基于工作区的对话",
+  "newThread.selectFolderHint": "选择一个文件夹作为工作区，或直接开启对话",
   "newThread.recentProjects": "最近的项目",
   "newThread.current": "当前",
   "newThread.chooseNewFolder": "选择新文件夹",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -183,7 +183,7 @@ const zhCN = {
   // ── New Thread Empty State ─────────────────────────────────
   "newThread.headline": "一切所需，聊聊即达。",
   "newThread.description":
-    "选择一个本地工作区，从这里开始你的下一项目标。",
+    "直接开始对话，或选择一个本地工作区后开启对话",
   "newThread.chooseProject": "选择项目",
   "newThread.selectFolderHint": "选择一个文件夹以启动基于工作区的对话",
   "newThread.recentProjects": "最近的项目",

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -56,6 +56,7 @@ import {
   threadDelete,
   threadList,
   workspaceAdd,
+  workspaceEnsureDefault,
   workspaceList,
   workspaceRemove,
   workspaceSetDefault,
@@ -174,6 +175,15 @@ function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
     ...project,
     id: workspace.id,
     name: workspace.name,
+  };
+}
+
+function buildWorkspaceBindingsForEntry(
+  workspace: Pick<WorkspaceDto, "id" | "path" | "canonicalPath">,
+) {
+  return {
+    [workspace.path]: workspace.id,
+    [workspace.canonicalPath]: workspace.id,
   };
 }
 
@@ -556,6 +566,7 @@ export function DashboardWorkbench() {
     isTauri() ? {} : buildInitialWorkspaceThreadDisplayCounts(),
   );
   const newThreadCreationRef = useRef<Record<string, Promise<string>>>({});
+  const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
   const activeThread = getActiveThread(workspaces);
   const selectedProjectWorkspaceId =
@@ -1214,6 +1225,10 @@ export function DashboardWorkbench() {
       return;
     }
 
+    if (removedWorkspacePathsRef.current.has(currentProject.path)) {
+      return;
+    }
+
     if (terminalWorkspaceBindings[currentProject.path]) {
       return;
     }
@@ -1584,6 +1599,7 @@ export function DashboardWorkbench() {
       lastOpenedLabel: t("time.justNow"),
     };
 
+    removedWorkspacePathsRef.current.delete(nextProject.path);
     setSelectedProject(nextProject);
     setRecentProjects((current) => mergeRecentProjects(current, nextProject));
   };
@@ -1609,6 +1625,7 @@ export function DashboardWorkbench() {
       lastOpenedLabel: t("time.justNow"),
     };
 
+    removedWorkspacePathsRef.current.delete(nextProject.path);
     setSelectedProject(nextProject);
     setRecentProjects((current) => mergeRecentProjects(current, nextProject));
     setOpenWorkspaces((current) => ({
@@ -1800,24 +1817,71 @@ export function DashboardWorkbench() {
       }
 
       void (async () => {
-        if (!selectedProject) {
+        let nextProject = selectedProject;
+        let nextWorkspaceId = resolvedWorkspaceId;
+
+        if (isTauri() && !nextWorkspaceId) {
+          try {
+            const projectToEnsure = nextProject;
+            const ensuredWorkspace = projectToEnsure
+              ? await workspaceList().then((workspaceEntries) => {
+                  const existingWorkspace =
+                    workspaceEntries.find(
+                      (workspace) =>
+                        workspace.path === projectToEnsure.path ||
+                        workspace.canonicalPath === projectToEnsure.path,
+                    ) ?? null;
+
+                  return (
+                    existingWorkspace ??
+                    workspaceAdd(projectToEnsure.path, projectToEnsure.name)
+                  );
+                })
+              : await workspaceEnsureDefault();
+            const ensuredProject =
+              buildProjectOptionFromWorkspace(ensuredWorkspace) ?? {
+                id: ensuredWorkspace.id,
+                name: ensuredWorkspace.name,
+                path: ensuredWorkspace.canonicalPath || ensuredWorkspace.path,
+                lastOpenedLabel: t("time.justNow"),
+              };
+
+            nextProject = ensuredProject;
+            nextWorkspaceId = ensuredWorkspace.id;
+
+            setSelectedProject(ensuredProject);
+            setRecentProjects((current) =>
+              mergeRecentProjects(current, {
+                ...ensuredProject,
+                lastOpenedLabel: t("time.justNow"),
+              }),
+            );
+            setTerminalWorkspaceBindings((current) => ({
+              ...current,
+              ...buildWorkspaceBindingsForEntry(ensuredWorkspace),
+            }));
+          } catch (error) {
+            const message = getInvokeErrorMessage(
+              error,
+              t("dashboard.error.workspaceInit"),
+            );
+            setComposerError(message);
+            return;
+          }
+        }
+
+        if (!nextProject) {
           return;
         }
 
-        if (isTauri() && !resolvedWorkspaceId) {
-          setComposerError(
-            "Workspace is still preparing. Try again in a moment.",
-          );
-          return;
-        }
-
+        removedWorkspacePathsRef.current.delete(nextProject.path);
         const project = {
-          ...selectedProject,
+          ...nextProject,
           lastOpenedLabel: t("time.justNow"),
         };
         const existingWorkspace = workspaces.find(
           (workspace) =>
-            workspace.id === resolvedWorkspaceId ||
+            workspace.id === nextWorkspaceId ||
             workspace.id === project.id ||
             workspace.name === project.name ||
             (workspace.path && workspace.path === project.path),
@@ -1828,15 +1892,18 @@ export function DashboardWorkbench() {
             : `${Date.now()}`;
 
         let persistedThreadId =
-          newThreadTerminalBindingKey === null
+          nextWorkspaceId === null
             ? null
-            : (terminalThreadBindings[newThreadTerminalBindingKey] ?? null);
+            : (terminalThreadBindings[
+                getNewThreadTerminalBindingKey(nextWorkspaceId)
+              ] ?? null);
         const nextThreadName = buildThreadTitle(trimmedValue || effectivePrompt);
 
         try {
-          if (isTauri() && resolvedWorkspaceId) {
+          if (isTauri() && nextWorkspaceId) {
             if (!persistedThreadId) {
-              persistedThreadId = await getOrCreateNewThreadId(resolvedWorkspaceId);
+              persistedThreadId =
+                await getOrCreateNewThreadId(nextWorkspaceId);
             }
           }
         } catch (error) {
@@ -1873,7 +1940,7 @@ export function DashboardWorkbench() {
 
           return [
             {
-              id: resolvedWorkspaceId ?? project.id,
+              id: nextWorkspaceId ?? project.id,
               name: project.name,
               defaultOpen: true,
               path: project.path,
@@ -1884,7 +1951,7 @@ export function DashboardWorkbench() {
         });
         setOpenWorkspaces((current) => ({
           ...current,
-          [existingWorkspace?.id ?? resolvedWorkspaceId ?? project.id]: true,
+          [existingWorkspace?.id ?? nextWorkspaceId ?? project.id]: true,
         }));
 
         if (activeTerminalStateKey) {
@@ -1904,17 +1971,19 @@ export function DashboardWorkbench() {
 
         if (persistedThreadId) {
           setTerminalThreadBindings((current) => {
-            if (!newThreadTerminalBindingKey || !persistedThreadId) {
+            if (!nextWorkspaceId || !persistedThreadId) {
               return current;
             }
 
-            if (current[newThreadTerminalBindingKey] === persistedThreadId) {
+            const bindingKey = getNewThreadTerminalBindingKey(nextWorkspaceId);
+
+            if (current[bindingKey] === persistedThreadId) {
               return current;
             }
 
             return {
               ...current,
-              [newThreadTerminalBindingKey]: persistedThreadId,
+              [bindingKey]: persistedThreadId,
             };
           });
 
@@ -1993,6 +2062,7 @@ export function DashboardWorkbench() {
           return;
         }
 
+        removedWorkspacePathsRef.current.delete(nextProject.path);
         const workspaceEntries = await workspaceList();
         const existingWorkspace =
           workspaceEntries.find(
@@ -2073,6 +2143,15 @@ export function DashboardWorkbench() {
         const nextThreadBindingKey = getNewThreadTerminalBindingKey(
           workspace.id,
         );
+        const isRemovingSelectedProject =
+          selectedProject?.id === workspace.id ||
+          selectedProject?.path === workspace.path;
+        const fallbackSelectedProject = isRemovingSelectedProject
+          ? (recentProjects.find(
+              (project) =>
+                project.id !== workspace.id && project.path !== workspace.path,
+            ) ?? null)
+          : selectedProject;
         newThreadCreationRef.current = Object.fromEntries(
           Object.entries(newThreadCreationRef.current).filter(
             ([candidateWorkspaceId]) => candidateWorkspaceId !== workspace.id,
@@ -2092,6 +2171,9 @@ export function DashboardWorkbench() {
 
         try {
           await workspaceRemove(workspace.id);
+          if (workspace.path) {
+            removedWorkspacePathsRef.current.add(workspace.path);
+          }
 
           if (isRemovingActiveWorkspace) {
             setNewThreadMode(true);
@@ -2099,6 +2181,21 @@ export function DashboardWorkbench() {
             setComposerError(null);
             setSelectedDiffSelection(null);
           }
+
+          if (isRemovingSelectedProject) {
+            if (fallbackSelectedProject?.path) {
+              removedWorkspacePathsRef.current.delete(
+                fallbackSelectedProject.path,
+              );
+            }
+            setSelectedProject(fallbackSelectedProject);
+          }
+          setRecentProjects((current) =>
+            current.filter(
+              (project) =>
+                project.id !== workspace.id && project.path !== workspace.path,
+            ),
+          );
 
           setPendingDeleteThreadId((current) =>
             current && workspaceThreadIds.has(current) ? null : current,
@@ -2160,6 +2257,7 @@ export function DashboardWorkbench() {
     },
     [
       activeThreadWorkspace?.id,
+      recentProjects,
       selectedProject?.id,
       selectedProject?.path,
       syncWorkspaceSidebar,

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2170,10 +2170,10 @@ export function DashboardWorkbench() {
         setTerminalBootstrapError(null);
 
         try {
-          await workspaceRemove(workspace.id);
           if (workspace.path) {
             removedWorkspacePathsRef.current.add(workspace.path);
           }
+          await workspaceRemove(workspace.id);
 
           if (isRemovingActiveWorkspace) {
             setNewThreadMode(true);
@@ -2245,6 +2245,9 @@ export function DashboardWorkbench() {
             preserveSelectedProjectIfMissing: shouldPreserveSelectedProject,
           });
         } catch (error) {
+          if (workspace.path) {
+            removedWorkspacePathsRef.current.delete(workspace.path);
+          }
           const message = getInvokeErrorMessage(
             error,
             `Failed to remove ${workspace.name}`,

--- a/src/services/bridge/workspace-commands.ts
+++ b/src/services/bridge/workspace-commands.ts
@@ -14,6 +14,13 @@ export async function workspaceAdd(
   return invoke<WorkspaceDto>("workspace_add", { path, name });
 }
 
+export async function workspaceEnsureDefault(): Promise<WorkspaceDto> {
+  if (!isTauri()) {
+    throw new Error("workspace_ensure_default requires Tauri runtime");
+  }
+  return invoke<WorkspaceDto>("workspace_ensure_default");
+}
+
 export async function workspaceRemove(id: string): Promise<void> {
   if (!isTauri()) throw new Error("workspace_remove requires Tauri runtime");
   return invoke("workspace_remove", { id });


### PR DESCRIPTION
## Summary

This PR adds a new Tauri command to ensure the built-in default workspace exists under the user's `~/.tiy/workspace/Default` directory, improving first-run and "start chatting right away" UX.

## Changes

### Backend (Rust/Tauri)
- Add new Tauri command for default workspace initialization
- Enhance workspace manager with default workspace creation logic
- Map workspace bindings for both canonical and raw workspace paths
- Avoid re-adding terminal bindings when a workspace was just removed
- Update selected and recent projects correctly after workspace removal

### Frontend (React/TypeScript)
- Update dashboard to create or reuse default workspace when starting a new thread without a selected workspace
- Improve workspace initialization flow
- Add workspace command bindings

### i18n
- Update English and Chinese locale files

## Files Changed
- `src-tauri/src/commands/workspace.rs` - Add new workspace command
- `src-tauri/src/core/executors/filesystem.rs` - Import updates
- `src-tauri/src/core/executors/process.rs` - Import updates  
- `src-tauri/src/core/workspace_manager.rs` - Core workspace management logic
- `src-tauri/src/lib.rs` - Command registration
- `src/i18n/locales/en.ts` - English translations
- `src/i18n/locales/zh-CN.ts` - Chinese translations
- `src/modules/workbench-shell/ui/dashboard-workbench.tsx` - Dashboard UI updates
- `src/services/bridge/workspace-commands.ts` - TypeScript command bindings

## Testing
- Manual testing on macOS
- Type-check passed: `npm run typecheck`
- Rust formatting applied: `cargo fmt`

## Related
Improves terminal workspace bindings consistency across platform path differences.