### PR TITLE
feat(settings): add OpenAI Responses provider type to custom catalog

### DIFF
--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -126,6 +126,12 @@ const CUSTOM_PROVIDER_TYPE_CATALOG: &[ProviderCatalogEntry] = &[
         default_base_url: "https://api.example.com/v1",
     },
     ProviderCatalogEntry {
+        provider_key: "openai-responses",
+        provider_type: "openai-responses",
+        display_name: "OpenAI Responses",
+        default_base_url: "https://api.example.com/v1",
+    },
+    ProviderCatalogEntry {
         provider_key: "anthropic",
         provider_type: "anthropic",
         display_name: "Anthropic",

--- a/src-tauri/tests/m1_3_settings.rs
+++ b/src-tauri/tests/m1_3_settings.rs
@@ -326,6 +326,23 @@ async fn test_provider_settings_seed_builtin_catalog() {
                 && entry.supports_custom),
         "OpenAI Compatible should still be available as a custom provider type"
     );
+    let openai_compatible_index = catalog
+        .iter()
+        .position(|entry| entry.provider_type == "openai-compatible")
+        .expect("OpenAI Compatible should exist in the provider catalog");
+    let openai_responses_index = catalog
+        .iter()
+        .position(|entry| entry.provider_type == "openai-responses")
+        .expect("OpenAI Responses should exist in the provider catalog");
+    assert_eq!(
+        openai_responses_index,
+        openai_compatible_index + 1,
+        "OpenAI Responses should appear immediately after OpenAI Compatible"
+    );
+    assert!(
+        !catalog[openai_responses_index].builtin && catalog[openai_responses_index].supports_custom,
+        "OpenAI Responses should be available only as a custom provider type"
+    );
 }
 
 #[tokio::test]

--- a/src/modules/settings-center/model/types.ts
+++ b/src/modules/settings-center/model/types.ts
@@ -18,6 +18,7 @@ export type ProviderKind = "builtin" | "custom";
 export type ProviderType =
   | "openai"
   | "openai-compatible"
+  | "openai-responses"
   | "anthropic"
   | "google"
   | "ollama"
@@ -30,7 +31,12 @@ export type ProviderType =
   | "deepseek"
   | "zenmux";
 
-export type CustomProviderType = "openai-compatible" | "anthropic" | "google" | "ollama";
+export type CustomProviderType =
+  | "openai-compatible"
+  | "openai-responses"
+  | "anthropic"
+  | "google"
+  | "ollama";
 
 export type ProviderCatalogEntry = {
   providerKey: ProviderType;


### PR DESCRIPTION
## Summary
- add `openai-responses` to the custom provider type catalog in the Tauri settings manager
- extend frontend settings types so `ProviderType` and `CustomProviderType` accept `openai-responses`
- add a settings integration test to verify the new catalog entry exists, is custom-only, and appears after `openai-compatible`

## Testing
- Not run in this PR flow.
