### PR TITLE
fix(workspace): normalize workspace paths and helper shell guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Run frontend unit tests
+        run: npm run test:unit
+
       - name: Build web assets
         run: npm run build:web
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ The desktop UI lives in `src/` with React + TypeScript. Use `src/app/` for boots
 - `npm run build:web` — type-check and bundle web assets.
 - `npm run build` — produce desktop binaries.
 - `npm run typecheck` — run TypeScript validation for UI changes.
+- `npm run test:unit` — run Vitest unit tests for frontend utilities and model helpers.
 - `cargo test --manifest-path src-tauri/Cargo.toml` — run Rust integration tests.
 - `cargo fmt --manifest-path src-tauri/Cargo.toml` — format Rust code before committing.
 
@@ -16,13 +17,13 @@ The desktop UI lives in `src/` with React + TypeScript. Use `src/app/` for boots
 Use 2-space indentation in TypeScript/TSX. Prefer functional React components with named exports. File names should be kebab-case, for example `workbench-top-bar.tsx`; components use PascalCase; hooks use `use...`. Prefer the `@/` alias over deep relative imports. Keep code close to the feature unless it is clearly reusable. Reuse design tokens from `src/app/styles/globals.css` and align UI work with `docs/design-spec.md`. In Rust, preserve the existing `commands/`, `core/`, `model/`, and `persistence/` separation.
 
 ## Testing Guidelines
-No frontend unit test runner is configured yet, so every UI change should pass `npm run typecheck` and receive manual verification. Rust tests live in `src-tauri/tests/*.rs`; follow the existing milestone-style naming pattern such as `m1_5_agent_run.rs`. Add or update backend integration tests whenever command, persistence, or runtime behavior changes.
+Frontend utility and model regressions can be covered with Vitest tests colocated under `src/`; UI changes should still pass `npm run typecheck` and receive manual verification. Rust tests live in `src-tauri/tests/*.rs`; follow the existing milestone-style naming pattern such as `m1_5_agent_run.rs`. Add or update backend integration tests whenever command, persistence, or runtime behavior changes.
 
 ## Commit & Pull Request Guidelines
 Follow Conventional Commits: `type(scope): short summary`, for example `feat(agent-session): enhance workspace context`. Common types include `feat`, `fix`, `refactor`, and `chore`. Keep scopes tied to the area changed. Pull requests should include a concise summary, linked issue or design doc when relevant, commands run, and screenshots or GIFs for visible UI changes. Call out migrations, capability updates, or setup steps explicitly.
 
 ## Post-Implementation Checklist
-After completing a task, always run the relevant formatting and validation commands before committing: `cargo fmt --manifest-path src-tauri/Cargo.toml` for any Rust changes, and `npm run typecheck` for any TypeScript/TSX changes. Fix all warnings and errors before finalizing the commit.
+After completing a task, always run the relevant formatting and validation commands before committing: `cargo fmt --manifest-path src-tauri/Cargo.toml` for any Rust changes, `npm run typecheck` for any TypeScript/TSX changes, and `npm run test:unit` when frontend utility or model tests were added or affected. Fix all warnings and errors before finalizing the commit.
 
 ## Agent-Specific Instructions
 Address the user as `Buddy` in all collaborator-facing responses for this repository. Pay special attention to cross-platform differences when coding, and preserve cross-platform compatibility in implementation choices.

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "@vitejs/plugin-react": "^4.6.0",
         "tailwindcss": "^4.1.12",
         "typescript": "~5.8.3",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@ai-sdk/gateway": {
@@ -5252,6 +5253,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -5514,6 +5526,13 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -5644,6 +5663,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
@@ -5690,6 +5822,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/bail": {
@@ -5778,6 +5920,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/character-entities": {
@@ -6577,6 +6729,13 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
@@ -6651,6 +6810,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -6658,6 +6827,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extend": {
@@ -8599,6 +8778,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/oniguruma-parser": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz",
@@ -9382,6 +9572,13 @@
         "node": ">=20"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -9401,6 +9598,20 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/streamdown": {
       "version": "2.4.0",
@@ -9510,6 +9721,13 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
@@ -9534,6 +9752,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/trim-lines": {
@@ -9937,6 +10165,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -9994,6 +10312,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/xterm": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "tauri build",
     "build:web": "tsc && vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@radix-ui/react-separator": "^1.1.7",
@@ -51,6 +52,7 @@
     "@vitejs/plugin-react": "^4.6.0",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.8.3",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^4.1.4"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6053,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.3"
+version = "0.1.4-rc.26041210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "232bb5c575f08eb6ef610e715ffcd9aed1505689ab1d3e376ad9607c9a9fbce6"
+checksum = "938b1eae1872f80e86c651505e72de96fe28686492ecf9298449a05ea7bfc2ea"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.3"
+tiycore = "0.1.4-rc.26041210"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/core/local_search.rs
+++ b/src-tauri/src/core/local_search.rs
@@ -222,7 +222,9 @@ impl LocalSearchStream {
 }
 
 pub async fn run_local_search(request: LocalSearchRequest) -> Result<LocalSearchOutcome> {
-    stream_local_search(request).finish().await
+    tokio::task::spawn_blocking(move || run_local_search_blocking(request, |_| {}))
+        .await
+        .context("local search task failed to join")?
 }
 
 pub fn stream_local_search(request: LocalSearchRequest) -> LocalSearchStream {

--- a/src-tauri/src/core/local_search.rs
+++ b/src-tauri/src/core/local_search.rs
@@ -209,7 +209,7 @@ pub struct LocalSearchBatch {
 }
 
 pub struct LocalSearchStream {
-    pub receiver: mpsc::UnboundedReceiver<LocalSearchBatch>,
+    pub receiver: mpsc::Receiver<LocalSearchBatch>,
     join_handle: JoinHandle<Result<LocalSearchOutcome>>,
 }
 
@@ -226,10 +226,10 @@ pub async fn run_local_search(request: LocalSearchRequest) -> Result<LocalSearch
 }
 
 pub fn stream_local_search(request: LocalSearchRequest) -> LocalSearchStream {
-    let (tx, rx) = mpsc::unbounded_channel();
+    let (tx, rx) = mpsc::channel(1);
     let join_handle = tokio::task::spawn_blocking(move || {
         run_local_search_blocking(request, |batch| {
-            let _ = tx.send(batch);
+            let _ = tx.blocking_send(batch);
         })
     });
 

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -679,7 +679,6 @@ const HELPER_INHERITED_SECTION_TITLES: &[&str] = &[
     "Profile Instructions",
     "System Environment",
     "Sandbox & Permissions",
-    "Shell Tooling Guide",
     "Runtime Context",
 ];
 
@@ -695,26 +694,40 @@ fn build_helper_system_prompt(
     helper_profile: SubagentProfile,
 ) -> String {
     let inherited_prompt = inherited_helper_prompt_sections(parent_system_prompt);
+    let helper_shell_tooling_guide = helper_shell_tooling_guide(helper_profile);
 
     if inherited_prompt.trim().is_empty() {
-        format!(
-            "{}\n\nYour output will be consumed by the parent agent, not the user. \
-Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
-If the inherited prompt specifies a response language, write your entire output in that language. \
-Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
-Reference specific file paths and code locations where relevant. Skip preamble.",
-            helper_profile.system_prompt()
-        )
-    } else {
         format!(
             "{}\n\n{}\n\nYour output will be consumed by the parent agent, not the user. \
 Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
 If the inherited prompt specifies a response language, write your entire output in that language. \
 Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
 Reference specific file paths and code locations where relevant. Skip preamble.",
-            inherited_prompt,
+            helper_shell_tooling_guide,
             helper_profile.system_prompt()
         )
+    } else {
+        format!(
+            "{}\n\n{}\n\n{}\n\nYour output will be consumed by the parent agent, not the user. \
+Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
+If the inherited prompt specifies a response language, write your entire output in that language. \
+Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
+Reference specific file paths and code locations where relevant. Skip preamble.",
+            inherited_prompt,
+            helper_shell_tooling_guide,
+            helper_profile.system_prompt()
+        )
+    }
+}
+
+fn helper_shell_tooling_guide(helper_profile: SubagentProfile) -> &'static str {
+    match helper_profile {
+        SubagentProfile::Explore => {
+            "## Shell Tooling Guide\n- This helper does not have `shell`, `edit`, or Terminal panel control tools.\n- Use the workspace-aware tools you actually have: `read`, `list`, `find`, and `search`.\n- Prefer `find` to locate likely files, `search` to locate relevant text or symbols, and `read` to inspect exact implementation details.\n- `search` defaults to literal matching. Set `queryMode` to `regex` only when you intentionally need regular expressions."
+        }
+        SubagentProfile::Review => {
+            "## Shell Tooling Guide\n- This helper may use `read`, `list`, `find`, `search`, `term_status`, `term_output`, and `shell`.\n- Use `shell` only for non-interactive diagnostic and verification commands in the workspace, such as type-checks, test suites, diffs, or other read-only inspection.\n- `term_status` and `term_output` refer only to the desktop app's embedded Terminal panel for the current thread.\n- This helper does not have `edit`, `term_write`, `term_restart`, or `term_close`."
+        }
     }
 }
 
@@ -843,16 +856,18 @@ mod tests {
 
     #[test]
     fn helper_system_prompt_inherits_only_allowed_sections() {
-        let parent_prompt = "## Role\nYou are TiyCode.\n\n## Project Context (workspace instructions)\nFollow AGENTS.md.\n\n## Behavioral Guidelines\nUse clarify when needed.\n\n## Profile Instructions\nRespond in 简体中文 unless the user explicitly asks for a different language.\n\n## Sandbox & Permissions\n- Approval policy: auto.\n\n## Final Response Structure\nUse structured markdown.";
+        let parent_prompt = "## Role\nYou are TiyCode.\n\n## Project Context (workspace instructions)\nFollow AGENTS.md.\n\n## Behavioral Guidelines\nUse clarify when needed.\n\n## Profile Instructions\nRespond in 简体中文 unless the user explicitly asks for a different language.\n\n## Sandbox & Permissions\n- Approval policy: auto.\n\n## Shell Tooling Guide\n- Generic shell guidance.\n\n## Final Response Structure\nUse structured markdown.";
 
         let prompt = build_helper_system_prompt(parent_prompt, SubagentProfile::Explore);
 
         assert!(prompt.contains("## Project Context (workspace instructions)"));
         assert!(prompt.contains("## Profile Instructions"));
         assert!(prompt.contains("## Sandbox & Permissions"));
+        assert!(prompt.contains("## Shell Tooling Guide"));
         assert!(!prompt.contains("## Role\nYou are TiyCode."));
         assert!(!prompt.contains("## Behavioral Guidelines"));
         assert!(!prompt.contains("## Final Response Structure"));
+        assert!(!prompt.contains("Generic shell guidance."));
     }
 
     #[test]
@@ -864,6 +879,31 @@ mod tests {
         assert!(inherited.contains("## System Environment"));
         assert!(inherited.contains("## Runtime Context"));
         assert!(!inherited.contains("## Run Mode"));
+    }
+
+    #[test]
+    fn explore_helper_shell_guide_only_mentions_read_only_tools() {
+        let prompt = build_helper_system_prompt("", SubagentProfile::Explore);
+
+        assert!(prompt.contains(
+            "This helper does not have `shell`, `edit`, or Terminal panel control tools."
+        ));
+        assert!(prompt.contains("`read`, `list`, `find`, and `search`"));
+        assert!(prompt.contains("`search` defaults to literal matching."));
+        assert!(!prompt.contains("`term_write`"));
+        assert!(!prompt.contains("`term_restart`"));
+        assert!(!prompt.contains("`term_close`"));
+    }
+
+    #[test]
+    fn review_helper_shell_guide_matches_review_tool_whitelist() {
+        let prompt = build_helper_system_prompt("", SubagentProfile::Review);
+
+        assert!(prompt.contains("`term_status`, `term_output`, and `shell`"));
+        assert!(
+            prompt.contains("does not have `edit`, `term_write`, `term_restart`, or `term_close`")
+        );
+        assert!(!prompt.contains("This helper may use `term_write`"));
     }
 
     #[test]

--- a/src-tauri/src/core/subagent/runtime_orchestration.rs
+++ b/src-tauri/src/core/subagent/runtime_orchestration.rs
@@ -141,7 +141,7 @@ Tool-use protocol:\n\
 - If a tool call fails because your arguments were invalid, do not repeat the same invalid call. Read the error, correct the arguments, and only then try again.\n\
 - Do not claim that tools are unavailable, broken, or unusable unless you have evidence of a system-level failure. A single invalid tool call means your arguments were wrong, not that the tool system is broken.\n\
 - For this helper, pay special attention to required fields: `read` requires `path`, `find` requires `pattern`, and `search` requires `query`. `list` may omit `path`, but include it when it helps narrow the scope.\n\
-- `search` may interpret the query as a regex-like pattern. Prefer simple literal keywords first. If the text includes regex-special characters, simplify the query or escape it before searching.\n\
+- `search` defaults to literal matching. Only treat the query as a regular expression when you explicitly set `queryMode` to `regex`. Prefer simple literal keywords first, and only opt into regex when you need pattern matching.\n\
 \n\
 Examples:\n\
 - Bad tool calls: `search {}`, `read {}`, `find {}`, `search {\"path\":\"src\"}`, `read {\"query\":\"title\"}`.\n\

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -2,7 +2,6 @@ use chrono::Utc;
 use sqlx::SqlitePool;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 use tokio::{fs, task};
 
 use crate::model::errors::{AppError, ErrorSource};
@@ -24,6 +23,10 @@ impl WorkspaceManager {
     }
 
     /// Add a new workspace from a user-provided path.
+    ///
+    /// This operation is idempotent on the workspace canonical path: if the
+    /// canonicalized target already exists in the database, the existing record
+    /// is returned instead of raising a duplicate error.
     pub async fn add(&self, input: WorkspaceAddInput) -> Result<WorkspaceRecord, AppError> {
         let raw_path = Path::new(&input.path);
 
@@ -279,21 +282,13 @@ fn derive_name_from_path(path: &Path) -> String {
 
 /// Derive a display-friendly path using `~` for the home directory.
 async fn derive_display_path(path: &Path) -> String {
-    /// Lazily compute and cache the canonical home directory.
-    fn cached_canonical_home() -> Option<&'static PathBuf> {
-        static CANONICAL_HOME: OnceLock<Option<PathBuf>> = OnceLock::new();
-        CANONICAL_HOME
-            .get_or_init(|| dirs::home_dir().and_then(|home| dunce::canonicalize(&home).ok()))
-            .as_ref()
-    }
-
     if let Some(home) = dirs::home_dir() {
         if let Ok(relative) = path.strip_prefix(&home) {
             return format!("~/{}", relative.display());
         }
 
-        if let Some(canonical_home) = cached_canonical_home() {
-            if let Ok(relative) = path.strip_prefix(canonical_home) {
+        if let Ok(canonical_home) = dunce::canonicalize(&home) {
+            if let Ok(relative) = path.strip_prefix(&canonical_home) {
                 return format!("~/{}", relative.display());
             }
         }
@@ -304,6 +299,54 @@ async fn derive_display_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::OsString;
+    use std::sync::{Mutex, OnceLock};
+
+    fn home_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct HomeEnvGuard {
+        original_home: Option<OsString>,
+        #[cfg(target_os = "windows")]
+        original_userprofile: Option<OsString>,
+    }
+
+    impl HomeEnvGuard {
+        fn set(home: &Path) -> Self {
+            let original_home = std::env::var_os("HOME");
+            std::env::set_var("HOME", home);
+
+            #[cfg(target_os = "windows")]
+            let original_userprofile = {
+                let prev = std::env::var_os("USERPROFILE");
+                std::env::set_var("USERPROFILE", home);
+                prev
+            };
+
+            Self {
+                original_home,
+                #[cfg(target_os = "windows")]
+                original_userprofile,
+            }
+        }
+    }
+
+    impl Drop for HomeEnvGuard {
+        fn drop(&mut self) {
+            match &self.original_home {
+                Some(home) => std::env::set_var("HOME", home),
+                None => std::env::remove_var("HOME"),
+            }
+
+            #[cfg(target_os = "windows")]
+            match &self.original_userprofile {
+                Some(profile) => std::env::set_var("USERPROFILE", profile),
+                None => std::env::remove_var("USERPROFILE"),
+            }
+        }
+    }
 
     #[test]
     fn builds_default_thread_workspace_path_under_tiy_workspace_directory() {
@@ -314,5 +357,34 @@ mod tests {
             workspace_path,
             PathBuf::from("/tmp/jorben/.tiy/workspace/Default")
         );
+    }
+
+    #[tokio::test]
+    async fn derive_display_path_uses_current_home_after_environment_changes() {
+        let _home_lock = home_env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let first_home = tempfile::tempdir().expect("should create first temp home");
+        let second_home = tempfile::tempdir().expect("should create second temp home");
+
+        let first_path = dunce::canonicalize(first_home.path().join("project"));
+        assert!(first_path.is_err(), "fixture should not exist yet");
+
+        tokio::fs::create_dir_all(first_home.path().join("project"))
+            .await
+            .expect("should create first project directory");
+        tokio::fs::create_dir_all(second_home.path().join("project"))
+            .await
+            .expect("should create second project directory");
+
+        let first_canonical = dunce::canonicalize(first_home.path().join("project"))
+            .expect("should canonicalize first project");
+        let second_canonical = dunce::canonicalize(second_home.path().join("project"))
+            .expect("should canonicalize second project");
+
+        let _first_guard = HomeEnvGuard::set(first_home.path());
+        assert_eq!(derive_display_path(&first_canonical).await, "~/project");
+        drop(_first_guard);
+
+        let _second_guard = HomeEnvGuard::set(second_home.path());
+        assert_eq!(derive_display_path(&second_canonical).await, "~/project");
     }
 }

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -49,16 +49,10 @@ impl WorkspaceManager {
 
         let canonical_str = canonical.to_string_lossy().to_string();
 
-        // Check for duplicates
-        if workspace_repo::find_by_canonical_path(&self.pool, &canonical_str)
-            .await?
-            .is_some()
+        if let Some(existing) =
+            workspace_repo::find_by_canonical_path(&self.pool, &canonical_str).await?
         {
-            return Err(AppError::recoverable(
-                ErrorSource::Workspace,
-                "workspace.duplicate",
-                format!("Workspace '{}' already exists", canonical_str),
-            ));
+            return Ok(existing);
         }
 
         // Validate path is a directory
@@ -258,26 +252,11 @@ impl WorkspaceManager {
             return Ok(existing);
         }
 
-        match self
-            .add(WorkspaceAddInput {
-                path: workspace_path.to_string_lossy().to_string(),
-                name: Some(name.to_string()),
-            })
-            .await
-        {
-            Ok(record) => Ok(record),
-            Err(error) if error.error_code == "workspace.duplicate" => {
-                workspace_repo::find_by_canonical_path(&self.pool, &canonical_str)
-                    .await?
-                    .ok_or_else(|| {
-                        AppError::internal(
-                            ErrorSource::Workspace,
-                            "workspace already exists but could not be loaded",
-                        )
-                    })
-            }
-            Err(error) => Err(error),
-        }
+        self.add(WorkspaceAddInput {
+            path: workspace_path.to_string_lossy().to_string(),
+            name: Some(name.to_string()),
+        })
+        .await
     }
 }
 

--- a/src-tauri/tests/m1_1_infrastructure.rs
+++ b/src-tauri/tests/m1_1_infrastructure.rs
@@ -389,11 +389,11 @@ fn test_app_error_recoverable_format() {
 
     let err = AppError::recoverable(
         ErrorSource::Workspace,
-        "workspace.duplicate",
-        "Already exists",
+        "workspace.path.invalid",
+        "Invalid path",
     );
 
-    assert_eq!(err.error_code, "workspace.duplicate");
+    assert_eq!(err.error_code, "workspace.path.invalid");
     assert!(matches!(err.category, ErrorCategory::Recoverable));
     assert!(err.retryable);
 }

--- a/src-tauri/tests/m1_2_workspace.rs
+++ b/src-tauri/tests/m1_2_workspace.rs
@@ -13,6 +13,7 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
 use tiycode::core::workspace_manager::WorkspaceManager;
+use tiycode::model::workspace::WorkspaceAddInput;
 
 fn home_env_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -101,6 +102,46 @@ async fn test_workspace_duplicate_canonical_path_rejected() {
         result.is_err(),
         "Duplicate canonical_path should be rejected by UNIQUE constraint"
     );
+}
+
+#[tokio::test]
+async fn test_workspace_manager_add_reuses_existing_workspace_for_same_canonical_path() {
+    let workspace_root = tempfile::tempdir().expect("should create temp workspace root");
+    let workspace_path = workspace_root.path().join("project");
+    tokio::fs::create_dir_all(&workspace_path)
+        .await
+        .expect("should create workspace directory");
+
+    let pool = test_helpers::setup_test_pool().await;
+    let manager = WorkspaceManager::new(pool.clone());
+
+    let first = manager
+        .add(WorkspaceAddInput {
+            path: workspace_path.to_string_lossy().to_string(),
+            name: Some("Project".to_string()),
+        })
+        .await
+        .expect("first workspace add should succeed");
+
+    let second = manager
+        .add(WorkspaceAddInput {
+            path: workspace_path.join(".").to_string_lossy().to_string(),
+            name: Some("Project Duplicate".to_string()),
+        })
+        .await
+        .expect("second workspace add should reuse existing workspace");
+
+    assert_eq!(second.id, first.id);
+    assert_eq!(second.canonical_path, first.canonical_path);
+    assert_eq!(second.path, first.path);
+
+    let row = sqlx::query("SELECT COUNT(*) as count FROM workspaces WHERE canonical_path = ?")
+        .bind(&first.canonical_path)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(row.get::<i64, _>("count"), 1);
 }
 
 #[tokio::test]

--- a/src-tauri/tests/m1_2_workspace.rs
+++ b/src-tauri/tests/m1_2_workspace.rs
@@ -134,6 +134,7 @@ async fn test_workspace_manager_add_reuses_existing_workspace_for_same_canonical
     assert_eq!(second.id, first.id);
     assert_eq!(second.canonical_path, first.canonical_path);
     assert_eq!(second.path, first.path);
+    assert_eq!(second.name, first.name);
 
     let row = sqlx::query("SELECT COUNT(*) as count FROM workspaces WHERE canonical_path = ?")
         .bind(&first.canonical_path)

--- a/src-tauri/tests/m1_7_frontend_integration.rs
+++ b/src-tauri/tests/m1_7_frontend_integration.rs
@@ -629,8 +629,8 @@ fn test_app_error_serialization_camel_case() {
 
     let err = AppError::recoverable(
         ErrorSource::Workspace,
-        "workspace.duplicate",
-        "Already exists",
+        "workspace.path.invalid",
+        "Invalid path",
     );
 
     let json = serde_json::to_value(&err).unwrap();

--- a/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
+++ b/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceItem } from "@/modules/workbench-shell/model/types";
+import {
+  addRemovedWorkspacePath,
+  buildWorkspaceBindings,
+  deleteRemovedWorkspacePath,
+  findWorkspaceByPath,
+  getWorkspaceBindingId,
+  hasRemovedWorkspacePath,
+  resolveProjectForWorkspace,
+} from "@/modules/workbench-shell/model/workspace-path-bindings";
+import type { WorkspaceDto } from "@/shared/types/api";
+
+function createWorkspace(overrides: Partial<WorkspaceDto> = {}): WorkspaceDto {
+  return {
+    id: "workspace-1",
+    name: "Repo",
+    path: "C:\\Users\\Buddy\\Repo",
+    canonicalPath: "c:/users/buddy/repo",
+    displayPath: "~/Repo",
+    isDefault: false,
+    isGit: true,
+    autoWorkTree: false,
+    status: "ready",
+    lastValidatedAt: null,
+    createdAt: "2026-04-12T00:00:00Z",
+    updatedAt: "2026-04-12T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function createWorkspaceItem(
+  overrides: Partial<WorkspaceItem> = {},
+): WorkspaceItem {
+  return {
+    id: "workspace-1",
+    name: "Repo",
+    defaultOpen: false,
+    threads: [],
+    path: "C:\\Users\\Buddy\\Repo",
+    ...overrides,
+  };
+}
+
+describe("workspace path bindings", () => {
+  it("normalizes path variants when building and resolving workspace bindings", () => {
+    const bindings = buildWorkspaceBindings([
+      createWorkspace(),
+      createWorkspace({
+        id: "workspace-2",
+        name: "Share",
+        path: "//SERVER/Share/Docs",
+        canonicalPath: "//server/share/docs",
+      }),
+    ]);
+
+    expect(getWorkspaceBindingId(bindings, "c:/Users/BUDDY/Repo/./"))
+      .toBe("workspace-1");
+    expect(getWorkspaceBindingId(bindings, "///server/share/docs"))
+      .toBe("workspace-2");
+  });
+
+  it("finds workspaces by either display path or canonical path", () => {
+    const workspace = findWorkspaceByPath(
+      [
+        createWorkspace({
+          path: "/Users/buddy/repo",
+          canonicalPath: "/private/Users/buddy/repo",
+        }),
+      ],
+      "/private/Users/buddy/repo/./",
+    );
+
+    expect(workspace?.id).toBe("workspace-1");
+  });
+
+  it("tracks removed workspace paths using normalized keys", () => {
+    const removedPaths = new Set<string>();
+
+    addRemovedWorkspacePath(removedPaths, "//SERVER/Share//Docs");
+    expect(hasRemovedWorkspacePath(removedPaths, "///server/share/docs"))
+      .toBe(true);
+
+    deleteRemovedWorkspacePath(removedPaths, "//server/share/docs/./");
+    expect(hasRemovedWorkspacePath(removedPaths, "//SERVER/Share/Docs"))
+      .toBe(false);
+  });
+
+  it("matches recent projects by normalized workspace path before falling back", () => {
+    const project = resolveProjectForWorkspace(
+      createWorkspaceItem(),
+      [
+        {
+          id: "project-1",
+          name: "Repo Alias",
+          path: "c:/users/buddy/repo/",
+          lastOpenedLabel: "Today",
+        },
+      ],
+    );
+
+    expect(project?.id).toBe("project-1");
+  });
+
+  it("builds a fallback project when no recent project matches", () => {
+    const project = resolveProjectForWorkspace(
+      createWorkspaceItem({
+        id: "workspace-2",
+        name: "Docs",
+        path: "/Users/buddy/docs",
+      }),
+      [],
+    );
+
+    expect(project).not.toBeNull();
+    expect(project?.path).toBe("/Users/buddy/docs");
+    expect(project?.name).toBe("docs");
+    expect(project?.id).toContain("docs");
+  });
+});

--- a/src/modules/workbench-shell/model/workspace-path-bindings.ts
+++ b/src/modules/workbench-shell/model/workspace-path-bindings.ts
@@ -1,0 +1,122 @@
+import { buildProjectOptionFromPath } from "@/modules/workbench-shell/model/helpers";
+import type {
+  ProjectOption,
+  WorkspaceItem,
+} from "@/modules/workbench-shell/model/types";
+import { buildWorkspacePathKeys, isSameWorkspacePath, normalizeWorkspacePath } from "@/shared/lib/workspace-path";
+import type { WorkspaceDto } from "@/shared/types/api";
+
+type WorkspacePathLike = {
+  path?: string | null;
+  canonicalPath?: string | null;
+};
+
+export function buildWorkspaceBindingEntries(
+  workspaceId: string,
+  ...paths: Array<string | null | undefined>
+) {
+  return Object.fromEntries(
+    buildWorkspacePathKeys(...paths).map((pathKey) => [pathKey, workspaceId]),
+  );
+}
+
+export function buildWorkspaceBindings(
+  workspaceEntries: ReadonlyArray<Pick<WorkspaceDto, "id" | "path" | "canonicalPath">>,
+) {
+  const bindings: Record<string, string> = {};
+
+  for (const workspace of workspaceEntries) {
+    Object.assign(bindings, buildWorkspaceBindingsForEntry(workspace));
+  }
+
+  return bindings;
+}
+
+export function buildWorkspaceBindingsForEntry(
+  workspace: Pick<WorkspaceDto, "id" | "path" | "canonicalPath">,
+  ...additionalPaths: Array<string | null | undefined>
+) {
+  return buildWorkspaceBindingEntries(
+    workspace.id,
+    workspace.path,
+    workspace.canonicalPath,
+    ...additionalPaths,
+  );
+}
+
+export function findWorkspaceByPath<T extends WorkspacePathLike>(
+  workspaces: ReadonlyArray<T>,
+  path: string | null | undefined,
+) {
+  return (
+    workspaces.find(
+      (workspace) =>
+        isSameWorkspacePath(workspace.path, path)
+        || isSameWorkspacePath(workspace.canonicalPath, path),
+    ) ?? null
+  );
+}
+
+export function getWorkspaceBindingId(
+  bindings: Readonly<Record<string, string>>,
+  path: string | null | undefined,
+) {
+  return bindings[normalizeWorkspacePath(path)] ?? null;
+}
+
+export function hasRemovedWorkspacePath(
+  removedPaths: ReadonlySet<string>,
+  path: string | null | undefined,
+) {
+  return removedPaths.has(normalizeWorkspacePath(path));
+}
+
+export function addRemovedWorkspacePath(
+  removedPaths: Set<string>,
+  path: string | null | undefined,
+) {
+  const pathKey = normalizeWorkspacePath(path);
+  if (!pathKey) {
+    return;
+  }
+
+  removedPaths.add(pathKey);
+}
+
+export function deleteRemovedWorkspacePath(
+  removedPaths: Set<string>,
+  path: string | null | undefined,
+) {
+  const pathKey = normalizeWorkspacePath(path);
+  if (!pathKey) {
+    return;
+  }
+
+  removedPaths.delete(pathKey);
+}
+
+export function resolveProjectForWorkspace(
+  workspace: Pick<WorkspaceItem, "id" | "name" | "path"> | null,
+  recentProjects: ReadonlyArray<ProjectOption>,
+) {
+  if (!workspace) {
+    return null;
+  }
+
+  const matchedProject = recentProjects.find(
+    (project) =>
+      isSameWorkspacePath(project.path, workspace.path)
+      || project.id === workspace.id
+      || project.name === workspace.name,
+  );
+
+  if (matchedProject) {
+    return matchedProject;
+  }
+
+  if (!workspace.path) {
+    return null;
+  }
+
+  return buildProjectOptionFromPath(workspace.path);
+}

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -170,13 +170,13 @@ function buildWorkspaceBindingEntries(
 }
 
 function buildWorkspaceBindings(workspaceEntries: ReadonlyArray<WorkspaceDto>) {
-  return workspaceEntries.reduce<Record<string, string>>(
-    (bindings, workspace) => ({
-      ...bindings,
-      ...buildWorkspaceBindingsForEntry(workspace),
-    }),
-    {},
-  );
+  const bindings: Record<string, string> = {};
+
+  for (const workspace of workspaceEntries) {
+    Object.assign(bindings, buildWorkspaceBindingsForEntry(workspace));
+  }
+
+  return bindings;
 }
 
 function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -96,6 +96,16 @@ import {
   readStoredUserSession,
   selectContainerContents,
 } from "@/modules/workbench-shell/model/helpers";
+import {
+  addRemovedWorkspacePath,
+  buildWorkspaceBindings,
+  buildWorkspaceBindingsForEntry,
+  deleteRemovedWorkspacePath,
+  findWorkspaceByPath,
+  getWorkspaceBindingId,
+  hasRemovedWorkspacePath,
+  resolveProjectForWorkspace,
+} from "@/modules/workbench-shell/model/workspace-path-bindings";
 import type {
   DrawerPanel,
   PanelVisibilityState,
@@ -123,11 +133,7 @@ import { WorkbenchTopBar } from "@/modules/workbench-shell/ui/workbench-top-bar"
 import { useSystemMetadata } from "@/features/system-info/model/use-system-metadata";
 import { cn } from "@/shared/lib/utils";
 import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
-import {
-  buildWorkspacePathKeys,
-  isSameWorkspacePath,
-  normalizeWorkspacePath,
-} from "@/shared/lib/workspace-path";
+import { isSameWorkspacePath } from "@/shared/lib/workspace-path";
 import { WorkbenchSegmentedControl } from "@/shared/ui/workbench-segmented-control";
 import { terminalStore } from "@/features/terminal/model/terminal-store";
 
@@ -160,25 +166,6 @@ function getNewThreadTerminalBindingKey(workspaceId: string) {
   return `${workspaceId}:${NEW_THREAD_TERMINAL_KEY_SUFFIX}`;
 }
 
-function buildWorkspaceBindingEntries(
-  workspaceId: string,
-  ...paths: Array<string | null | undefined>
-) {
-  return Object.fromEntries(
-    buildWorkspacePathKeys(...paths).map((pathKey) => [pathKey, workspaceId]),
-  );
-}
-
-function buildWorkspaceBindings(workspaceEntries: ReadonlyArray<WorkspaceDto>) {
-  const bindings: Record<string, string> = {};
-
-  for (const workspace of workspaceEntries) {
-    Object.assign(bindings, buildWorkspaceBindingsForEntry(workspace));
-  }
-
-  return bindings;
-}
-
 function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
   const project = buildProjectOptionFromPath(
     workspace.canonicalPath || workspace.path,
@@ -194,69 +181,6 @@ function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
   };
 }
 
-function buildWorkspaceBindingsForEntry(
-  workspace: Pick<WorkspaceDto, "id" | "path" | "canonicalPath">,
-  ...additionalPaths: Array<string | null | undefined>
-) {
-  return buildWorkspaceBindingEntries(
-    workspace.id,
-    workspace.path,
-    workspace.canonicalPath,
-    ...additionalPaths,
-  );
-}
-
-function findWorkspaceByPath<T extends { path?: string | null; canonicalPath?: string | null }>(
-  workspaces: ReadonlyArray<T>,
-  path: string | null | undefined,
-) {
-  return (
-    workspaces.find(
-      (workspace) =>
-        isSameWorkspacePath(workspace.path, path)
-        || isSameWorkspacePath(workspace.canonicalPath, path),
-    ) ?? null
-  );
-}
-
-function getWorkspaceBindingId(
-  bindings: Readonly<Record<string, string>>,
-  path: string | null | undefined,
-) {
-  return bindings[normalizeWorkspacePath(path)] ?? null;
-}
-
-function hasRemovedWorkspacePath(
-  removedPaths: ReadonlySet<string>,
-  path: string | null | undefined,
-) {
-  return removedPaths.has(normalizeWorkspacePath(path));
-}
-
-function addRemovedWorkspacePath(
-  removedPaths: Set<string>,
-  path: string | null | undefined,
-) {
-  const pathKey = normalizeWorkspacePath(path);
-  if (!pathKey) {
-    return;
-  }
-
-  removedPaths.add(pathKey);
-}
-
-function deleteRemovedWorkspacePath(
-  removedPaths: Set<string>,
-  path: string | null | undefined,
-) {
-  const pathKey = normalizeWorkspacePath(path);
-  if (!pathKey) {
-    return;
-  }
-
-  removedPaths.delete(pathKey);
-}
-
 function findWorkspaceForThread(
   workspaces: ReadonlyArray<WorkspaceItem>,
   threadId: string | null,
@@ -270,32 +194,6 @@ function findWorkspaceForThread(
       workspace.threads.some((thread) => thread.id === threadId),
     ) ?? null
   );
-}
-
-function resolveProjectForWorkspace(
-  workspace: WorkspaceItem | null,
-  recentProjects: ReadonlyArray<ProjectOption>,
-) {
-  if (!workspace) {
-    return null;
-  }
-
-  const matchedProject = recentProjects.find(
-    (project) =>
-      isSameWorkspacePath(project.path, workspace.path)
-      || project.id === workspace.id
-      || project.name === workspace.name,
-  );
-
-  if (matchedProject) {
-    return matchedProject;
-  }
-
-  if (!workspace.path) {
-    return null;
-  }
-
-  return buildProjectOptionFromPath(workspace.path);
 }
 
 function mergeLocalFallbackThreads(options: {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -123,6 +123,11 @@ import { WorkbenchTopBar } from "@/modules/workbench-shell/ui/workbench-top-bar"
 import { useSystemMetadata } from "@/features/system-info/model/use-system-metadata";
 import { cn } from "@/shared/lib/utils";
 import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
+import {
+  buildWorkspacePathKeys,
+  isSameWorkspacePath,
+  normalizeWorkspacePath,
+} from "@/shared/lib/workspace-path";
 import { WorkbenchSegmentedControl } from "@/shared/ui/workbench-segmented-control";
 import { terminalStore } from "@/features/terminal/model/terminal-store";
 
@@ -155,13 +160,21 @@ function getNewThreadTerminalBindingKey(workspaceId: string) {
   return `${workspaceId}:${NEW_THREAD_TERMINAL_KEY_SUFFIX}`;
 }
 
+function buildWorkspaceBindingEntries(
+  workspaceId: string,
+  ...paths: Array<string | null | undefined>
+) {
+  return Object.fromEntries(
+    buildWorkspacePathKeys(...paths).map((pathKey) => [pathKey, workspaceId]),
+  );
+}
+
 function buildWorkspaceBindings(workspaceEntries: ReadonlyArray<WorkspaceDto>) {
   return workspaceEntries.reduce<Record<string, string>>(
-    (bindings, workspace) => {
-      bindings[workspace.path] = workspace.id;
-      bindings[workspace.canonicalPath] = workspace.id;
-      return bindings;
-    },
+    (bindings, workspace) => ({
+      ...bindings,
+      ...buildWorkspaceBindingsForEntry(workspace),
+    }),
     {},
   );
 }
@@ -183,11 +196,65 @@ function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
 
 function buildWorkspaceBindingsForEntry(
   workspace: Pick<WorkspaceDto, "id" | "path" | "canonicalPath">,
+  ...additionalPaths: Array<string | null | undefined>
 ) {
-  return {
-    [workspace.path]: workspace.id,
-    [workspace.canonicalPath]: workspace.id,
-  };
+  return buildWorkspaceBindingEntries(
+    workspace.id,
+    workspace.path,
+    workspace.canonicalPath,
+    ...additionalPaths,
+  );
+}
+
+function findWorkspaceByPath<T extends { path?: string | null; canonicalPath?: string | null }>(
+  workspaces: ReadonlyArray<T>,
+  path: string | null | undefined,
+) {
+  return (
+    workspaces.find(
+      (workspace) =>
+        isSameWorkspacePath(workspace.path, path)
+        || isSameWorkspacePath(workspace.canonicalPath, path),
+    ) ?? null
+  );
+}
+
+function getWorkspaceBindingId(
+  bindings: Readonly<Record<string, string>>,
+  path: string | null | undefined,
+) {
+  return bindings[normalizeWorkspacePath(path)] ?? null;
+}
+
+function hasRemovedWorkspacePath(
+  removedPaths: ReadonlySet<string>,
+  path: string | null | undefined,
+) {
+  return removedPaths.has(normalizeWorkspacePath(path));
+}
+
+function addRemovedWorkspacePath(
+  removedPaths: Set<string>,
+  path: string | null | undefined,
+) {
+  const pathKey = normalizeWorkspacePath(path);
+  if (!pathKey) {
+    return;
+  }
+
+  removedPaths.add(pathKey);
+}
+
+function deleteRemovedWorkspacePath(
+  removedPaths: Set<string>,
+  path: string | null | undefined,
+) {
+  const pathKey = normalizeWorkspacePath(path);
+  if (!pathKey) {
+    return;
+  }
+
+  removedPaths.delete(pathKey);
 }
 
 function findWorkspaceForThread(
@@ -215,9 +282,9 @@ function resolveProjectForWorkspace(
 
   const matchedProject = recentProjects.find(
     (project) =>
-      (workspace.path && project.path === workspace.path) ||
-      project.id === workspace.id ||
-      project.name === workspace.name,
+      isSameWorkspacePath(project.path, workspace.path)
+      || project.id === workspace.id
+      || project.name === workspace.name,
   );
 
   if (matchedProject) {
@@ -573,10 +640,10 @@ export function DashboardWorkbench() {
   const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
   const activeThread = getActiveThread(workspaces);
-  const selectedProjectWorkspaceId =
-    selectedProject === null
-      ? null
-      : (terminalWorkspaceBindings[selectedProject.path] ?? null);
+  const selectedProjectWorkspaceId = getWorkspaceBindingId(
+    terminalWorkspaceBindings,
+    selectedProject?.path ?? null,
+  );
   const activeThreadWorkspace = findWorkspaceForThread(
     workspaces,
     activeThread?.id ?? null,
@@ -588,10 +655,10 @@ export function DashboardWorkbench() {
   const currentProject = isNewThreadMode
     ? selectedProject
     : activeThreadProject;
-  const resolvedWorkspaceId =
-    currentProject === null
-      ? null
-      : (terminalWorkspaceBindings[currentProject.path] ?? null);
+  const resolvedWorkspaceId = getWorkspaceBindingId(
+    terminalWorkspaceBindings,
+    currentProject?.path ?? null,
+  );
   const newThreadTerminalBindingKey =
     selectedProjectWorkspaceId === null
       ? null
@@ -926,9 +993,9 @@ export function DashboardWorkbench() {
           ? null
           : (nextProjects.find(
               (project) =>
-                project.id === defaultWorkspace.id ||
-                project.path === defaultWorkspace.canonicalPath ||
-                project.path === defaultWorkspace.path,
+                project.id === defaultWorkspace.id
+                || isSameWorkspacePath(project.path, defaultWorkspace.canonicalPath)
+                || isSameWorkspacePath(project.path, defaultWorkspace.path),
             ) ?? null);
 
       setTerminalWorkspaceBindings(nextBindings);
@@ -949,7 +1016,8 @@ export function DashboardWorkbench() {
           const matchingProject =
             nextProjects.find(
               (project) =>
-                project.id === current.id || project.path === current.path,
+                project.id === current.id
+                || isSameWorkspacePath(project.path, current.path),
             ) ?? null;
 
           if (matchingProject) {
@@ -1246,11 +1314,11 @@ export function DashboardWorkbench() {
       return;
     }
 
-    if (removedWorkspacePathsRef.current.has(currentProject.path)) {
+    if (hasRemovedWorkspacePath(removedWorkspacePathsRef.current, currentProject.path)) {
       return;
     }
 
-    if (terminalWorkspaceBindings[currentProject.path]) {
+    if (getWorkspaceBindingId(terminalWorkspaceBindings, currentProject.path)) {
       return;
     }
 
@@ -1259,11 +1327,7 @@ export function DashboardWorkbench() {
 
     void workspaceList()
       .then(async (workspaces) => {
-        const existing = workspaces.find(
-          (workspace) =>
-            workspace.path === currentProject.path ||
-            workspace.canonicalPath === currentProject.path,
-        );
+        const existing = findWorkspaceByPath(workspaces, currentProject.path);
         if (existing) {
           return existing;
         }
@@ -1277,17 +1341,15 @@ export function DashboardWorkbench() {
 
         setTerminalWorkspaceBindings((current) => {
           if (
-            current[currentProject.path] &&
-            current[workspace.canonicalPath]
+            getWorkspaceBindingId(current, currentProject.path)
+            && getWorkspaceBindingId(current, workspace.canonicalPath)
           ) {
             return current;
           }
 
           return {
             ...current,
-            [currentProject.path]: workspace.id,
-            [workspace.path]: workspace.id,
-            [workspace.canonicalPath]: workspace.id,
+            ...buildWorkspaceBindingsForEntry(workspace, currentProject.path),
           };
         });
         void syncWorkspaceSidebar().catch((refreshError) => {
@@ -1663,7 +1725,7 @@ export function DashboardWorkbench() {
       lastOpenedLabel: t("time.justNow"),
     };
 
-    removedWorkspacePathsRef.current.delete(nextProject.path);
+    deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
     setSelectedProject(nextProject);
     setRecentProjects((current) => mergeRecentProjects(current, nextProject));
   };
@@ -1689,7 +1751,7 @@ export function DashboardWorkbench() {
       lastOpenedLabel: t("time.justNow"),
     };
 
-    removedWorkspacePathsRef.current.delete(nextProject.path);
+    deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
     setSelectedProject(nextProject);
     setRecentProjects((current) => mergeRecentProjects(current, nextProject));
     setOpenWorkspaces((current) => ({
@@ -1889,12 +1951,10 @@ export function DashboardWorkbench() {
             const projectToEnsure = nextProject;
             const ensuredWorkspace = projectToEnsure
               ? await workspaceList().then((workspaceEntries) => {
-                  const existingWorkspace =
-                    workspaceEntries.find(
-                      (workspace) =>
-                        workspace.path === projectToEnsure.path ||
-                        workspace.canonicalPath === projectToEnsure.path,
-                    ) ?? null;
+                  const existingWorkspace = findWorkspaceByPath(
+                    workspaceEntries,
+                    projectToEnsure.path,
+                  );
 
                   return (
                     existingWorkspace ??
@@ -1922,7 +1982,10 @@ export function DashboardWorkbench() {
             );
             setTerminalWorkspaceBindings((current) => ({
               ...current,
-              ...buildWorkspaceBindingsForEntry(ensuredWorkspace),
+              ...buildWorkspaceBindingsForEntry(
+                ensuredWorkspace,
+                projectToEnsure?.path,
+              ),
             }));
           } catch (error) {
             const message = getInvokeErrorMessage(
@@ -1938,18 +2001,19 @@ export function DashboardWorkbench() {
           return;
         }
 
-        removedWorkspacePathsRef.current.delete(nextProject.path);
+        deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
         const project = {
           ...nextProject,
           lastOpenedLabel: t("time.justNow"),
         };
-        const existingWorkspace = workspaces.find(
-          (workspace) =>
-            workspace.id === nextWorkspaceId ||
-            workspace.id === project.id ||
-            workspace.name === project.name ||
-            (workspace.path && workspace.path === project.path),
-        );
+        const existingWorkspace =
+          workspaces.find(
+            (workspace) =>
+              workspace.id === nextWorkspaceId
+              || workspace.id === project.id
+              || workspace.name === project.name
+              || isSameWorkspacePath(workspace.path, project.path),
+          ) ?? null;
         const nextPendingRunId =
           typeof crypto !== "undefined" && "randomUUID" in crypto
             ? crypto.randomUUID()
@@ -2126,14 +2190,12 @@ export function DashboardWorkbench() {
           return;
         }
 
-        removedWorkspacePathsRef.current.delete(nextProject.path);
+        deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
         const workspaceEntries = await workspaceList();
-        const existingWorkspace =
-          workspaceEntries.find(
-            (workspace) =>
-              workspace.path === selectedPath ||
-              workspace.canonicalPath === selectedPath,
-          ) ?? null;
+        const existingWorkspace = findWorkspaceByPath(
+          workspaceEntries,
+          selectedPath,
+        );
         const workspace =
           existingWorkspace ??
           (await workspaceAdd(selectedPath, nextProject.name));
@@ -2208,12 +2270,13 @@ export function DashboardWorkbench() {
           workspace.id,
         );
         const isRemovingSelectedProject =
-          selectedProject?.id === workspace.id ||
-          selectedProject?.path === workspace.path;
+          selectedProject?.id === workspace.id
+          || isSameWorkspacePath(selectedProject?.path, workspace.path);
         const fallbackSelectedProject = isRemovingSelectedProject
           ? (recentProjects.find(
               (project) =>
-                project.id !== workspace.id && project.path !== workspace.path,
+                project.id !== workspace.id
+                && !isSameWorkspacePath(project.path, workspace.path),
             ) ?? null)
           : selectedProject;
         newThreadCreationRef.current = Object.fromEntries(
@@ -2224,8 +2287,8 @@ export function DashboardWorkbench() {
         const isRemovingActiveWorkspace =
           activeThreadWorkspace?.id === workspace.id;
         const shouldPreserveSelectedProject =
-          selectedProject?.id !== workspace.id &&
-          selectedProject?.path !== workspace.path;
+          selectedProject?.id !== workspace.id
+          && !isSameWorkspacePath(selectedProject?.path, workspace.path);
 
         setWorkspaceAction({
           workspaceId: workspace.id,
@@ -2235,7 +2298,7 @@ export function DashboardWorkbench() {
 
         try {
           if (workspace.path) {
-            removedWorkspacePathsRef.current.add(workspace.path);
+            addRemovedWorkspacePath(removedWorkspacePathsRef.current, workspace.path);
           }
           await workspaceRemove(workspace.id);
 
@@ -2248,7 +2311,8 @@ export function DashboardWorkbench() {
 
           if (isRemovingSelectedProject) {
             if (fallbackSelectedProject?.path) {
-              removedWorkspacePathsRef.current.delete(
+              deleteRemovedWorkspacePath(
+                removedWorkspacePathsRef.current,
                 fallbackSelectedProject.path,
               );
             }
@@ -2257,7 +2321,8 @@ export function DashboardWorkbench() {
           setRecentProjects((current) =>
             current.filter(
               (project) =>
-                project.id !== workspace.id && project.path !== workspace.path,
+                project.id !== workspace.id
+                && !isSameWorkspacePath(project.path, workspace.path),
             ),
           );
 
@@ -2310,7 +2375,7 @@ export function DashboardWorkbench() {
           });
         } catch (error) {
           if (workspace.path) {
-            removedWorkspacePathsRef.current.delete(workspace.path);
+            deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, workspace.path);
           }
           const message = getInvokeErrorMessage(
             error,

--- a/src/shared/lib/workspace-path.test.ts
+++ b/src/shared/lib/workspace-path.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkspacePathKeys,
+  isSameWorkspacePath,
+  normalizeWorkspacePath,
+} from "@/shared/lib/workspace-path";
+
+describe("normalizeWorkspacePath", () => {
+  it("normalizes POSIX paths and resolves dot segments", () => {
+    expect(normalizeWorkspacePath("/Users/Buddy//repo/./src/../README.md"))
+      .toBe("/Users/Buddy/repo/README.md");
+    expect(normalizeWorkspacePath("../../repo/./src/..")).toBe("../../repo");
+    expect(normalizeWorkspacePath("/../../repo")).toBe("/repo");
+  });
+
+  it("normalizes Windows drive-letter paths case-insensitively", () => {
+    expect(normalizeWorkspacePath("C:\\Users\\Buddy\\Repo\\..\\Docs\\"))
+      .toBe("c:/users/buddy/docs");
+    expect(normalizeWorkspacePath("c:/Users/BUDDY/docs/./guide.md"))
+      .toBe("c:/users/buddy/docs/guide.md");
+  });
+
+  it("normalizes UNC paths without escaping the protected server/share segments", () => {
+    expect(normalizeWorkspacePath("///SERVER/Share//Folder/../File.txt"))
+      .toBe("//server/share/file.txt");
+    expect(normalizeWorkspacePath("//SERVER/Share/path/../../.."))
+      .toBe("//server/share");
+  });
+});
+
+describe("workspace path helpers", () => {
+  it("treats equivalent paths as the same workspace", () => {
+    expect(isSameWorkspacePath(
+      "C:\\Users\\Buddy\\Repo",
+      "c:/users/buddy/repo/./",
+    )).toBe(true);
+    expect(isSameWorkspacePath(
+      "//SERVER/Share/Repo",
+      "///server/share/repo",
+    )).toBe(true);
+  });
+
+  it("deduplicates normalized workspace path keys", () => {
+    expect(buildWorkspacePathKeys(
+      "/tmp/workspace",
+      "/tmp//workspace/",
+      "/tmp/workspace/./",
+      null,
+      undefined,
+      "",
+    )).toEqual(["/tmp/workspace"]);
+  });
+});

--- a/src/shared/lib/workspace-path.ts
+++ b/src/shared/lib/workspace-path.ts
@@ -1,6 +1,7 @@
 function normalizePathSegments(
   segments: ReadonlyArray<string>,
   clampAboveRoot: boolean,
+  protectedSegmentCount = 0,
 ) {
   const normalized: string[] = [];
 
@@ -10,7 +11,12 @@ function normalizePathSegments(
     }
 
     if (segment === "..") {
-      if (normalized.length > 0) {
+      const lastSegment = normalized[normalized.length - 1];
+      if (
+        lastSegment &&
+        lastSegment !== ".." &&
+        normalized.length > protectedSegmentCount
+      ) {
         normalized.pop();
       } else if (!clampAboveRoot) {
         normalized.push("..");
@@ -24,28 +30,40 @@ function normalizePathSegments(
   return normalized;
 }
 
-function normalizeUncWorkspacePath(path: string) {
-  const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
+function normalizeWindowsSegments(segments: ReadonlyArray<string>) {
+  return segments.map((segment) =>
+    segment === "." || segment === ".." ? segment : segment.toLowerCase(),
+  );
+}
 
-  if (segments.length === 0) {
+function normalizeUncWorkspacePath(path: string) {
+  const segments = normalizeWindowsSegments(
+    path.replace(/^\/+/, "").split("/").filter(Boolean),
+  );
+  const normalizedSegments = normalizePathSegments(
+    segments,
+    true,
+    Math.min(2, segments.length),
+  );
+
+  if (normalizedSegments.length === 0) {
     return "//";
   }
 
-  if (segments.length === 1) {
-    return `//${segments[0]}`;
+  if (normalizedSegments.length === 1) {
+    return `//${normalizedSegments[0]}`;
   }
 
-  const [server, share, ...remainder] = segments;
-  const normalizedRemainder = normalizePathSegments(remainder, true);
+  const [server, share, ...remainder] = normalizedSegments;
 
-  return `//${server}/${share}${normalizedRemainder.length > 0 ? `/${normalizedRemainder.join("/")}` : ""}`;
+  return `//${server}/${share}${remainder.length > 0 ? `/${remainder.join("/")}` : ""}`;
 }
 
 function normalizeDriveWorkspacePath(path: string, driveLetter: string) {
   const remainder = path.slice(2).replace(/\/{2,}/g, "/");
   const isAbsolute = remainder.startsWith("/");
   const normalizedSegments = normalizePathSegments(
-    remainder.split("/").filter(Boolean),
+    normalizeWindowsSegments(remainder.split("/").filter(Boolean)),
     isAbsolute,
   );
   let normalized = isAbsolute ? `${driveLetter}:/` : `${driveLetter}:`;

--- a/src/shared/lib/workspace-path.ts
+++ b/src/shared/lib/workspace-path.ts
@@ -1,0 +1,46 @@
+export function normalizeWorkspacePath(path: string | null | undefined) {
+  if (!path) {
+    return "";
+  }
+
+  const slashNormalized = path.replace(/\\/g, "/");
+  const isUncPath = slashNormalized.startsWith("//");
+  const prefix = isUncPath ? "//" : "";
+  const remainder = (isUncPath ? slashNormalized.slice(2) : slashNormalized).replace(
+    /\/{2,}/g,
+    "/",
+  );
+
+  let normalized = `${prefix}${remainder}`;
+
+  if (
+    normalized.length > 1
+    && normalized !== "//"
+    && !/^[a-zA-Z]:\/$/.test(normalized)
+  ) {
+    normalized = normalized.replace(/\/+$/g, "");
+  }
+
+  if (/^[a-zA-Z]:\//.test(normalized)) {
+    normalized = `${normalized[0].toLowerCase()}${normalized.slice(1)}`;
+  }
+
+  return normalized;
+}
+
+export function isSameWorkspacePath(
+  left: string | null | undefined,
+  right: string | null | undefined,
+) {
+  if (!left || !right) {
+    return false;
+  }
+
+  return normalizeWorkspacePath(left) === normalizeWorkspacePath(right);
+}
+
+export function buildWorkspacePathKeys(
+  ...paths: Array<string | null | undefined>
+) {
+  return [...new Set(paths.map((path) => normalizeWorkspacePath(path)).filter(Boolean))];
+}

--- a/src/shared/lib/workspace-path.ts
+++ b/src/shared/lib/workspace-path.ts
@@ -1,31 +1,96 @@
+function normalizePathSegments(
+  segments: ReadonlyArray<string>,
+  clampAboveRoot: boolean,
+) {
+  const normalized: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment || segment === ".") {
+      continue;
+    }
+
+    if (segment === "..") {
+      if (normalized.length > 0) {
+        normalized.pop();
+      } else if (!clampAboveRoot) {
+        normalized.push("..");
+      }
+      continue;
+    }
+
+    normalized.push(segment);
+  }
+
+  return normalized;
+}
+
+function normalizeUncWorkspacePath(path: string) {
+  const segments = path.replace(/^\/+/, "").split("/").filter(Boolean);
+
+  if (segments.length === 0) {
+    return "//";
+  }
+
+  if (segments.length === 1) {
+    return `//${segments[0]}`;
+  }
+
+  const [server, share, ...remainder] = segments;
+  const normalizedRemainder = normalizePathSegments(remainder, true);
+
+  return `//${server}/${share}${normalizedRemainder.length > 0 ? `/${normalizedRemainder.join("/")}` : ""}`;
+}
+
+function normalizeDriveWorkspacePath(path: string, driveLetter: string) {
+  const remainder = path.slice(2).replace(/\/{2,}/g, "/");
+  const isAbsolute = remainder.startsWith("/");
+  const normalizedSegments = normalizePathSegments(
+    remainder.split("/").filter(Boolean),
+    isAbsolute,
+  );
+  let normalized = isAbsolute ? `${driveLetter}:/` : `${driveLetter}:`;
+
+  if (normalizedSegments.length > 0) {
+    normalized += normalizedSegments.join("/");
+  }
+
+  return normalized;
+}
+
+function normalizePosixWorkspacePath(path: string) {
+  const collapsed = path.replace(/\/{2,}/g, "/");
+  const isAbsolute = collapsed.startsWith("/");
+  const normalizedSegments = normalizePathSegments(
+    collapsed.split("/").filter(Boolean),
+    isAbsolute,
+  );
+
+  if (normalizedSegments.length === 0) {
+    return isAbsolute ? "/" : ".";
+  }
+
+  return `${isAbsolute ? "/" : ""}${normalizedSegments.join("/")}`;
+}
+
 export function normalizeWorkspacePath(path: string | null | undefined) {
   if (!path) {
     return "";
   }
 
   const slashNormalized = path.replace(/\\/g, "/");
-  const isUncPath = slashNormalized.startsWith("//");
-  const prefix = isUncPath ? "//" : "";
-  const remainder = (isUncPath ? slashNormalized.slice(2) : slashNormalized).replace(
-    /\/{2,}/g,
-    "/",
-  );
-
-  let normalized = `${prefix}${remainder}`;
-
-  if (
-    normalized.length > 1
-    && normalized !== "//"
-    && !/^[a-zA-Z]:\/$/.test(normalized)
-  ) {
-    normalized = normalized.replace(/\/+$/g, "");
+  if (slashNormalized.startsWith("//")) {
+    return normalizeUncWorkspacePath(slashNormalized);
   }
 
-  if (/^[a-zA-Z]:\//.test(normalized)) {
-    normalized = `${normalized[0].toLowerCase()}${normalized.slice(1)}`;
+  const driveMatch = slashNormalized.match(/^([a-zA-Z]):(?:\/|$)/);
+  if (driveMatch) {
+    return normalizeDriveWorkspacePath(
+      slashNormalized,
+      driveMatch[1].toLowerCase(),
+    );
   }
 
-  return normalized;
+  return normalizePosixWorkspacePath(slashNormalized);
 }
 
 export function isSameWorkspacePath(


### PR DESCRIPTION
## Summary
- Fix Windows workspace path matching so Terminal and new thread flows stop re-adding the same workspace when path strings differ by separator or drive-letter casing.
- Make `workspace_add` idempotent on canonical path so duplicate adds return the existing workspace instead of failing.
- Update helper subagent shell-tooling guidance so explore/review prompts describe only the tools each helper profile can actually use.
- Refresh Rust test fixtures that referenced the removed `workspace.duplicate` error code.

## Changes
- Added `src/shared/lib/workspace-path.ts` and switched `dashboard-workbench.tsx` workspace lookup, binding keys, and removed-path tracking to normalized path keys.
- Changed `src-tauri/src/core/workspace_manager.rs` to return the existing workspace record when the canonical path already exists, and simplified the ensure-default flow around that idempotent behavior.
- Tightened subagent prompt construction in `src-tauri/src/core/subagent/orchestrator.rs` and `runtime_orchestration.rs` so helper shell guidance matches the actual tool whitelist.
- Replaced outdated Rust test fixtures in `src-tauri/tests/m1_1_infrastructure.rs` and `src-tauri/tests/m1_7_frontend_integration.rs` with current workspace error codes.

## Verification
- Main agent ran `cargo fmt --manifest-path src-tauri/Cargo.toml`.
- Main agent ran `cargo test --manifest-path src-tauri/Cargo.toml test_app_error_recoverable_format`.
- Main agent ran `cargo test --manifest-path src-tauri/Cargo.toml test_app_error_serialization_camel_case`.
- Review helper ran `npm run typecheck`.
- Review helper ran `cargo check --tests`.
- Review helper ran `cargo test --test m1_1_infrastructure test_app_error`.
- Review helper ran `cargo test --test m1_7_frontend_integration`.
- Review helper ran `cargo test --test m1_8_index`.
- Review helper ran `cargo test --test m1_6_tool_gateway test_search_repo`.
