### PR TITLE
feat(git): add branch selector with checkout, create and AI-powered naming

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -17,8 +17,8 @@ use crate::core::tiycode_default_headers;
 use crate::ipc::frontend_channels::GitStreamEvent;
 use crate::model::errors::{AppError, ErrorCategory, ErrorSource};
 use crate::model::git::{
-    GitCommandResultDto, GitCommitSummaryDto, GitDiffDto, GitFileChangeDto, GitFileStatusDto,
-    GitMutationAction, GitMutationResponseDto, GitSnapshotDto,
+    GitBranchDto, GitCommandResultDto, GitCommitSummaryDto, GitDiffDto, GitFileChangeDto,
+    GitFileStatusDto, GitMutationAction, GitMutationResponseDto, GitSnapshotDto,
 };
 use crate::model::workspace::WorkspaceRecord;
 use crate::persistence::repo::{audit_repo, workspace_repo};
@@ -432,6 +432,124 @@ pub async fn git_push(
     .await
 }
 
+#[tauri::command]
+pub async fn git_list_branches(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<Vec<GitBranchDto>, AppError> {
+    let workspace = load_workspace(&state, &workspace_id).await?;
+
+    state
+        .git_manager
+        .list_branches(&workspace.canonical_path)
+        .await
+}
+
+#[tauri::command]
+pub async fn git_checkout_branch(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    branch: String,
+    approved: Option<bool>,
+) -> Result<GitMutationResponseDto, AppError> {
+    let workspace = load_workspace(&state, &workspace_id).await?;
+    let git_manager = state.git_manager.clone();
+    let workspace_id_for_run = workspace_id.clone();
+    let workspace_path = workspace.canonical_path.clone();
+    let branch_for_run = branch.clone();
+    let input = serde_json::json!({ "branch": branch.trim() });
+
+    authorize_and_run_git_mutation(
+        &state,
+        &workspace,
+        GitMutationAction::Checkout,
+        &input,
+        approved.unwrap_or(false),
+        move || async move {
+            git_manager
+                .checkout_branch(&workspace_id_for_run, &workspace_path, &branch_for_run)
+                .await
+        },
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn git_create_branch(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    branch: String,
+    approved: Option<bool>,
+) -> Result<GitMutationResponseDto, AppError> {
+    let workspace = load_workspace(&state, &workspace_id).await?;
+    let git_manager = state.git_manager.clone();
+    let workspace_id_for_run = workspace_id.clone();
+    let workspace_path = workspace.canonical_path.clone();
+    let branch_for_run = branch.clone();
+    let input = serde_json::json!({ "branch": branch.trim() });
+
+    authorize_and_run_git_mutation(
+        &state,
+        &workspace,
+        GitMutationAction::CreateBranch,
+        &input,
+        approved.unwrap_or(false),
+        move || async move {
+            git_manager
+                .create_branch(&workspace_id_for_run, &workspace_path, &branch_for_run)
+                .await
+        },
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn git_generate_branch_name(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    model_plan: serde_json::Value,
+) -> Result<String, AppError> {
+    let workspace = load_workspace(&state, &workspace_id).await?;
+    let raw_plan: RuntimeModelPlan = serde_json::from_value(model_plan).unwrap_or_default();
+    let selected_model = select_commit_message_model_role(&raw_plan)?;
+    let model_role = resolve_runtime_model_role(&state.pool, selected_model).await?;
+    let snapshot = state
+        .git_manager
+        .get_snapshot(&workspace_id, &workspace.canonical_path)
+        .await?;
+    let branches = state
+        .git_manager
+        .list_branches(&workspace.canonical_path)
+        .await?;
+    let prompt = build_branch_name_prompt(&snapshot, &branches);
+
+    generate_with_lite_model(
+        &model_role,
+        "You generate a single Git branch name. Return ONLY the branch name, nothing else. No explanation, no markdown.",
+        &prompt,
+    )
+    .await
+    .and_then(|raw| {
+        let cleaned = raw
+            .trim()
+            .trim_matches('`')
+            .trim()
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if cleaned.is_empty() {
+            return Err(AppError::recoverable(
+                ErrorSource::Git,
+                "git.branch_name.empty",
+                "The model returned an empty branch name. Try again.",
+            ));
+        }
+        Ok(cleaned)
+    })
+}
+
 async fn load_workspace(state: &AppState, workspace_id: &str) -> Result<WorkspaceRecord, AppError> {
     workspace_repo::find_by_id(&state.pool, workspace_id)
         .await?
@@ -780,9 +898,108 @@ fn git_diff_status_label(diff: &GitDiffDto) -> &'static str {
     }
 }
 
+fn build_branch_name_prompt(
+    snapshot: &GitSnapshotDto,
+    branches: &[GitBranchDto],
+) -> String {
+    let current_branch = snapshot
+        .head_ref
+        .as_deref()
+        .unwrap_or("(detached HEAD)");
+
+    // Collect existing local branch names for naming convention analysis
+    let local_branch_names: Vec<&str> = branches
+        .iter()
+        .filter(|b| !b.is_remote)
+        .map(|b| b.name.as_str())
+        .collect();
+
+    // Summarize changed files
+    let staged_summary: Vec<String> = snapshot
+        .staged_files
+        .iter()
+        .take(15)
+        .map(|f| format!("  [staged] {} ({})", f.path, git_change_kind_label(f)))
+        .collect();
+    let unstaged_summary: Vec<String> = snapshot
+        .unstaged_files
+        .iter()
+        .take(15)
+        .map(|f| format!("  [modified] {} ({})", f.path, git_change_kind_label(f)))
+        .collect();
+    let untracked_summary: Vec<String> = snapshot
+        .untracked_files
+        .iter()
+        .take(10)
+        .map(|f| format!("  [new] {}", f.path))
+        .collect();
+
+    let all_changes = [staged_summary, unstaged_summary, untracked_summary].concat();
+    let changes_section = if all_changes.is_empty() {
+        "No local changes detected.".to_string()
+    } else {
+        all_changes.join("\n")
+    };
+
+    let branches_section = if local_branch_names.is_empty() {
+        "No existing branches.".to_string()
+    } else {
+        local_branch_names
+            .iter()
+            .take(30)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+
+    format!(
+        r#"Generate a Git branch name for the following context.
+
+## Rules
+- Follow the naming convention of existing branches (e.g. feat/xxx, fix/xxx, chore/xxx).
+- If no convention is apparent, use conventional style: <type>/<short-description>
+- Types: feat, fix, refactor, chore, docs, style, test, perf, ci, build
+- Use lowercase, hyphens for spaces, no special characters.
+- Keep it concise (under 40 chars total).
+- Return ONLY the branch name. No explanation.
+
+## Current branch
+{current_branch}
+
+## Existing local branches
+{branches_section}
+
+## Local changes
+{changes_section}
+"#
+    )
+}
+
 async fn generate_commit_message(
     model_role: &ResolvedModelRole,
     prompt: &str,
+) -> Result<String, AppError> {
+    generate_with_lite_model(
+        model_role,
+        "You generate a single commit message from Git changes. Return only the commit message.",
+        prompt,
+    )
+    .await
+    .and_then(|raw| {
+        normalize_generated_commit_message(&raw).ok_or_else(|| {
+            AppError::recoverable(
+                ErrorSource::Settings,
+                "settings.commit_message.empty",
+                "The model returned an empty commit message. Try again.",
+            )
+        })
+    })
+}
+
+async fn generate_with_lite_model(
+    model_role: &ResolvedModelRole,
+    system_prompt: &str,
+    user_prompt: &str,
 ) -> Result<String, AppError> {
     let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
         AppError::recoverable(
@@ -796,11 +1013,8 @@ async fn generate_commit_message(
     })?;
 
     let context = TiyContext {
-        system_prompt: Some(
-            "You generate a single commit message from Git changes. Return only the commit message."
-                .to_string(),
-        ),
-        messages: vec![TiyMessage::User(UserMessage::text(prompt.to_string()))],
+        system_prompt: Some(system_prompt.to_string()),
+        messages: vec![TiyMessage::User(UserMessage::text(user_prompt.to_string()))],
         tools: None,
     };
 
@@ -843,8 +1057,8 @@ async fn generate_commit_message(
     normalize_generated_commit_message(&message.text_content()).ok_or_else(|| {
         AppError::recoverable(
             ErrorSource::Settings,
-            "settings.commit_message.empty",
-            "The model returned an empty commit message. Try again.",
+            "settings.lite_model.empty",
+            "The model returned an empty response. Try again.",
         )
     })
 }

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -521,7 +521,8 @@ pub async fn git_generate_branch_name(
         .git_manager
         .list_branches(&workspace.canonical_path)
         .await?;
-    let prompt = build_branch_name_prompt(&snapshot, &branches);
+    let prompt =
+        build_branch_name_prompt(&state, &workspace.canonical_path, &snapshot, &branches).await?;
 
     generate_with_lite_model(
         &model_role,
@@ -898,14 +899,18 @@ fn git_diff_status_label(diff: &GitDiffDto) -> &'static str {
     }
 }
 
-fn build_branch_name_prompt(
+/// Files at or below this threshold get detailed diffs in the branch name prompt.
+const BRANCH_NAME_DIFF_FILE_THRESHOLD: usize = 8;
+/// Character budget for diffs in the branch name prompt (smaller than commit messages).
+const BRANCH_NAME_DIFF_CHAR_BUDGET: usize = 16_000;
+
+async fn build_branch_name_prompt(
+    state: &AppState,
+    workspace_path: &str,
     snapshot: &GitSnapshotDto,
     branches: &[GitBranchDto],
-) -> String {
-    let current_branch = snapshot
-        .head_ref
-        .as_deref()
-        .unwrap_or("(detached HEAD)");
+) -> Result<String, AppError> {
+    let current_branch = snapshot.head_ref.as_deref().unwrap_or("(detached HEAD)");
 
     // Collect existing local branch names for naming convention analysis
     let local_branch_names: Vec<&str> = branches
@@ -914,31 +919,77 @@ fn build_branch_name_prompt(
         .map(|b| b.name.as_str())
         .collect();
 
-    // Summarize changed files
-    let staged_summary: Vec<String> = snapshot
-        .staged_files
-        .iter()
-        .take(15)
-        .map(|f| format!("  [staged] {} ({})", f.path, git_change_kind_label(f)))
-        .collect();
-    let unstaged_summary: Vec<String> = snapshot
-        .unstaged_files
-        .iter()
-        .take(15)
-        .map(|f| format!("  [modified] {} ({})", f.path, git_change_kind_label(f)))
-        .collect();
-    let untracked_summary: Vec<String> = snapshot
-        .untracked_files
-        .iter()
-        .take(10)
-        .map(|f| format!("  [new] {}", f.path))
-        .collect();
+    // Collect changes — staged take priority (same logic as commit message)
+    let (source_label, staged, changes): (&str, bool, Vec<GitFileChangeDto>) =
+        if !snapshot.staged_files.is_empty() {
+            ("staged changes", true, snapshot.staged_files.clone())
+        } else {
+            let wt: Vec<GitFileChangeDto> = snapshot
+                .unstaged_files
+                .iter()
+                .chain(snapshot.untracked_files.iter())
+                .cloned()
+                .collect();
+            ("working tree changes", false, wt)
+        };
 
-    let all_changes = [staged_summary, unstaged_summary, untracked_summary].concat();
-    let changes_section = if all_changes.is_empty() {
+    // File summary (always included)
+    let change_summary = changes
+        .iter()
+        .take(20)
+        .map(|f| {
+            format!(
+                "- {} [{}] (+{} -{})",
+                f.path,
+                git_change_kind_label(f),
+                f.additions,
+                f.deletions,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let changes_section = if change_summary.is_empty() {
         "No local changes detected.".to_string()
     } else {
-        all_changes.join("\n")
+        format!("Source: {source_label}\n{change_summary}")
+    };
+
+    // Detailed diffs — only when file count is small enough to keep context short
+    let diffs_section = if !changes.is_empty() && changes.len() <= BRANCH_NAME_DIFF_FILE_THRESHOLD {
+        let mut remaining_budget = BRANCH_NAME_DIFF_CHAR_BUDGET;
+        let mut rendered_diffs = Vec::new();
+
+        for change in &changes {
+            if remaining_budget == 0 {
+                break;
+            }
+
+            let diff = state
+                .git_manager
+                .get_diff(workspace_path, &change.path, staged)
+                .await?;
+            let rendered = render_diff_for_commit_prompt(&diff);
+
+            if rendered.len() > remaining_budget {
+                rendered_diffs.push(truncate_to_char_boundary(&rendered, remaining_budget));
+                break;
+            }
+
+            remaining_budget -= rendered.len();
+            rendered_diffs.push(rendered);
+        }
+
+        if rendered_diffs.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n## Detailed diffs\n```\n{}\n```\n",
+                rendered_diffs.join("\n\n")
+            )
+        }
+    } else {
+        String::new()
     };
 
     let branches_section = if local_branch_names.is_empty() {
@@ -952,7 +1003,7 @@ fn build_branch_name_prompt(
             .join(", ")
     };
 
-    format!(
+    Ok(format!(
         r#"Generate a Git branch name for the following context.
 
 ## Rules
@@ -971,8 +1022,8 @@ fn build_branch_name_prompt(
 
 ## Local changes
 {changes_section}
-"#
-    )
+{diffs_section}"#
+    ))
 }
 
 async fn generate_commit_message(

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -236,14 +236,40 @@ pub async fn git_subscribe(
     on_event: Channel<GitStreamEvent>,
 ) -> Result<(), AppError> {
     let mut receiver = state.git_manager.subscribe(&workspace_id).await;
+    let subscription_id = on_event.id();
+    let git_manager = state.git_manager.clone();
+    let workspace_id_for_cleanup = workspace_id.clone();
 
-    tokio::spawn(async move {
+    let handle = tokio::spawn(async move {
         while let Ok(event) = receiver.recv().await {
             if on_event.send(event).is_err() {
                 break;
             }
         }
+
+        git_manager
+            .finish_subscription(&workspace_id_for_cleanup, subscription_id)
+            .await;
     });
+
+    state
+        .git_manager
+        .register_subscription(&workspace_id, subscription_id, handle)
+        .await;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn git_unsubscribe(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    subscription_id: u32,
+) -> Result<(), AppError> {
+    state
+        .git_manager
+        .unregister_subscription(&workspace_id, subscription_id)
+        .await;
 
     Ok(())
 }

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -129,12 +129,50 @@ pub async fn pull(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
 }
 
 pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError> {
-    run_git_action(
-        workspace_path,
-        GitMutationAction::Push,
-        vec!["push".to_string()],
-    )
+    let workspace_root = canonicalize_workspace(workspace_path);
+
+    // Check if the current branch has an upstream; if not, push with --set-upstream
+    let args = tokio::task::spawn_blocking(move || -> Result<Vec<String>, AppError> {
+        let repo = open_repository(&workspace_root)?;
+        let head = repo.head().map_err(|e| {
+            git_error("git.push.head_failed", format!("Cannot read HEAD: {e}"), true)
+        })?;
+
+        if !head.is_branch() {
+            return Ok(vec!["push".to_string()]);
+        }
+
+        let branch_name = head.shorthand().unwrap_or("HEAD").to_string();
+        let branch = repo.find_branch(&branch_name, git2::BranchType::Local);
+
+        let has_upstream = branch
+            .ok()
+            .and_then(|b| b.upstream().ok())
+            .is_some();
+
+        if has_upstream {
+            Ok(vec!["push".to_string()])
+        } else {
+            // Determine the remote — use "origin" as default, or the first available remote
+            let remote_name = repo
+                .remotes()
+                .ok()
+                .and_then(|remotes| remotes.get(0).map(str::to_string))
+                .unwrap_or_else(|| "origin".to_string());
+
+            Ok(vec![
+                "push".to_string(),
+                "--set-upstream".to_string(),
+                remote_name,
+                branch_name,
+            ])
+        }
+    })
     .await
+    .map_err(|e| AppError::internal(ErrorSource::Git, format!("Git push check failed: {e}")))?
+    ?;
+
+    run_git_action(workspace_path, GitMutationAction::Push, args).await
 }
 
 pub async fn checkout_branch(

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -135,7 +135,11 @@ pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
     let args = tokio::task::spawn_blocking(move || -> Result<Vec<String>, AppError> {
         let repo = open_repository(&workspace_root)?;
         let head = repo.head().map_err(|e| {
-            git_error("git.push.head_failed", format!("Cannot read HEAD: {e}"), true)
+            git_error(
+                "git.push.head_failed",
+                format!("Cannot read HEAD: {e}"),
+                true,
+            )
         })?;
 
         if !head.is_branch() {
@@ -145,10 +149,7 @@ pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
         let branch_name = head.shorthand().unwrap_or("HEAD").to_string();
         let branch = repo.find_branch(&branch_name, git2::BranchType::Local);
 
-        let has_upstream = branch
-            .ok()
-            .and_then(|b| b.upstream().ok())
-            .is_some();
+        let has_upstream = branch.ok().and_then(|b| b.upstream().ok()).is_some();
 
         if has_upstream {
             Ok(vec!["push".to_string()])
@@ -169,8 +170,7 @@ pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
         }
     })
     .await
-    .map_err(|e| AppError::internal(ErrorSource::Git, format!("Git push check failed: {e}")))?
-    ?;
+    .map_err(|e| AppError::internal(ErrorSource::Git, format!("Git push check failed: {e}")))??;
 
     run_git_action(workspace_path, GitMutationAction::Push, args).await
 }

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -179,14 +179,7 @@ pub async fn checkout_branch(
     workspace_path: &str,
     branch_name: &str,
 ) -> Result<GitCommandResultDto, AppError> {
-    let trimmed = branch_name.trim();
-    if trimmed.is_empty() {
-        return Err(git_error(
-            "git.checkout.branch_invalid",
-            "Branch name cannot be empty",
-            false,
-        ));
-    }
+    let trimmed = validate_branch_name(branch_name)?;
 
     run_git_action(
         workspace_path,
@@ -200,14 +193,7 @@ pub async fn create_branch(
     workspace_path: &str,
     branch_name: &str,
 ) -> Result<GitCommandResultDto, AppError> {
-    let trimmed = branch_name.trim();
-    if trimmed.is_empty() {
-        return Err(git_error(
-            "git.create_branch.name_invalid",
-            "Branch name cannot be empty",
-            false,
-        ));
-    }
+    let trimmed = validate_branch_name(branch_name)?;
 
     run_git_action(
         workspace_path,
@@ -662,5 +648,28 @@ fn git_error(code: &str, message: impl Into<String>, retryable: bool) -> AppErro
         user_message: message.into(),
         detail: None,
         retryable,
+    }
+}
+
+fn validate_branch_name(name: &str) -> Result<&str, AppError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(git_error(
+            "git.branch.name_empty",
+            "Branch name cannot be empty",
+            false,
+        ));
+    }
+
+    // Use git2's reference validation: a valid branch is refs/heads/<name>
+    let full_ref = format!("refs/heads/{trimmed}");
+    if git2::Reference::is_valid_name(&full_ref) {
+        Ok(trimmed)
+    } else {
+        Err(git_error(
+            "git.branch.name_invalid",
+            format!("'{}' is not a valid branch name", trimmed),
+            false,
+        ))
     }
 }

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
-use git2::Repository;
+use git2::{BranchType, Repository};
 
 use super::ToolOutput;
 use crate::core::windows_process::configure_background_std_command;
@@ -154,12 +154,7 @@ pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
         if has_upstream {
             Ok(vec!["push".to_string()])
         } else {
-            // Determine the remote — use "origin" as default, or the first available remote
-            let remote_name = repo
-                .remotes()
-                .ok()
-                .and_then(|remotes| remotes.get(0).map(str::to_string))
-                .unwrap_or_else(|| "origin".to_string());
+            let remote_name = resolve_push_remote(&repo, &branch_name)?;
 
             Ok(vec![
                 "push".to_string(),
@@ -179,21 +174,28 @@ pub async fn checkout_branch(
     workspace_path: &str,
     branch_name: &str,
 ) -> Result<GitCommandResultDto, AppError> {
-    let trimmed = validate_branch_name(branch_name)?;
-
-    run_git_action(
-        workspace_path,
-        GitMutationAction::Checkout,
-        vec!["checkout".to_string(), trimmed.to_string()],
-    )
+    let workspace_root = canonicalize_workspace(workspace_path);
+    let branch_name = branch_name.to_string();
+    let args = tokio::task::spawn_blocking(move || -> Result<Vec<String>, AppError> {
+        let repo = open_repository(&workspace_root)?;
+        build_checkout_args(&repo, &branch_name)
+    })
     .await
+    .map_err(|error| {
+        AppError::internal(
+            ErrorSource::Git,
+            format!("Git checkout branch resolution failed: {error}"),
+        )
+    })??;
+
+    run_git_action(workspace_path, GitMutationAction::Checkout, args).await
 }
 
 pub async fn create_branch(
     workspace_path: &str,
     branch_name: &str,
 ) -> Result<GitCommandResultDto, AppError> {
-    let trimmed = validate_branch_name(branch_name)?;
+    let trimmed = validate_local_branch_name(branch_name)?;
 
     run_git_action(
         workspace_path,
@@ -580,6 +582,109 @@ fn open_repository(workspace_root: &Path) -> Result<Repository, AppError> {
     })
 }
 
+fn build_checkout_args(repo: &Repository, branch_name: &str) -> Result<Vec<String>, AppError> {
+    let trimmed = require_branch_name(branch_name)?;
+
+    if repo.find_branch(trimmed, BranchType::Local).is_ok() {
+        return Ok(vec!["checkout".to_string(), trimmed.to_string()]);
+    }
+
+    if repo.find_branch(trimmed, BranchType::Remote).is_ok() {
+        let local_branch_name = local_branch_name_from_remote(trimmed)?;
+        if local_branch_tracks_remote(repo, local_branch_name, trimmed)? {
+            return Ok(vec!["checkout".to_string(), local_branch_name.to_string()]);
+        }
+
+        if repo
+            .find_branch(local_branch_name, BranchType::Local)
+            .is_ok()
+        {
+            return Err(git_error(
+                "git.checkout.remote_conflict",
+                format!(
+                    "Local branch '{}' already exists and is not tracking '{}'",
+                    local_branch_name, trimmed
+                ),
+                false,
+            ));
+        }
+
+        return Ok(vec![
+            "checkout".to_string(),
+            "--track".to_string(),
+            trimmed.to_string(),
+        ]);
+    }
+
+    let trimmed = validate_local_branch_name(trimmed)?;
+    Ok(vec!["checkout".to_string(), trimmed.to_string()])
+}
+
+fn resolve_push_remote(repo: &Repository, branch_name: &str) -> Result<String, AppError> {
+    let remotes = repo
+        .remotes()
+        .map_err(|error| {
+            git_error(
+                "git.remote.list_failed",
+                format!("Unable to read Git remotes: {error}"),
+                true,
+            )
+        })?
+        .iter()
+        .flatten()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+
+    let config = repo.config().ok();
+    let branch_push_remote = config.as_ref().and_then(|cfg| {
+        cfg.get_string(&format!("branch.{branch_name}.pushRemote"))
+            .ok()
+    });
+    let remote_push_default = config
+        .as_ref()
+        .and_then(|cfg| cfg.get_string("remote.pushDefault").ok());
+
+    select_push_remote(
+        &remotes,
+        branch_push_remote
+            .as_deref()
+            .or(remote_push_default.as_deref()),
+    )
+}
+
+fn select_push_remote(
+    remotes: &[String],
+    preferred_remote: Option<&str>,
+) -> Result<String, AppError> {
+    if remotes.is_empty() {
+        return Err(git_error(
+            "git.push.no_remote",
+            "No Git remotes are configured for this repository",
+            false,
+        ));
+    }
+
+    if let Some(remote) =
+        preferred_remote.filter(|remote| remotes.iter().any(|name| name == remote))
+    {
+        return Ok(remote.to_string());
+    }
+
+    if remotes.iter().any(|name| name == "origin") {
+        return Ok("origin".to_string());
+    }
+
+    if remotes.len() == 1 {
+        return Ok(remotes[0].clone());
+    }
+
+    Err(git_error(
+        "git.push.remote_ambiguous",
+        "Multiple Git remotes are configured. Set remote.pushDefault before pushing a branch without an upstream.",
+        false,
+    ))
+}
+
 fn repo_workdir(repo: &Repository) -> Result<PathBuf, AppError> {
     repo.workdir()
         .map(|path| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
@@ -651,7 +756,7 @@ fn git_error(code: &str, message: impl Into<String>, retryable: bool) -> AppErro
     }
 }
 
-fn validate_branch_name(name: &str) -> Result<&str, AppError> {
+fn require_branch_name(name: &str) -> Result<&str, AppError> {
     let trimmed = name.trim();
     if trimmed.is_empty() {
         return Err(git_error(
@@ -660,6 +765,12 @@ fn validate_branch_name(name: &str) -> Result<&str, AppError> {
             false,
         ));
     }
+
+    Ok(trimmed)
+}
+
+fn validate_local_branch_name(name: &str) -> Result<&str, AppError> {
+    let trimmed = require_branch_name(name)?;
 
     // Use git2's reference validation: a valid branch is refs/heads/<name>
     let full_ref = format!("refs/heads/{trimmed}");
@@ -671,5 +782,117 @@ fn validate_branch_name(name: &str) -> Result<&str, AppError> {
             format!("'{}' is not a valid branch name", trimmed),
             false,
         ))
+    }
+}
+
+fn local_branch_name_from_remote(remote_branch_name: &str) -> Result<&str, AppError> {
+    let trimmed = require_branch_name(remote_branch_name)?;
+    let Some((_, local_branch_name)) = trimmed.split_once('/') else {
+        return Err(git_error(
+            "git.checkout.not_found",
+            "The specified remote branch was not found",
+            false,
+        ));
+    };
+
+    validate_local_branch_name(local_branch_name)
+}
+
+fn local_branch_tracks_remote(
+    repo: &Repository,
+    local_branch_name: &str,
+    remote_branch_name: &str,
+) -> Result<bool, AppError> {
+    let branch = match repo.find_branch(local_branch_name, BranchType::Local) {
+        Ok(branch) => branch,
+        Err(_) => return Ok(false),
+    };
+
+    let upstream_name = branch
+        .upstream()
+        .ok()
+        .and_then(|upstream| upstream.name().ok().flatten().map(str::to_string));
+
+    Ok(upstream_matches_remote(
+        upstream_name.as_deref(),
+        remote_branch_name,
+    ))
+}
+
+fn upstream_matches_remote(upstream_name: Option<&str>, remote_branch_name: &str) -> bool {
+    upstream_name == Some(remote_branch_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{select_push_remote, upstream_matches_remote, validate_local_branch_name};
+
+    #[test]
+    fn validate_local_branch_name_accepts_conventional_names() {
+        assert_eq!(
+            validate_local_branch_name("feat/git-branch-selector").unwrap(),
+            "feat/git-branch-selector"
+        );
+        assert_eq!(
+            validate_local_branch_name("fix/worktree").unwrap(),
+            "fix/worktree"
+        );
+    }
+
+    #[test]
+    fn validate_local_branch_name_rejects_invalid_names() {
+        for branch_name in ["", "my branch", "/branch", "branch/", "invalid..name"] {
+            assert!(
+                validate_local_branch_name(branch_name).is_err(),
+                "{branch_name}"
+            );
+        }
+    }
+
+    #[test]
+    fn select_push_remote_prefers_configured_remote() {
+        let remotes = vec!["upstream".to_string(), "origin".to_string()];
+        assert_eq!(
+            select_push_remote(&remotes, Some("upstream")).unwrap(),
+            "upstream"
+        );
+    }
+
+    #[test]
+    fn select_push_remote_prefers_origin_before_first_remote() {
+        let remotes = vec!["upstream".to_string(), "origin".to_string()];
+        assert_eq!(select_push_remote(&remotes, None).unwrap(), "origin");
+    }
+
+    #[test]
+    fn select_push_remote_uses_single_remote() {
+        let remotes = vec!["backup".to_string()];
+        assert_eq!(select_push_remote(&remotes, None).unwrap(), "backup");
+    }
+
+    #[test]
+    fn select_push_remote_errors_when_no_remote_exists() {
+        let error = select_push_remote(&[], None).unwrap_err();
+        assert_eq!(error.error_code, "git.push.no_remote");
+    }
+
+    #[test]
+    fn select_push_remote_errors_when_multiple_remotes_are_ambiguous() {
+        let remotes = vec!["upstream".to_string(), "backup".to_string()];
+        let error = select_push_remote(&remotes, None).unwrap_err();
+        assert_eq!(error.error_code, "git.push.remote_ambiguous");
+    }
+
+    #[test]
+    fn upstream_matches_remote_requires_exact_remote_ref_match() {
+        assert!(upstream_matches_remote(
+            Some("origin/feat/foo"),
+            "origin/feat/foo"
+        ));
+        assert!(!upstream_matches_remote(
+            Some("upstream/feat/foo"),
+            "origin/feat/foo"
+        ));
+        assert!(!upstream_matches_remote(None, "origin/feat/foo"));
     }
 }

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -67,6 +67,22 @@ pub async fn execute(
                 result: serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
             })
         }
+        "git_checkout_branch" => {
+            let branch = input["branch"].as_str().unwrap_or_default();
+            let result = checkout_branch(workspace_path, branch).await?;
+            Ok(ToolOutput {
+                success: true,
+                result: serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+            })
+        }
+        "git_create_branch" => {
+            let branch = input["branch"].as_str().unwrap_or_default();
+            let result = create_branch(workspace_path, branch).await?;
+            Ok(ToolOutput {
+                success: true,
+                result: serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})),
+            })
+        }
         _ => Ok(ToolOutput {
             success: false,
             result: serde_json::json!({
@@ -117,6 +133,52 @@ pub async fn push(workspace_path: &str) -> Result<GitCommandResultDto, AppError>
         workspace_path,
         GitMutationAction::Push,
         vec!["push".to_string()],
+    )
+    .await
+}
+
+pub async fn checkout_branch(
+    workspace_path: &str,
+    branch_name: &str,
+) -> Result<GitCommandResultDto, AppError> {
+    let trimmed = branch_name.trim();
+    if trimmed.is_empty() {
+        return Err(git_error(
+            "git.checkout.branch_invalid",
+            "Branch name cannot be empty",
+            false,
+        ));
+    }
+
+    run_git_action(
+        workspace_path,
+        GitMutationAction::Checkout,
+        vec!["checkout".to_string(), trimmed.to_string()],
+    )
+    .await
+}
+
+pub async fn create_branch(
+    workspace_path: &str,
+    branch_name: &str,
+) -> Result<GitCommandResultDto, AppError> {
+    let trimmed = branch_name.trim();
+    if trimmed.is_empty() {
+        return Err(git_error(
+            "git.create_branch.name_invalid",
+            "Branch name cannot be empty",
+            false,
+        ));
+    }
+
+    run_git_action(
+        workspace_path,
+        GitMutationAction::CreateBranch,
+        vec![
+            "checkout".to_string(),
+            "-b".to_string(),
+            trimmed.to_string(),
+        ],
     )
     .await
 }
@@ -398,6 +460,40 @@ fn map_cli_failure(action: GitMutationAction, stdout: &str, stderr: &str) -> App
         );
     }
 
+    if action == GitMutationAction::Checkout || action == GitMutationAction::CreateBranch {
+        if combined.contains("your local changes to the following files would be overwritten") {
+            return git_error(
+                "git.checkout.blocked_by_local_changes",
+                "Branch switch was blocked by uncommitted local changes",
+                false,
+            );
+        }
+
+        if combined.contains("already exists") {
+            return git_error(
+                "git.create_branch.already_exists",
+                "A branch with that name already exists",
+                false,
+            );
+        }
+
+        if combined.contains("is not a valid branch name") {
+            return git_error(
+                "git.branch.invalid_name",
+                "The branch name is invalid",
+                false,
+            );
+        }
+
+        if combined.contains("did not match any") {
+            return git_error(
+                "git.checkout.not_found",
+                "The specified branch was not found",
+                false,
+            );
+        }
+    }
+
     git_error(
         &format!("git.{}.failed", action.as_str()),
         format!(
@@ -428,6 +524,8 @@ fn success_summary(action: GitMutationAction) -> String {
         GitMutationAction::Fetch => "Fetched remote updates".to_string(),
         GitMutationAction::Pull => "Pulled remote updates".to_string(),
         GitMutationAction::Push => "Pushed local commits".to_string(),
+        GitMutationAction::Checkout => "Switched branch".to_string(),
+        GitMutationAction::CreateBranch => "Created and switched to new branch".to_string(),
     }
 }
 

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -9,6 +9,7 @@ use git2::{
     StatusOptions,
 };
 use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::task::JoinHandle;
 
 use crate::core::executors::git as git_executor;
 use crate::core::windows_process::configure_background_std_command;
@@ -54,6 +55,7 @@ struct SnapshotParts {
 #[derive(Clone)]
 pub struct GitManager {
     streams: Arc<Mutex<HashMap<String, broadcast::Sender<GitStreamEvent>>>>,
+    subscriptions: Arc<Mutex<HashMap<(String, u32), JoinHandle<()>>>>,
     overlay_cache: Arc<RwLock<HashMap<String, OverlayCacheEntry>>>,
 }
 
@@ -61,6 +63,7 @@ impl GitManager {
     pub fn new() -> Self {
         Self {
             streams: Arc::new(Mutex::new(HashMap::new())),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
             overlay_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -68,6 +71,32 @@ impl GitManager {
     pub async fn subscribe(&self, workspace_id: &str) -> broadcast::Receiver<GitStreamEvent> {
         let sender = self.get_or_create_sender(workspace_id).await;
         sender.subscribe()
+    }
+
+    pub async fn register_subscription(
+        &self,
+        workspace_id: &str,
+        subscription_id: u32,
+        handle: JoinHandle<()>,
+    ) {
+        let key = (workspace_id.to_string(), subscription_id);
+        let mut subscriptions = self.subscriptions.lock().await;
+        if let Some(existing) = subscriptions.insert(key, handle) {
+            existing.abort();
+        }
+    }
+
+    pub async fn unregister_subscription(&self, workspace_id: &str, subscription_id: u32) {
+        let key = (workspace_id.to_string(), subscription_id);
+        let mut subscriptions = self.subscriptions.lock().await;
+        if let Some(handle) = subscriptions.remove(&key) {
+            handle.abort();
+        }
+    }
+
+    pub async fn finish_subscription(&self, workspace_id: &str, subscription_id: u32) {
+        let key = (workspace_id.to_string(), subscription_id);
+        self.subscriptions.lock().await.remove(&key);
     }
 
     pub async fn refresh(

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -309,10 +309,7 @@ impl GitManager {
         Ok((result, snapshot))
     }
 
-    pub async fn list_branches(
-        &self,
-        workspace_path: &str,
-    ) -> Result<Vec<GitBranchDto>, AppError> {
+    pub async fn list_branches(&self, workspace_path: &str) -> Result<Vec<GitBranchDto>, AppError> {
         let workspace_root = canonicalize_workspace(workspace_path);
 
         tokio::task::spawn_blocking(move || {
@@ -1273,7 +1270,9 @@ fn state_priority(state: &GitFileState) -> u8 {
 
 fn collect_branches(repo: &Repository) -> Result<Vec<GitBranchDto>, AppError> {
     let head = repo.head().ok();
-    let head_shorthand = head.as_ref().and_then(|r| r.shorthand().map(str::to_string));
+    let head_shorthand = head
+        .as_ref()
+        .and_then(|r| r.shorthand().map(str::to_string));
     let is_detached = repo.head_detached().unwrap_or(false);
 
     let branches = repo.branches(None).map_err(|error| {

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -15,9 +15,9 @@ use crate::core::windows_process::configure_background_std_command;
 use crate::ipc::frontend_channels::GitStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::git::{
-    GitChangeKind, GitCommandResultDto, GitCommitSummaryDto, GitDiffDto, GitDiffHunkDto,
-    GitDiffLineDto, GitDiffLineKind, GitFileChangeDto, GitFileState, GitFileStatusDto,
-    GitRepoCapabilitiesDto, GitSnapshotDto,
+    GitBranchDto, GitChangeKind, GitCommandResultDto, GitCommitSummaryDto, GitDiffDto,
+    GitDiffHunkDto, GitDiffLineDto, GitDiffLineKind, GitFileChangeDto, GitFileState,
+    GitFileStatusDto, GitRepoCapabilitiesDto, GitSnapshotDto,
 };
 
 const DEFAULT_HISTORY_LIMIT: usize = 24;
@@ -305,6 +305,47 @@ impl GitManager {
         workspace_path: &str,
     ) -> Result<(GitCommandResultDto, GitSnapshotDto), AppError> {
         let result = git_executor::push(workspace_path).await?;
+        let snapshot = self.refresh(workspace_id, workspace_path).await?;
+        Ok((result, snapshot))
+    }
+
+    pub async fn list_branches(
+        &self,
+        workspace_path: &str,
+    ) -> Result<Vec<GitBranchDto>, AppError> {
+        let workspace_root = canonicalize_workspace(workspace_path);
+
+        tokio::task::spawn_blocking(move || {
+            let repo = open_repository(&workspace_root)?;
+            collect_branches(&repo)
+        })
+        .await
+        .map_err(|error| {
+            AppError::internal(
+                ErrorSource::Git,
+                format!("Git list branches task failed: {error}"),
+            )
+        })?
+    }
+
+    pub async fn checkout_branch(
+        &self,
+        workspace_id: &str,
+        workspace_path: &str,
+        branch_name: &str,
+    ) -> Result<(GitCommandResultDto, GitSnapshotDto), AppError> {
+        let result = git_executor::checkout_branch(workspace_path, branch_name).await?;
+        let snapshot = self.refresh(workspace_id, workspace_path).await?;
+        Ok((result, snapshot))
+    }
+
+    pub async fn create_branch(
+        &self,
+        workspace_id: &str,
+        workspace_path: &str,
+        branch_name: &str,
+    ) -> Result<(GitCommandResultDto, GitSnapshotDto), AppError> {
+        let result = git_executor::create_branch(workspace_path, branch_name).await?;
         let snapshot = self.refresh(workspace_id, workspace_path).await?;
         Ok((result, snapshot))
     }
@@ -1228,4 +1269,70 @@ fn state_priority(state: &GitFileState) -> u8 {
         GitFileState::Modified => 3,
         GitFileState::Untracked => 4,
     }
+}
+
+fn collect_branches(repo: &Repository) -> Result<Vec<GitBranchDto>, AppError> {
+    let head = repo.head().ok();
+    let head_shorthand = head.as_ref().and_then(|r| r.shorthand().map(str::to_string));
+    let is_detached = repo.head_detached().unwrap_or(false);
+
+    let branches = repo.branches(None).map_err(|error| {
+        AppError::recoverable(
+            ErrorSource::Git,
+            "git.branch.list_failed",
+            format!("Unable to list branches: {error}"),
+        )
+    })?;
+
+    let mut result = Vec::new();
+
+    for branch_entry in branches {
+        let (branch, branch_type) = branch_entry.map_err(|error| {
+            AppError::recoverable(
+                ErrorSource::Git,
+                "git.branch.read_failed",
+                format!("Unable to read branch entry: {error}"),
+            )
+        })?;
+
+        let Some(name) = branch.name().ok().flatten() else {
+            continue;
+        };
+
+        let is_remote = branch_type == BranchType::Remote;
+        let is_head = if is_detached {
+            false
+        } else {
+            !is_remote && head_shorthand.as_deref() == Some(name)
+        };
+
+        let upstream = if !is_remote {
+            branch
+                .upstream()
+                .ok()
+                .and_then(|u| u.name().ok().flatten().map(str::to_string))
+        } else {
+            None
+        };
+
+        result.push(GitBranchDto {
+            name: name.to_string(),
+            is_head,
+            is_remote,
+            upstream,
+        });
+    }
+
+    // Sort: head first, then local branches alphabetically, then remote branches
+    result.sort_by(|a, b| {
+        if a.is_head != b.is_head {
+            return b.is_head.cmp(&a.is_head);
+        }
+        if a.is_remote != b.is_remote {
+            return a.is_remote.cmp(&b.is_remote);
+        }
+        a.name.cmp(&b.name)
+    });
+
+    Ok(result)
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -349,6 +349,10 @@ pub fn run() {
             commands::git::git_fetch,
             commands::git::git_pull,
             commands::git::git_push,
+            commands::git::git_list_branches,
+            commands::git::git_checkout_branch,
+            commands::git::git_create_branch,
+            commands::git::git_generate_branch_name,
             // Terminal
             commands::terminal::terminal_create_or_attach,
             commands::terminal::terminal_write_input,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -341,6 +341,7 @@ pub fn run() {
             commands::git::git_get_diff,
             commands::git::git_get_file_status,
             commands::git::git_subscribe,
+            commands::git::git_unsubscribe,
             commands::git::git_refresh,
             commands::git::git_stage,
             commands::git::git_unstage,

--- a/src-tauri/src/model/git.rs
+++ b/src-tauri/src/model/git.rs
@@ -126,6 +126,16 @@ pub struct GitFileStatusDto {
     pub is_ignored: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitBranchDto {
+    pub name: String,
+    pub is_head: bool,
+    pub is_remote: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upstream: Option<String>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GitMutationAction {
@@ -133,6 +143,8 @@ pub enum GitMutationAction {
     Fetch,
     Pull,
     Push,
+    Checkout,
+    CreateBranch,
 }
 
 impl GitMutationAction {
@@ -142,6 +154,8 @@ impl GitMutationAction {
             Self::Fetch => "fetch",
             Self::Pull => "pull",
             Self::Push => "push",
+            Self::Checkout => "checkout",
+            Self::CreateBranch => "create_branch",
         }
     }
 
@@ -151,6 +165,8 @@ impl GitMutationAction {
             Self::Fetch => "git_fetch",
             Self::Pull => "git_pull",
             Self::Push => "git_push",
+            Self::Checkout => "git_checkout_branch",
+            Self::CreateBranch => "git_create_branch",
         }
     }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -167,7 +167,7 @@ const en: Record<TranslationKey, string> = {
   "sourceControl.branch.localBranches": "Local",
   "sourceControl.branch.remoteBranches": "Remote",
   "sourceControl.branch.createBranch": "Create branch",
-  "sourceControl.branch.smartCreate": "Smart create branch",
+  "sourceControl.branch.smartCreate": "Create branch",
   "sourceControl.branch.newBranchName": "New branch name",
   "sourceControl.branch.create": "Create",
   "sourceControl.branch.cancel": "Cancel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -162,6 +162,22 @@ const en: Record<TranslationKey, string> = {
   "sourceControl.untracked": "Untracked",
   "sourceControl.failedLoadFileDiff": "Failed to load file diff",
 
+  // ── Branch Selector ────────────────────────────────────────
+  "sourceControl.branch.search": "Search branches...",
+  "sourceControl.branch.localBranches": "Local",
+  "sourceControl.branch.remoteBranches": "Remote",
+  "sourceControl.branch.createBranch": "Create branch",
+  "sourceControl.branch.smartCreate": "Smart create branch",
+  "sourceControl.branch.newBranchName": "New branch name",
+  "sourceControl.branch.create": "Create",
+  "sourceControl.branch.cancel": "Cancel",
+  "sourceControl.branch.confirm": "Confirm",
+  "sourceControl.branch.detachedHead": "Detached HEAD",
+  "sourceControl.branch.loading": "Loading branches...",
+  "sourceControl.branch.checkoutFailed": "Failed to switch branch",
+  "sourceControl.branch.createFailed": "Failed to create branch",
+  "sourceControl.branch.noResults": "No matching branches",
+
   // ── Workspace Apps ───────────────────────────────────────
   "workspaceApps.error.readApps": "Failed to read available apps",
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -162,6 +162,22 @@ const zhCN = {
   "sourceControl.untracked": "未跟踪",
   "sourceControl.failedLoadFileDiff": "加载文件差异失败",
 
+  // ── Branch Selector ────────────────────────────────────────
+  "sourceControl.branch.search": "搜索分支...",
+  "sourceControl.branch.localBranches": "本地分支",
+  "sourceControl.branch.remoteBranches": "远程分支",
+  "sourceControl.branch.createBranch": "创建分支",
+  "sourceControl.branch.smartCreate": "智能创建分支",
+  "sourceControl.branch.newBranchName": "新分支名称",
+  "sourceControl.branch.create": "创建",
+  "sourceControl.branch.cancel": "取消",
+  "sourceControl.branch.confirm": "确认",
+  "sourceControl.branch.detachedHead": "游离 HEAD",
+  "sourceControl.branch.loading": "正在加载分支...",
+  "sourceControl.branch.checkoutFailed": "切换分支失败",
+  "sourceControl.branch.createFailed": "创建分支失败",
+  "sourceControl.branch.noResults": "没有匹配的分支",
+
   // ── Workspace Apps ───────────────────────────────────────
   "workspaceApps.error.readApps": "读取可用应用失败",
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -167,7 +167,7 @@ const zhCN = {
   "sourceControl.branch.localBranches": "本地分支",
   "sourceControl.branch.remoteBranches": "远程分支",
   "sourceControl.branch.createBranch": "创建分支",
-  "sourceControl.branch.smartCreate": "智能创建分支",
+  "sourceControl.branch.smartCreate": "创建分支",
   "sourceControl.branch.newBranchName": "新分支名称",
   "sourceControl.branch.create": "创建",
   "sourceControl.branch.cancel": "取消",

--- a/src/modules/workbench-shell/ui/branch-selector.tsx
+++ b/src/modules/workbench-shell/ui/branch-selector.tsx
@@ -547,14 +547,6 @@ export function BranchSelector({
                         {showRemoteBranches
                           ? filteredRemote.map((branch) => {
                               const isSwitching = switchingBranch === branch.name;
-                              // Strip remote prefix to get the local branch name.
-                              // git2 returns remote branches as "<remote>/<branch>" where
-                              // remote names never contain "/", so splitting on the first
-                              // "/" is safe even for multi-segment branch names like "feat/foo".
-                              const slashIdx = branch.name.indexOf("/");
-                              const localName = slashIdx >= 0
-                                ? branch.name.substring(slashIdx + 1)
-                                : branch.name;
 
                               return (
                                 <button
@@ -565,7 +557,7 @@ export function BranchSelector({
                                     isSwitching && "cursor-wait opacity-70",
                                   )}
                                   disabled={!!switchingBranch}
-                                  onClick={() => void handleCheckout(localName)}
+                                  onClick={() => void handleCheckout(branch.name)}
                                 >
                                   <GitBranch className="size-3.5 shrink-0 text-app-subtle" />
                                   <span className="min-w-0 flex-1 truncate">{branch.name}</span>

--- a/src/modules/workbench-shell/ui/branch-selector.tsx
+++ b/src/modules/workbench-shell/ui/branch-selector.tsx
@@ -1,0 +1,607 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  LoaderCircle,
+  Plus,
+  Search,
+  Sparkles,
+} from "lucide-react";
+
+import { useT } from "@/i18n";
+import {
+  gitCheckoutBranch,
+  gitCreateBranch,
+  gitGenerateBranchName,
+  gitListBranches,
+} from "@/services/bridge/git-commands";
+import type { GitBranchDto, GitMutationResponseDto, GitSnapshotDto, RunModelPlanDto } from "@/shared/types/api";
+import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
+import { cn } from "@/shared/lib/utils";
+
+function mostFrequent(counts: Record<string, number>, fallback: string): string {
+  let best = fallback;
+  let max = 0;
+  for (const [key, count] of Object.entries(counts)) {
+    if (count > max) {
+      max = count;
+      best = key;
+    }
+  }
+  return best;
+}
+
+function sanitizeBranchSegment(value: string): string {
+  return value
+    .replace(/[^a-zA-Z0-9-]/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .toLowerCase() || "update";
+}
+
+export function BranchSelector({
+  workspaceId,
+  snapshot,
+  modelPlan,
+}: {
+  workspaceId: string | null;
+  snapshot: Pick<GitSnapshotDto, "headRef" | "isDetached" | "stagedFiles" | "unstagedFiles" | "untrackedFiles"> | null;
+  modelPlan: RunModelPlanDto | null;
+}) {
+  const t = useT();
+  const [isOpen, setOpen] = useState(false);
+  const [branches, setBranches] = useState<GitBranchDto[]>([]);
+  const [isLoading, setLoading] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [switchingBranch, setSwitchingBranch] = useState<string | null>(null);
+  const [approvalPending, setApprovalPending] = useState<{
+    action: "checkout" | "create";
+    branch: string;
+    reason: string;
+  } | null>(null);
+
+  // Create branch mode
+  const [isCreateMode, setCreateMode] = useState(false);
+  const [newBranchName, setNewBranchName] = useState("");
+  const [isCreating, setCreating] = useState(false);
+  const [isGeneratingName, setGeneratingName] = useState(false);
+  const [hasGeneratedSuggestion, setHasGeneratedSuggestion] = useState(false);
+
+  // Remote branches visibility
+  const [showRemoteBranches, setShowRemoteBranches] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const newBranchInputRef = useRef<HTMLInputElement | null>(null);
+
+  const currentBranch = snapshot?.isDetached
+    ? null
+    : (snapshot?.headRef ?? null);
+
+  const branchLabel = snapshot?.isDetached
+    ? t("sourceControl.branch.detachedHead")
+    : (snapshot?.headRef ?? t("sourceControl.noBranch"));
+
+  const localBranches = useMemo(
+    () => branches.filter((b) => !b.isRemote),
+    [branches],
+  );
+  const remoteBranches = useMemo(
+    () => branches.filter((b) => b.isRemote),
+    [branches],
+  );
+
+  const filteredLocal = useMemo(() => {
+    if (!searchQuery) return localBranches;
+    const query = searchQuery.toLowerCase();
+    return localBranches.filter((b) => b.name.toLowerCase().includes(query));
+  }, [localBranches, searchQuery]);
+
+  const filteredRemote = useMemo(() => {
+    if (!searchQuery) return remoteBranches;
+    const query = searchQuery.toLowerCase();
+    return remoteBranches.filter((b) => b.name.toLowerCase().includes(query));
+  }, [remoteBranches, searchQuery]);
+
+  const loadBranches = useCallback(async () => {
+    if (!workspaceId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await gitListBranches(workspaceId);
+      setBranches(result);
+    } catch (err) {
+      setError(getInvokeErrorMessage(err, t("sourceControl.branch.loading")));
+    } finally {
+      setLoading(false);
+    }
+  }, [workspaceId, t]);
+
+  useEffect(() => {
+    if (isOpen) {
+      void loadBranches();
+      requestAnimationFrame(() => {
+        searchInputRef.current?.focus();
+      });
+    } else {
+      setSearchQuery("");
+      setCreateMode(false);
+      setNewBranchName("");
+      setHasGeneratedSuggestion(false);
+      setGeneratingName(false);
+      setError(null);
+      setApprovalPending(null);
+      setShowRemoteBranches(false);
+    }
+  }, [isOpen, loadBranches]);
+
+  // Close on click outside
+  useEffect(() => {
+    if (!isOpen || typeof window === "undefined") return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (target && containerRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+
+    window.addEventListener("mousedown", handlePointerDown);
+    return () => window.removeEventListener("mousedown", handlePointerDown);
+  }, [isOpen]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen || typeof window === "undefined") return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        if (isCreateMode) {
+          setCreateMode(false);
+          setNewBranchName("");
+          setHasGeneratedSuggestion(false);
+        } else {
+          setOpen(false);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, isCreateMode]);
+
+  const handleMutationResponse = useCallback(
+    (
+      response: GitMutationResponseDto,
+      action: "checkout" | "create",
+      branch: string,
+    ) => {
+      if (response.type === "approval_required") {
+        setApprovalPending({
+          action,
+          branch,
+          reason: response.reason,
+        });
+        return false;
+      }
+      return true;
+    },
+    [],
+  );
+
+  const handleCheckout = useCallback(
+    async (branchName: string, approved?: boolean) => {
+      if (!workspaceId) return;
+      setSwitchingBranch(branchName);
+      setError(null);
+      try {
+        const response = await gitCheckoutBranch(
+          workspaceId,
+          branchName,
+          approved,
+        );
+        if (handleMutationResponse(response, "checkout", branchName)) {
+          setOpen(false);
+        }
+      } catch (err) {
+        setError(getInvokeErrorMessage(err, t("sourceControl.branch.checkoutFailed")));
+      } finally {
+        setSwitchingBranch(null);
+      }
+    },
+    [workspaceId, handleMutationResponse, t],
+  );
+
+  const doCreateBranch = useCallback(
+    async (branchToCreate: string, approved?: boolean) => {
+      if (!workspaceId || !branchToCreate.trim()) return;
+      setCreating(true);
+      setError(null);
+      try {
+        const response = await gitCreateBranch(
+          workspaceId,
+          branchToCreate.trim(),
+          approved,
+        );
+        if (handleMutationResponse(response, "create", branchToCreate.trim())) {
+          setOpen(false);
+        }
+      } catch (err) {
+        setError(getInvokeErrorMessage(err, t("sourceControl.branch.createFailed")));
+      } finally {
+        setCreating(false);
+      }
+    },
+    [workspaceId, handleMutationResponse, t],
+  );
+
+  const handleApprovalConfirm = useCallback(async () => {
+    if (!approvalPending) return;
+    const { action, branch } = approvalPending;
+    setApprovalPending(null);
+    if (action === "checkout") {
+      await handleCheckout(branch, true);
+    } else {
+      await doCreateBranch(branch, true);
+    }
+  }, [approvalPending, handleCheckout, doCreateBranch]);
+
+  const generateStrategyRef = useRef(0);
+
+  // Quick local heuristic for instant fallback
+  const generateLocalFallbackName = useCallback((): string => {
+    const changedFiles = snapshot
+      ? [...snapshot.stagedFiles, ...snapshot.unstagedFiles, ...snapshot.untrackedFiles]
+      : [];
+
+    const prefixCounts: Record<string, number> = {};
+    for (const branch of localBranches) {
+      const slashIndex = branch.name.indexOf("/");
+      if (slashIndex > 0) {
+        const prefix = branch.name.substring(0, slashIndex);
+        prefixCounts[prefix] = (prefixCounts[prefix] ?? 0) + 1;
+      }
+    }
+    const conventionPrefix = mostFrequent(prefixCounts, "");
+    let defaultPrefix: string;
+    if (conventionPrefix) {
+      defaultPrefix = conventionPrefix;
+    } else {
+      const hasOnlyModifications =
+        changedFiles.length > 0 && changedFiles.every((f) => f.status === "modified");
+      defaultPrefix = hasOnlyModifications ? "fix" : "feat";
+    }
+
+    const candidates: string[] = [];
+    if (changedFiles.length > 0) {
+      const folders = changedFiles.slice(0, 8).map((f) => {
+        const parts = f.path.split("/");
+        return parts.length > 1 ? parts[parts.length - 2] : null;
+      }).filter(Boolean) as string[];
+      if (folders.length > 0) {
+        const folderCounts: Record<string, number> = {};
+        for (const folder of folders) folderCounts[folder] = (folderCounts[folder] ?? 0) + 1;
+        candidates.push(`${defaultPrefix}/${sanitizeBranchSegment(mostFrequent(folderCounts, "update"))}`);
+      }
+      const firstFile = changedFiles[0];
+      if (firstFile) {
+        const fileName = firstFile.path.split("/").pop()?.split(".")[0] ?? "";
+        if (fileName) candidates.push(`${defaultPrefix}/${sanitizeBranchSegment(fileName)}`);
+      }
+    }
+    if (candidates.length === 0) {
+      const timestamp = new Date().toISOString().slice(5, 10).replace("-", "");
+      candidates.push(`${defaultPrefix}/update-${timestamp}`);
+    }
+
+    const unique = [...new Set(candidates)];
+    const index = generateStrategyRef.current % unique.length;
+    generateStrategyRef.current += 1;
+    return unique[index] ?? `${defaultPrefix}/update`;
+  }, [snapshot, localBranches]);
+
+  // AI-powered branch name generation
+  const generateSmartBranchName = useCallback(() => {
+    // Set instant local fallback first
+    const fallback = generateLocalFallbackName();
+    setNewBranchName(fallback);
+    setHasGeneratedSuggestion(true);
+
+    // Then call AI if model is available
+    if (!workspaceId || !modelPlan) return;
+
+    setGeneratingName(true);
+    void gitGenerateBranchName(workspaceId, modelPlan)
+      .then((name) => {
+        setNewBranchName(name);
+      })
+      .catch(() => {
+        // AI failed — keep the local fallback, no error needed
+      })
+      .finally(() => {
+        setGeneratingName(false);
+      });
+  }, [workspaceId, modelPlan, generateLocalFallbackName]);
+
+  const handleEnterCreateMode = useCallback(() => {
+    setCreateMode(true);
+    setError(null);
+    generateSmartBranchName();
+    requestAnimationFrame(() => {
+      newBranchInputRef.current?.focus();
+      newBranchInputRef.current?.select();
+    });
+  }, [generateSmartBranchName]);
+
+  if (!workspaceId || !snapshot) {
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-app-subtle">
+        <GitBranch className="size-3.5" />
+        <span>{t("sourceControl.noBranch")}</span>
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs transition-colors",
+          isOpen
+            ? "bg-app-surface-hover text-app-foreground"
+            : "text-app-subtle hover:bg-app-surface-hover hover:text-app-foreground",
+        )}
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        title={branchLabel}
+      >
+        <GitBranch className="size-3.5 shrink-0" />
+        <span className="max-w-[120px] truncate">{branchLabel}</span>
+        <ChevronDown className={cn("size-3.5 shrink-0 transition-transform duration-200", isOpen && "rotate-180")} />
+      </button>
+
+      {isOpen ? (
+        <div className="absolute right-0 top-[calc(100%+0.35rem)] z-30 w-[280px] overflow-hidden rounded-xl border border-app-border bg-app-menu/98 shadow-[0_20px_48px_rgba(15,23,42,0.18)] backdrop-blur-xl dark:bg-app-menu/94 dark:shadow-[0_20px_48px_rgba(0,0,0,0.42)]">
+          {approvalPending ? (
+            <div className="p-3">
+              <p className="mb-2 text-sm text-app-foreground">
+                {approvalPending.reason}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="flex-1 rounded-lg border border-app-border bg-app-surface-muted px-3 py-1.5 text-xs font-medium text-app-foreground transition-colors hover:bg-app-surface-hover"
+                  onClick={() => setApprovalPending(null)}
+                >
+                  {t("sourceControl.branch.cancel")}
+                </button>
+                <button
+                  type="button"
+                  className="flex-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                  onClick={() => void handleApprovalConfirm()}
+                >
+                  {t("sourceControl.branch.confirm")}
+                </button>
+              </div>
+            </div>
+          ) : isCreateMode ? (
+            <div className="p-2">
+              <div className="mb-2 flex items-center gap-2 px-1">
+                <Plus className="size-3.5 shrink-0 text-app-subtle" />
+                <span className="text-xs font-medium text-app-foreground">
+                  {t("sourceControl.branch.createBranch")}
+                </span>
+              </div>
+              <div className="relative">
+                <input
+                  ref={newBranchInputRef}
+                  type="text"
+                  className="w-full rounded-lg border border-app-border bg-app-surface-muted px-3 py-2 text-xs text-app-foreground outline-none placeholder:text-app-subtle focus:border-primary/60 focus:ring-1 focus:ring-primary/30"
+                  placeholder={t("sourceControl.branch.newBranchName")}
+                  value={newBranchName}
+                  onChange={(e) => setNewBranchName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && newBranchName.trim()) {
+                      void doCreateBranch(newBranchName);
+                    }
+                  }}
+                />
+                {hasGeneratedSuggestion ? (
+                  <button
+                    type="button"
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 rounded p-0.5 text-app-subtle transition-colors hover:text-primary active:scale-90 disabled:pointer-events-none"
+                    title={t("sourceControl.branch.smartCreate")}
+                    disabled={isGeneratingName}
+                    onClick={() => {
+                      generateSmartBranchName();
+                      newBranchInputRef.current?.focus();
+                    }}
+                  >
+                    {isGeneratingName ? (
+                      <LoaderCircle className="size-3.5 animate-spin" />
+                    ) : (
+                      <Sparkles className="size-3.5" />
+                    )}
+                  </button>
+                ) : null}
+              </div>
+              {error ? (
+                <p className="mt-1.5 px-1 text-[11px] text-app-danger">{error}</p>
+              ) : null}
+              <div className="mt-2 flex items-center gap-2">
+                <button
+                  type="button"
+                  className="flex-1 rounded-lg border border-app-border bg-app-surface-muted px-3 py-1.5 text-xs font-medium text-app-foreground transition-colors hover:bg-app-surface-hover"
+                  onClick={() => {
+                    setCreateMode(false);
+                    setNewBranchName("");
+                    setHasGeneratedSuggestion(false);
+                    setError(null);
+                  }}
+                >
+                  {t("sourceControl.branch.cancel")}
+                </button>
+                <button
+                  type="button"
+                  className="flex-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={!newBranchName.trim() || isCreating}
+                  onClick={() => void doCreateBranch(newBranchName)}
+                >
+                  {isCreating ? (
+                    <LoaderCircle className="mx-auto size-3.5 animate-spin" />
+                  ) : (
+                    t("sourceControl.branch.create")
+                  )}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Search bar */}
+              <div className="border-b border-app-border px-2 py-1.5">
+                <div className="relative">
+                  <Search className="pointer-events-none absolute left-2 top-1/2 size-3.5 -translate-y-1/2 text-app-subtle" />
+                  <input
+                    ref={searchInputRef}
+                    type="text"
+                    className="w-full rounded-md border-none bg-transparent py-1.5 pl-7 pr-2 text-xs text-app-foreground outline-none placeholder:text-app-subtle"
+                    placeholder={t("sourceControl.branch.search")}
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              {/* Branch list */}
+              <div className="max-h-[280px] overflow-auto overscroll-contain p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                {isLoading ? (
+                  <div className="flex items-center justify-center gap-2 py-6 text-xs text-app-subtle">
+                    <LoaderCircle className="size-3.5 animate-spin" />
+                    <span>{t("sourceControl.branch.loading")}</span>
+                  </div>
+                ) : error && branches.length === 0 ? (
+                  <div className="px-3 py-4 text-center text-xs text-app-danger">
+                    {error}
+                  </div>
+                ) : (
+                  <>
+                    {/* Local branches */}
+                    {filteredLocal.length > 0 ? (
+                      <div>
+                        <div className="px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-app-subtle">
+                          {t("sourceControl.branch.localBranches")}
+                        </div>
+                        {filteredLocal.map((branch) => {
+                          const isCurrent = branch.name === currentBranch;
+                          const isSwitching = switchingBranch === branch.name;
+
+                          return (
+                            <button
+                              key={branch.name}
+                              type="button"
+                              className={cn(
+                                "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs transition-colors",
+                                isCurrent
+                                  ? "bg-app-surface-hover/80 text-app-foreground"
+                                  : "text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
+                                isSwitching && "cursor-wait opacity-70",
+                              )}
+                              disabled={isCurrent || !!switchingBranch}
+                              onClick={() => void handleCheckout(branch.name)}
+                            >
+                              <GitBranch className="size-3.5 shrink-0 text-app-subtle" />
+                              <span className="min-w-0 flex-1 truncate">{branch.name}</span>
+                              {isSwitching ? (
+                                <LoaderCircle className="size-3 shrink-0 animate-spin text-app-subtle" />
+                              ) : isCurrent ? (
+                                <Check className="size-3.5 shrink-0 text-primary" />
+                              ) : null}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+
+                    {/* Remote branches (collapsible) */}
+                    {filteredRemote.length > 0 ? (
+                      <div className="mt-1">
+                        <button
+                          type="button"
+                          className="flex w-full items-center gap-1 px-2 pb-1 pt-1.5 text-[10px] font-semibold uppercase tracking-wider text-app-subtle hover:text-app-foreground"
+                          onClick={() => setShowRemoteBranches((s) => !s)}
+                        >
+                          <ChevronRight
+                            className={cn(
+                              "size-3 transition-transform duration-150",
+                              showRemoteBranches && "rotate-90",
+                            )}
+                          />
+                          <span>
+                            {t("sourceControl.branch.remoteBranches")} ({filteredRemote.length})
+                          </span>
+                        </button>
+                        {showRemoteBranches
+                          ? filteredRemote.map((branch) => {
+                              const isSwitching = switchingBranch === branch.name;
+                              const localName = branch.name.includes("/")
+                                ? branch.name.substring(branch.name.indexOf("/") + 1)
+                                : branch.name;
+
+                              return (
+                                <button
+                                  key={branch.name}
+                                  type="button"
+                                  className={cn(
+                                    "flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-app-muted transition-colors hover:bg-app-surface-hover hover:text-app-foreground",
+                                    isSwitching && "cursor-wait opacity-70",
+                                  )}
+                                  disabled={!!switchingBranch}
+                                  onClick={() => void handleCheckout(localName)}
+                                >
+                                  <GitBranch className="size-3.5 shrink-0 text-app-subtle" />
+                                  <span className="min-w-0 flex-1 truncate">{branch.name}</span>
+                                  {isSwitching ? (
+                                    <LoaderCircle className="size-3 shrink-0 animate-spin text-app-subtle" />
+                                  ) : null}
+                                </button>
+                              );
+                            })
+                          : null}
+                      </div>
+                    ) : null}
+
+                    {filteredLocal.length === 0 && filteredRemote.length === 0 && searchQuery ? (
+                      <div className="px-3 py-4 text-center text-xs text-app-subtle">
+                        {t("sourceControl.branch.noResults")}
+                      </div>
+                    ) : null}
+
+                    {error && branches.length > 0 ? (
+                      <p className="px-2 py-1 text-[11px] text-app-danger">{error}</p>
+                    ) : null}
+                  </>
+                )}
+              </div>
+
+              {/* Smart create branch */}
+              <div className="border-t border-app-border p-1">
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2 rounded-lg px-2 py-2 text-left text-xs text-app-muted transition-colors hover:bg-app-surface-hover hover:text-app-foreground"
+                  onClick={handleEnterCreateMode}
+                >
+                  <Sparkles className="size-3.5 shrink-0 text-primary/70" />
+                  <span>{t("sourceControl.branch.smartCreate")}</span>
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/workbench-shell/ui/branch-selector.tsx
+++ b/src/modules/workbench-shell/ui/branch-selector.tsx
@@ -547,8 +547,13 @@ export function BranchSelector({
                         {showRemoteBranches
                           ? filteredRemote.map((branch) => {
                               const isSwitching = switchingBranch === branch.name;
-                              const localName = branch.name.includes("/")
-                                ? branch.name.substring(branch.name.indexOf("/") + 1)
+                              // Strip remote prefix to get the local branch name.
+                              // git2 returns remote branches as "<remote>/<branch>" where
+                              // remote names never contain "/", so splitting on the first
+                              // "/" is safe even for multi-segment branch names like "feat/foo".
+                              const slashIdx = branch.name.indexOf("/");
+                              const localName = slashIdx >= 0
+                                ? branch.name.substring(slashIdx + 1)
                                 : branch.name;
 
                               return (

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -1462,6 +1462,7 @@ export function DashboardWorkbench() {
     }
 
     let cancelled = false;
+    let unsubscribe: (() => Promise<void>) | null = null;
 
     // Subscribe first so we don't miss events during the initial fetch
     void gitSubscribe(resolvedWorkspaceId, (event) => {
@@ -1469,7 +1470,15 @@ export function DashboardWorkbench() {
       if (event.type === "snapshot_updated") {
         setTopBarGitSnapshot(event.snapshot);
       }
-    }).catch(() => {});
+    })
+      .then((nextUnsubscribe) => {
+        if (cancelled) {
+          void nextUnsubscribe().catch(() => {});
+          return;
+        }
+        unsubscribe = nextUnsubscribe;
+      })
+      .catch(() => {});
 
     // Then fetch the initial snapshot to fill the gap before subscription delivers
     void gitGetSnapshot(resolvedWorkspaceId)
@@ -1482,6 +1491,9 @@ export function DashboardWorkbench() {
 
     return () => {
       cancelled = true;
+      if (unsubscribe) {
+        void unsubscribe().catch(() => {});
+      }
     };
   }, [resolvedWorkspaceId]);
 

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -11,7 +11,6 @@ import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import {
   Boxes,
-  ChevronDown,
   Folder,
   FolderOpen,
   FolderPlus,
@@ -46,6 +45,7 @@ import { UpdateAvailableDialog } from "@/modules/workbench-shell/ui/update-avail
 import { isOnboardingCompleted } from "@/modules/onboarding/model/use-onboarding";
 import { OnboardingWizard } from "@/modules/onboarding/ui/onboarding-wizard";
 import type {
+  GitSnapshotDto,
   MessageAttachmentDto,
   RunMode,
   ThreadSummaryDto,
@@ -60,6 +60,8 @@ import {
   workspaceList,
   workspaceRemove,
   workspaceSetDefault,
+  gitGetSnapshot,
+  gitSubscribe,
 } from "@/services/bridge";
 import type { RunState } from "@/services/thread-stream";
 import {
@@ -105,6 +107,7 @@ import type {
 import type { ExtensionDetail, SkillPreview } from "@/shared/types/extensions";
 import { NewThreadEmptyState } from "@/modules/workbench-shell/ui/new-thread-empty-state";
 import { ProjectPanel } from "@/modules/workbench-shell/ui/project-panel";
+import { BranchSelector } from "@/modules/workbench-shell/ui/branch-selector";
 import {
   RuntimeThreadSurface,
   type ThreadContextUsage,
@@ -555,6 +558,7 @@ export function DashboardWorkbench() {
     useState<DrawerPanel>("project");
   const [selectedDiffSelection, setSelectedDiffSelection] =
     useState<GitDiffSelection | null>(null);
+  const [topBarGitSnapshot, setTopBarGitSnapshot] = useState<GitSnapshotDto | null>(null);
   const mainContentRef = useRef<HTMLElement | null>(null);
   const overlayContentRef = useRef<HTMLDivElement | null>(null);
   const userMenuRef = useRef<HTMLDivElement | null>(null);
@@ -662,6 +666,23 @@ export function DashboardWorkbench() {
       ),
     [workspaces],
   );
+
+  const branchSnapshot = useMemo(() => {
+    if (!topBarGitSnapshot) return null;
+    return {
+      headRef: topBarGitSnapshot.headRef,
+      isDetached: topBarGitSnapshot.isDetached,
+      stagedFiles: topBarGitSnapshot.stagedFiles,
+      unstagedFiles: topBarGitSnapshot.unstagedFiles,
+      untrackedFiles: topBarGitSnapshot.untrackedFiles,
+    };
+  }, [
+    topBarGitSnapshot?.headRef,
+    topBarGitSnapshot?.isDetached,
+    topBarGitSnapshot?.stagedFiles,
+    topBarGitSnapshot?.unstagedFiles,
+    topBarGitSnapshot?.untrackedFiles,
+  ]);
 
   useEffect(() => {
     workspaceThreadDisplayCountsRef.current = workspaceThreadDisplayCounts;
@@ -1432,6 +1453,37 @@ export function DashboardWorkbench() {
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
   }, [selectedDiffSelection]);
+
+  // ── Git snapshot subscription for branch display in thread title bar ──
+  useEffect(() => {
+    if (!isTauri() || !resolvedWorkspaceId) {
+      setTopBarGitSnapshot(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    // Subscribe first so we don't miss events during the initial fetch
+    void gitSubscribe(resolvedWorkspaceId, (event) => {
+      if (cancelled) return;
+      if (event.type === "snapshot_updated") {
+        setTopBarGitSnapshot(event.snapshot);
+      }
+    }).catch(() => {});
+
+    // Then fetch the initial snapshot to fill the gap before subscription delivers
+    void gitGetSnapshot(resolvedWorkspaceId)
+      .then((snapshot) => {
+        if (!cancelled && snapshot) {
+          setTopBarGitSnapshot((current) => current ?? snapshot);
+        }
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resolvedWorkspaceId]);
 
   useEffect(() => {
     if (!activeOverlay || typeof window === "undefined") {
@@ -2806,14 +2858,11 @@ export function DashboardWorkbench() {
                               ) : null}
                             </div>
                           </div>
-                          <button
-                            type="button"
-                            className="inline-flex items-center gap-1.5 text-xs text-app-subtle transition-colors hover:text-app-foreground"
-                          >
-                            <GitBranch className="size-3.5" />
-                            <span>main</span>
-                            <ChevronDown className="size-3.5" />
-                          </button>
+                          <BranchSelector
+                            workspaceId={resolvedWorkspaceId}
+                            snapshot={branchSnapshot}
+                            modelPlan={commitMessageModelPlan}
+                          />
                         </div>
                       </div>
 

--- a/src/modules/workbench-shell/ui/source-control-panels.tsx
+++ b/src/modules/workbench-shell/ui/source-control-panels.tsx
@@ -804,6 +804,7 @@ export function GitPanel({
     }
 
     let cancelled = false;
+    let unsubscribe: (() => Promise<void>) | null = null;
     setIsLoading(true);
     setError(null);
     setActionAlert(null);
@@ -862,17 +863,28 @@ export function GitPanel({
       if (event.type === "refresh_completed") {
         setIsRefreshing(false);
       }
-    }).catch((subscriptionError) => {
-      if (cancelled) {
-        return;
-      }
+    })
+      .then((nextUnsubscribe) => {
+        if (cancelled) {
+          void nextUnsubscribe().catch(() => {});
+          return;
+        }
+        unsubscribe = nextUnsubscribe;
+      })
+      .catch((subscriptionError) => {
+        if (cancelled) {
+          return;
+        }
 
-      const message = formatUiError(subscriptionError, t("sourceControl.failedSubscribeGit"));
-      setError(message);
-    });
+        const message = formatUiError(subscriptionError, t("sourceControl.failedSubscribeGit"));
+        setError(message);
+      });
 
     return () => {
       cancelled = true;
+      if (unsubscribe) {
+        void unsubscribe().catch(() => {});
+      }
     };
   }, [isMockMode, workspaceId]);
 

--- a/src/services/bridge/git-commands.ts
+++ b/src/services/bridge/git-commands.ts
@@ -10,6 +10,8 @@ import type {
   RunModelPlanDto,
 } from "@/shared/types/api";
 
+export type GitUnsubscribe = () => Promise<void>;
+
 const requireTauri = (cmd: string) => {
   if (!isTauri()) throw new Error(`${cmd} requires Tauri runtime`);
 };
@@ -59,7 +61,7 @@ export async function gitGetFileStatus(
 export async function gitSubscribe(
   workspaceId: string,
   onEvent: (event: GitStreamEvent) => void,
-): Promise<void> {
+): Promise<GitUnsubscribe> {
   requireTauri("git_subscribe");
 
   const channel = new Channel<GitStreamEvent>();
@@ -69,6 +71,18 @@ export async function gitSubscribe(
     workspaceId,
     onEvent: channel,
   });
+
+  let unsubscribed = false;
+  return async () => {
+    if (unsubscribed) {
+      return;
+    }
+    unsubscribed = true;
+    await invoke("git_unsubscribe", {
+      workspaceId,
+      subscriptionId: channel.id,
+    });
+  };
 }
 
 export async function gitRefresh(workspaceId: string): Promise<GitSnapshotDto> {

--- a/src/services/bridge/git-commands.ts
+++ b/src/services/bridge/git-commands.ts
@@ -1,5 +1,6 @@
 import { invoke, isTauri, Channel } from "@tauri-apps/api/core";
 import type {
+  GitBranchDto,
   GitCommitSummaryDto,
   GitDiffDto,
   GitFileStatusDto,
@@ -149,5 +150,49 @@ export async function gitPush(
   return invoke<GitMutationResponseDto>("git_push", {
     workspaceId,
     approved: approved ?? null,
+  });
+}
+
+export async function gitListBranches(
+  workspaceId: string,
+): Promise<GitBranchDto[]> {
+  if (!isTauri()) return [];
+  return invoke<GitBranchDto[]>("git_list_branches", { workspaceId });
+}
+
+export async function gitCheckoutBranch(
+  workspaceId: string,
+  branch: string,
+  approved?: boolean,
+): Promise<GitMutationResponseDto> {
+  requireTauri("git_checkout_branch");
+  return invoke<GitMutationResponseDto>("git_checkout_branch", {
+    workspaceId,
+    branch,
+    approved: approved ?? null,
+  });
+}
+
+export async function gitCreateBranch(
+  workspaceId: string,
+  branch: string,
+  approved?: boolean,
+): Promise<GitMutationResponseDto> {
+  requireTauri("git_create_branch");
+  return invoke<GitMutationResponseDto>("git_create_branch", {
+    workspaceId,
+    branch,
+    approved: approved ?? null,
+  });
+}
+
+export async function gitGenerateBranchName(
+  workspaceId: string,
+  modelPlan: RunModelPlanDto,
+): Promise<string> {
+  requireTauri("git_generate_branch_name");
+  return invoke<string>("git_generate_branch_name", {
+    workspaceId,
+    modelPlan,
   });
 }

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -548,6 +548,13 @@ export interface GitSnapshotDto {
   lastRefreshedAt: string;
 }
 
+export interface GitBranchDto {
+  name: string;
+  isHead: boolean;
+  isRemote: boolean;
+  upstream: string | null;
+}
+
 export type GitDiffLineKind = "context" | "add" | "remove";
 
 export interface GitDiffLineDto {


### PR DESCRIPTION
## Summary

Add an interactive Git branch selector to the workbench and improve push behavior for new branches.

### Branch Selector UI (`branch-selector.tsx`)
- List local and remote branches with search/filter
- Checkout existing branches with approval gate
- Create new branches from the current HEAD
- AI-powered branch name generation based on the current model plan context

### Backend Commands
- `git_list_branches` — list local and remote branches
- `git_checkout_branch` — switch to a target branch (with approval flow)
- `git_create_branch` — create a new branch (with approval flow)
- `git_generate_branch_name` — generate a branch name suggestion via the model plan

### Auto Upstream on Push
- Detect branches without an upstream tracking reference
- Automatically pass `--set-upstream origin <branch>` on push, eliminating manual configuration for new branches

## Changed Files

| Area | File | Change |
|------|------|--------|
| UI | `src/modules/workbench-shell/ui/branch-selector.tsx` | New component (607 lines) |
| UI | `src/modules/workbench-shell/ui/dashboard-workbench.tsx` | Integrate branch selector |
| Rust | `src-tauri/src/commands/git.rs` | +4 Tauri commands |
| Rust | `src-tauri/src/core/executors/git.rs` | Branch executor logic |
| Rust | `src-tauri/src/core/git_manager.rs` | List/checkout/create + auto upstream |
| Rust | `src-tauri/src/model/git.rs` | `GitBranchDto`, new mutation actions |
| Rust | `src-tauri/src/lib.rs` | Register new commands |
| Bridge | `src/services/bridge/git-commands.ts` | Frontend bridge functions |
| Types | `src/shared/types/api.ts` | `GitBranchDto` type |
| i18n | `src/i18n/locales/en.ts` | New keys |
| i18n | `src/i18n/locales/zh-CN.ts` | New keys |

**Total: 11 files, +1,240 / −23**