### PR TITLE
fix(extensions): 🐛 Fix composer $ skill picker missing workspace skills

### DIFF
--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/app/providers/language-provider";
 import { useTheme, type ThemePreference } from "@/app/providers/theme-provider";
 import { useT } from "@/i18n";
-import { useExtensionsController } from "@/modules/extensions-center/model/use-extensions-controller";
+import { useExtensionsController, type ExtensionScope } from "@/modules/extensions-center/model/use-extensions-controller";
 import { ExtensionsCenterOverlay } from "@/modules/extensions-center/ui/extensions-center-overlay";
 import {
   buildProfileModelPlan,
@@ -397,8 +397,8 @@ export function DashboardWorkbench() {
     skills: extensionSkills,
     uninstallExtension,
     updateMcpServer,
-  } = useExtensionsController();
-  const currentExtensionScope = "global";
+  } = useExtensionsController(selectedProject?.path ?? null);
+  const currentExtensionScope: ExtensionScope = selectedProject ? "workspace" : "global";
   const extensionDetailById = useMemo<Record<string, ExtensionDetail>>(() => {
     return Object.fromEntries(
       Object.entries(extensionDetailByKey)


### PR DESCRIPTION
## Summary
- Fix `useExtensionsController()` being called without workspace path in `DashboardWorkbench`, causing `scope` to default to `"global"` and skip workspace `.tiy/skills` directory scanning
- Pass `selectedProject?.path` to the hook and derive `currentExtensionScope` dynamically, so all downstream operations (composer `$` skill picker, settings panel enable/disable/rescan) are workspace-aware

## Root Cause
The backend `skill_source_roots()` only includes `<workspace>/.tiy/skills` when `scope == Workspace`, but the frontend always passed `"global"` scope due to hardcoded `currentExtensionScope = "global"` and missing `currentWorkspacePath` argument.

Note: The runtime prompt injection path (`SkillsProvider` in `providers.rs`) was unaffected — it correctly uses `ConfigScope::Workspace` with the session's workspace path. This bug only impacted the UI layer (composer autocomplete and settings panel).

## Test Plan
- [ ] Open a project that has `.tiy/skills/` with custom skills
- [ ] Type `$` in the composer — workspace skills should now appear
- [ ] Verify built-in (global) skills still appear alongside workspace skills
- [ ] Open Extensions settings panel — verify rescan/enable/disable operate on workspace scope
- [ ] Switch to a project without `.tiy/skills/` — verify graceful fallback to global-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)