### PR TITLE
refactor: ⚡️ parallelize overlay fetching and cache canonical paths

### DIFF
--- a/src-tauri/src/commands/index.rs
+++ b/src-tauri/src/commands/index.rs
@@ -17,15 +17,13 @@ pub async fn index_get_tree(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
-    let mut tree = state
-        .index_manager
-        .get_tree(&workspace.canonical_path)
-        .await?;
+    let (tree_result, overlay_result) = tokio::join!(
+        state.index_manager.get_tree(&workspace.canonical_path),
+        state.git_manager.get_workspace_overlay(&workspace.canonical_path)
+    );
 
-    let overlay = state
-        .git_manager
-        .get_workspace_overlay(&workspace.canonical_path)
-        .await?;
+    let mut tree = tree_result?;
+    let overlay = overlay_result?;
 
     tree.apply_git_overlay(&overlay.states);
 
@@ -47,6 +45,19 @@ pub async fn index_get_children(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
+    let (children_result, overlay_result) = tokio::join!(
+        state.index_manager.get_children(
+            &workspace.canonical_path,
+            &directory_path,
+            offset,
+            max_results,
+        ),
+        state.git_manager.get_workspace_overlay(&workspace.canonical_path)
+    );
+
+    let response = children_result?;
+    let overlay = overlay_result?;
+
     let mut overlay_root = FileTreeNode {
         name: workspace.name.clone(),
         path: String::new(),
@@ -55,23 +66,8 @@ pub async fn index_get_children(
         children_has_more: false,
         children_next_offset: None,
         git_state: None,
-        children: None,
+        children: Some(response.children),
     };
-    let response = state
-        .index_manager
-        .get_children(
-            &workspace.canonical_path,
-            &directory_path,
-            offset,
-            max_results,
-        )
-        .await?;
-    overlay_root.children = Some(response.children);
-
-    let overlay = state
-        .git_manager
-        .get_workspace_overlay(&workspace.canonical_path)
-        .await?;
 
     overlay_root.apply_git_overlay(&overlay.states);
 
@@ -109,15 +105,17 @@ pub async fn index_reveal_path(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
-    let mut response = state
-        .index_manager
-        .reveal_path(&workspace.canonical_path, &target_path)
-        .await?;
+    let (response_result, overlay_result) = tokio::join!(
+        state
+            .index_manager
+            .reveal_path(&workspace.canonical_path, &target_path),
+        state
+            .git_manager
+            .get_workspace_overlay(&workspace.canonical_path)
+    );
 
-    let overlay = state
-        .git_manager
-        .get_workspace_overlay(&workspace.canonical_path)
-        .await?;
+    let mut response = response_result?;
+    let overlay = overlay_result?;
 
     for segment in &mut response.segments {
         let mut overlay_root = FileTreeNode {

--- a/src-tauri/src/commands/index.rs
+++ b/src-tauri/src/commands/index.rs
@@ -19,7 +19,9 @@ pub async fn index_get_tree(
 
     let (tree_result, overlay_result) = tokio::join!(
         state.index_manager.get_tree(&workspace.canonical_path),
-        state.git_manager.get_workspace_overlay(&workspace.canonical_path)
+        state
+            .git_manager
+            .get_workspace_overlay(&workspace.canonical_path)
     );
 
     let mut tree = tree_result?;
@@ -52,7 +54,9 @@ pub async fn index_get_children(
             offset,
             max_results,
         ),
-        state.git_manager.get_workspace_overlay(&workspace.canonical_path)
+        state
+            .git_manager
+            .get_workspace_overlay(&workspace.canonical_path)
     );
 
     let response = children_result?;

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -412,7 +412,9 @@ impl GitManager {
     }
 
     async fn invalidate_workspace_overlay(&self, workspace_path: &str) {
-        let cache_key = self.cached_canonicalize(workspace_path).await
+        let cache_key = self
+            .cached_canonicalize(workspace_path)
+            .await
             .to_string_lossy()
             .to_string();
         self.overlay_cache.write().await.remove(&cache_key);

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -24,7 +24,7 @@ use crate::model::git::{
 const DEFAULT_HISTORY_LIMIT: usize = 24;
 const MAX_DIFF_LINES: usize = 1200;
 const GIT_STREAM_BUFFER: usize = 32;
-const OVERLAY_CACHE_TTL: Duration = Duration::from_secs(2);
+const OVERLAY_CACHE_TTL: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Clone)]
 pub struct WorkspaceGitOverlay {
@@ -57,6 +57,7 @@ pub struct GitManager {
     streams: Arc<Mutex<HashMap<String, broadcast::Sender<GitStreamEvent>>>>,
     subscriptions: Arc<Mutex<HashMap<(String, u32), JoinHandle<()>>>>,
     overlay_cache: Arc<RwLock<HashMap<String, OverlayCacheEntry>>>,
+    canonical_cache: Arc<RwLock<HashMap<String, PathBuf>>>,
 }
 
 impl GitManager {
@@ -65,7 +66,29 @@ impl GitManager {
             streams: Arc::new(Mutex::new(HashMap::new())),
             subscriptions: Arc::new(Mutex::new(HashMap::new())),
             overlay_cache: Arc::new(RwLock::new(HashMap::new())),
+            canonical_cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Canonicalize a workspace path with in-memory caching and dunce to avoid
+    /// Windows UNC path prefixes and repeated expensive syscalls.
+    async fn cached_canonicalize(&self, workspace_path: &str) -> PathBuf {
+        {
+            let cache = self.canonical_cache.read().await;
+            if let Some(cached) = cache.get(workspace_path) {
+                return cached.clone();
+            }
+        }
+
+        let canonical =
+            dunce::canonicalize(workspace_path).unwrap_or_else(|_| PathBuf::from(workspace_path));
+
+        self.canonical_cache
+            .write()
+            .await
+            .insert(workspace_path.to_string(), canonical.clone());
+
+        canonical
     }
 
     pub async fn subscribe(&self, workspace_id: &str) -> broadcast::Receiver<GitStreamEvent> {
@@ -127,7 +150,7 @@ impl GitManager {
         &self,
         workspace_path: &str,
     ) -> Result<Arc<WorkspaceGitOverlay>, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
         let cache_key = workspace_root.to_string_lossy().to_string();
 
         if let Some(cached) = self.overlay_cache.read().await.get(&cache_key) {
@@ -163,7 +186,7 @@ impl GitManager {
         workspace_id: &str,
         workspace_path: &str,
     ) -> Result<GitSnapshotDto, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
         let workspace_id = workspace_id.to_string();
 
         tokio::task::spawn_blocking(move || {
@@ -193,7 +216,7 @@ impl GitManager {
         workspace_path: &str,
         limit: Option<usize>,
     ) -> Result<Vec<GitCommitSummaryDto>, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
         let history_limit = limit.unwrap_or(DEFAULT_HISTORY_LIMIT);
 
         tokio::task::spawn_blocking(move || {
@@ -215,7 +238,7 @@ impl GitManager {
         path: &str,
         staged: bool,
     ) -> Result<GitDiffDto, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
         let workspace_relative = normalize_workspace_relative_path(path);
 
         tokio::task::spawn_blocking(move || {
@@ -237,7 +260,7 @@ impl GitManager {
         workspace_path: &str,
         path: &str,
     ) -> Result<GitFileStatusDto, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
         let workspace_relative = normalize_workspace_relative_path(path);
 
         tokio::task::spawn_blocking(move || {
@@ -339,7 +362,7 @@ impl GitManager {
     }
 
     pub async fn list_branches(&self, workspace_path: &str) -> Result<Vec<GitBranchDto>, AppError> {
-        let workspace_root = canonicalize_workspace(workspace_path);
+        let workspace_root = self.cached_canonicalize(workspace_path).await;
 
         tokio::task::spawn_blocking(move || {
             let repo = open_repository(&workspace_root)?;
@@ -389,7 +412,7 @@ impl GitManager {
     }
 
     async fn invalidate_workspace_overlay(&self, workspace_path: &str) {
-        let cache_key = canonicalize_workspace(workspace_path)
+        let cache_key = self.cached_canonicalize(workspace_path).await
             .to_string_lossy()
             .to_string();
         self.overlay_cache.write().await.remove(&cache_key);
@@ -1071,7 +1094,7 @@ fn open_repository(workspace_root: &Path) -> Result<Repository, AppError> {
 
 fn repo_workdir(repo: &Repository) -> Result<PathBuf, AppError> {
     repo.workdir()
-        .map(|path| std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
+        .map(|path| dunce::canonicalize(path).unwrap_or_else(|_| path.to_path_buf()))
         .ok_or_else(|| {
             AppError::recoverable(
                 ErrorSource::Git,
@@ -1079,10 +1102,6 @@ fn repo_workdir(repo: &Repository) -> Result<PathBuf, AppError> {
                 "Bare repositories are not supported in the workspace Git drawer",
             )
         })
-}
-
-fn canonicalize_workspace(workspace_path: &str) -> PathBuf {
-    std::fs::canonicalize(workspace_path).unwrap_or_else(|_| PathBuf::from(workspace_path))
 }
 
 fn workspace_path_to_repo_path(

--- a/src-tauri/src/core/index_manager.rs
+++ b/src-tauri/src/core/index_manager.rs
@@ -167,6 +167,7 @@ struct DirectoryEntry {
 #[derive(Clone)]
 pub struct IndexManager {
     manifest_cache: Arc<RwLock<HashMap<String, ManifestCacheEntry>>>,
+    canonical_cache: Arc<RwLock<HashMap<String, PathBuf>>>,
 }
 
 impl FileTreeNode {
@@ -179,12 +180,33 @@ impl IndexManager {
     pub fn new() -> Self {
         Self {
             manifest_cache: Arc::new(RwLock::new(HashMap::new())),
+            canonical_cache: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    /// Canonicalize a workspace path with in-memory caching to avoid repeated
+    /// `dunce::canonicalize` syscalls on Windows.
+    async fn cached_canonicalize(&self, workspace_path: &str) -> Result<PathBuf, AppError> {
+        {
+            let cache = self.canonical_cache.read().await;
+            if let Some(cached) = cache.get(workspace_path) {
+                return Ok(cached.clone());
+            }
+        }
+
+        let canonical = canonicalize_workspace(workspace_path)?;
+
+        self.canonical_cache
+            .write()
+            .await
+            .insert(workspace_path.to_string(), canonical.clone());
+
+        Ok(canonical)
     }
 
     /// Scan workspace directory and return a shallow, expandable file tree.
     pub async fn get_tree(&self, workspace_path: &str) -> Result<FileTreeNode, AppError> {
-        let root = canonicalize_workspace(workspace_path)?;
+        let root = self.cached_canonicalize(workspace_path).await?;
 
         tokio::task::spawn_blocking(move || build_initial_tree(&root))
             .await
@@ -204,7 +226,7 @@ impl IndexManager {
         offset: Option<usize>,
         max_results: Option<usize>,
     ) -> Result<DirectoryChildrenResponse, AppError> {
-        let root = canonicalize_workspace(workspace_path)?;
+        let root = self.cached_canonicalize(workspace_path).await?;
         let target = resolve_workspace_directory(&root, directory_path)?;
         let page_offset = offset.unwrap_or(0);
         let page_size = max_results.unwrap_or(DIRECTORY_PAGE_SIZE);
@@ -237,7 +259,7 @@ impl IndexManager {
             ));
         }
 
-        let root = canonicalize_workspace(workspace_path)?;
+        let root = self.cached_canonicalize(workspace_path).await?;
         let manifest = self.get_or_build_manifest(&root).await?;
         let limit = max_results.unwrap_or(DEFAULT_FILTER_LIMIT);
 
@@ -292,7 +314,7 @@ impl IndexManager {
             ));
         }
 
-        let root = canonicalize_workspace(workspace_path)?;
+        let root = self.cached_canonicalize(workspace_path).await?;
         let target = resolve_workspace_entry(&root, normalized_target)?;
         let relative_target = relative_path(&target, &root);
         let components = relative_target
@@ -375,7 +397,7 @@ impl IndexManager {
             ));
         }
 
-        let workspace_root = canonicalize_workspace(workspace_path)?;
+        let workspace_root = self.cached_canonicalize(workspace_path).await?;
         let limit = max_results.unwrap_or(50).max(1);
         let normalized_file_pattern = normalize_search_file_pattern(file_pattern);
 
@@ -724,9 +746,7 @@ fn read_directory_entries_page(
                 nodes.push(make_directory_placeholder(
                     &entry.path,
                     root,
-                    skipped,
-                    tree_lazy_only,
-                )?);
+                ));
             }
         } else {
             nodes.push(make_file_node(&entry.path, root));
@@ -771,19 +791,17 @@ fn make_preloaded_directory_node(
 fn make_directory_placeholder(
     path: &Path,
     root: &Path,
-    skipped: &HashSet<&str>,
-    tree_lazy_only: &HashSet<&str>,
-) -> Result<FileTreeNode, AppError> {
-    Ok(FileTreeNode {
+) -> FileTreeNode {
+    FileTreeNode {
         name: node_name(path, root),
         path: relative_path(path, root),
         is_dir: true,
-        is_expandable: directory_has_visible_entries(path, skipped, tree_lazy_only)?,
+        is_expandable: true,
         children_has_more: false,
         children_next_offset: None,
         git_state: None,
         children: None,
-    })
+    }
 }
 
 fn make_file_node(path: &Path, root: &Path) -> FileTreeNode {
@@ -797,31 +815,6 @@ fn make_file_node(path: &Path, root: &Path) -> FileTreeNode {
         git_state: None,
         children: None,
     }
-}
-
-fn directory_has_visible_entries(
-    path: &Path,
-    skipped: &HashSet<&str>,
-    _tree_lazy_only: &HashSet<&str>,
-) -> Result<bool, AppError> {
-    for entry in fs::read_dir(path).map_err(|error| {
-        AppError::internal(ErrorSource::Index, format!("Failed to read dir: {error}"))
-    })? {
-        let entry = entry.map_err(|error| {
-            AppError::internal(
-                ErrorSource::Index,
-                format!("Failed to read dir entry: {error}"),
-            )
-        })?;
-        let entry_name = entry.file_name().to_string_lossy().to_string();
-        if skipped.contains(entry_name.as_str()) {
-            continue;
-        }
-
-        return Ok(true);
-    }
-
-    Ok(false)
 }
 
 fn sort_directory_entries(nodes: &mut [DirectoryEntry]) {

--- a/src-tauri/src/core/index_manager.rs
+++ b/src-tauri/src/core/index_manager.rs
@@ -743,10 +743,7 @@ fn read_directory_entries_page(
                     tree_lazy_only,
                 )?);
             } else {
-                nodes.push(make_directory_placeholder(
-                    &entry.path,
-                    root,
-                ));
+                nodes.push(make_directory_placeholder(&entry.path, root));
             }
         } else {
             nodes.push(make_file_node(&entry.path, root));
@@ -788,10 +785,7 @@ fn make_preloaded_directory_node(
     })
 }
 
-fn make_directory_placeholder(
-    path: &Path,
-    root: &Path,
-) -> FileTreeNode {
+fn make_directory_placeholder(path: &Path, root: &Path) -> FileTreeNode {
     FileTreeNode {
         name: node_name(path, root),
         path: relative_path(path, root),


### PR DESCRIPTION
## Problem

TreeView on Windows has noticeable loading latency, while macOS is nearly instant. The root causes are:

1. **Serial blocking IO** — `index_get_tree`, `index_get_children`, and `index_reveal_path` fetch the file index and git overlay sequentially; Windows file system calls are 5-10× slower than macOS
2. **N redundant `read_dir` calls** — `directory_has_visible_entries` does a full `read_dir` per child directory to set `is_expandable`; on NTFS each call is expensive
3. **Repeated `canonicalize`** — every command re-resolves the workspace path via `std::fs::canonicalize`, which on Windows resolves long paths and junctions slowly
4. **Short overlay cache TTL** — 2s TTL causes frequent full `git status` rescans; NTFS + Windows Defender make these scans much slower

## Changes

### P0 — Parallel overlay + eliminate read_dir probes

- **`commands/index.rs`**: Replace sequential `get_tree → get_overlay` (and equivalents in `get_children`, `reveal_path`) with `tokio::join!` so index and overlay fetch concurrently. ~50% latency reduction on the critical path.
- **`core/index_manager.rs`**: Remove `directory_has_visible_entries` entirely. `make_directory_placeholder` now always returns `is_expandable: true`. Empty directories show an expand arrow until the user opens them, at which point the arrow disappears. This eliminates N `read_dir` syscalls on the root listing.

### P1 — Cache canonicalize + extend overlay TTL

- **`core/index_manager.rs`**: Add `canonical_cache: Arc<RwLock<HashMap<PathBuf, PathBuf>>>` and async `cached_canonicalize()` method. All 5 async methods now use the cache instead of calling `dunce::canonicalize` on every request.
- **`core/git_manager.rs`**: Same caching pattern. Also switch from `std::fs::canonicalize` to `dunce::canonicalize` (avoids UNC `\\?\` prefix on Windows). Remove the old `canonicalize_workspace` free function. `repo_workdir` also uses `dunce::canonicalize`.
- **`core/git_manager.rs`**: Increase `OVERLAY_CACHE_TTL` from 2s → 10s to reduce full `git status` rescans.

## Trade-offs

- Empty directories will show an expand arrow until expanded — accepted for eliminating per-directory `read_dir` on Windows
- `canonicalize` cache is session-scoped (in-memory only); workspace root does not change during a session

## Verification

- `cargo check` — compiles clean
- `cargo test` — 162 unit tests + 19 integration tests pass (2 pre-existing failures in `m1_2_workspace` unrelated to this change, caused by missing test fixture path on Windows)
- Manual: TreeView loads noticeably faster on Windows

## Files Changed

| File | Change |
|------|--------|
| `src-tauri/src/commands/index.rs` | `tokio::join!` parallel overlay in 3 handlers |
| `src-tauri/src/core/index_manager.rs` | Remove `directory_has_visible_entries`, add canonical cache |
| `src-tauri/src/core/git_manager.rs` | Add canonical cache, switch to `dunce`, TTL 2s→10s |
