### PR TITLE
feat(review): add diff-first review contract and Git read-only review tools

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -20,8 +20,8 @@ use crate::core::plan_checkpoint::{
 };
 use crate::core::prompt;
 use crate::core::subagent::{
-    runtime_orchestration_tools, HelperAgentOrchestrator, HelperRunRequest,
-    RuntimeOrchestrationTool, SubagentProfile, TERM_CLOSE_TOOL_DESCRIPTION,
+    extract_review_report, runtime_orchestration_tools, HelperAgentOrchestrator, HelperRunRequest,
+    ReviewRequest, RuntimeOrchestrationTool, SubagentProfile, TERM_CLOSE_TOOL_DESCRIPTION,
     TERM_OUTPUT_TOOL_DESCRIPTION, TERM_RESTART_TOOL_DESCRIPTION, TERM_STATUS_TOOL_DESCRIPTION,
     TERM_WRITE_TOOL_DESCRIPTION,
 };
@@ -607,12 +607,30 @@ impl AgentSession {
         tool_call_id: &str,
         tool_input: &serde_json::Value,
     ) -> AgentToolResult {
-        let task = tool_input
-            .get("task")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or_default()
-            .trim()
-            .to_string();
+        let (task, review_request) = if tool == RuntimeOrchestrationTool::Review {
+            match ReviewRequest::from_tool_input(tool_input) {
+                Ok(request) => (request.to_helper_prompt(), Some(request)),
+                Err(error) => {
+                    tool_call_repo::update_result(
+                        &self.pool,
+                        tool_call_id,
+                        &serde_json::json!({ "error": error }).to_string(),
+                        "failed",
+                    )
+                    .await
+                    .ok();
+                    return agent_error_result(error);
+                }
+            }
+        } else {
+            let task = tool_input
+                .get("task")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+            (task, None)
+        };
 
         if task.is_empty() {
             tool_call_repo::update_result(
@@ -648,9 +666,21 @@ impl AgentSession {
 
         match result {
             Ok(summary) => {
+                let review_report = if tool == RuntimeOrchestrationTool::Review {
+                    summary
+                        .raw_summary
+                        .as_deref()
+                        .and_then(extract_review_report)
+                } else {
+                    None
+                };
+
                 let result = serde_json::json!({
                     "summary": summary.summary.clone(),
+                    "rawSummary": summary.raw_summary.clone(),
                     "snapshot": summary.snapshot,
+                    "reviewRequest": review_request,
+                    "reviewReport": review_report,
                 });
                 tool_call_repo::update_result(
                     &self.pool,

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -16,6 +16,33 @@ pub async fn execute(
     workspace_path: &str,
 ) -> Result<ToolOutput, AppError> {
     match tool_name {
+        "git_status" => {
+            let path = read_optional_path(input);
+            let result = git_status(workspace_path, path.as_deref()).await?;
+            Ok(ToolOutput {
+                success: true,
+                result,
+            })
+        }
+        "git_diff" => {
+            let path = read_optional_path(input);
+            let staged = input["staged"].as_bool().unwrap_or(false);
+            let context_lines = read_context_lines(input)?;
+            let result = git_diff(workspace_path, path.as_deref(), staged, context_lines).await?;
+            Ok(ToolOutput {
+                success: true,
+                result,
+            })
+        }
+        "git_log" => {
+            let path = read_optional_path(input);
+            let limit = read_log_limit(input)?;
+            let result = git_log(workspace_path, path.as_deref(), limit).await?;
+            Ok(ToolOutput {
+                success: true,
+                result,
+            })
+        }
         "git_add" | "git_stage" => {
             let paths = read_paths(input)?;
             stage_paths(workspace_path, &paths).await?;
@@ -90,6 +117,30 @@ pub async fn execute(
             }),
         }),
     }
+}
+
+pub async fn git_status(
+    workspace_path: &str,
+    path: Option<&str>,
+) -> Result<serde_json::Value, AppError> {
+    run_git_read_only(workspace_path, build_status_args(path)).await
+}
+
+pub async fn git_diff(
+    workspace_path: &str,
+    path: Option<&str>,
+    staged: bool,
+    context_lines: u32,
+) -> Result<serde_json::Value, AppError> {
+    run_git_read_only(workspace_path, build_diff_args(path, staged, context_lines)).await
+}
+
+pub async fn git_log(
+    workspace_path: &str,
+    path: Option<&str>,
+    limit: u32,
+) -> Result<serde_json::Value, AppError> {
+    run_git_read_only(workspace_path, build_log_args(path, limit)).await
 }
 
 pub async fn commit(workspace_path: &str, message: &str) -> Result<GitCommandResultDto, AppError> {
@@ -256,6 +307,27 @@ async fn run_git_action(
     })?
 }
 
+async fn run_git_read_only(
+    workspace_path: &str,
+    args: Vec<String>,
+) -> Result<serde_json::Value, AppError> {
+    ensure_git_cli_available()?;
+
+    let workspace_root = canonicalize_workspace(workspace_path);
+
+    tokio::task::spawn_blocking(move || {
+        let repo_root = discover_repo_root(&workspace_root)?;
+        run_git_read_only_command(&repo_root, args)
+    })
+    .await
+    .map_err(|error| {
+        AppError::internal(
+            ErrorSource::Git,
+            format!("Git read-only CLI task failed: {error}"),
+        )
+    })?
+}
+
 fn run_git_command(
     repo_root: &Path,
     action: GitMutationAction,
@@ -295,6 +367,91 @@ fn run_git_command(
     })
 }
 
+fn run_git_read_only_command(
+    repo_root: &Path,
+    args: Vec<String>,
+) -> Result<serde_json::Value, AppError> {
+    let mut command = Command::new("git");
+    configure_background_std_command(&mut command);
+
+    let output = command
+        .args(&args)
+        .current_dir(repo_root)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_PAGER", "cat")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| {
+            git_error(
+                "git.cli.spawn_failed",
+                format!("Failed to launch Git CLI: {error}"),
+                true,
+            )
+        })?;
+
+    let stdout = trim_output(&String::from_utf8_lossy(&output.stdout));
+    let stderr = trim_output(&String::from_utf8_lossy(&output.stderr));
+
+    if !output.status.success() {
+        return Err(git_error(
+            "git.read_only.failed",
+            format!(
+                "Git read-only command failed{}",
+                render_cli_hint(&stdout, &stderr)
+            ),
+            true,
+        ));
+    }
+
+    Ok(serde_json::json!({
+        "command": format!("git {}", args.join(" ")),
+        "stdout": stdout,
+        "stderr": stderr,
+    }))
+}
+
+fn build_status_args(path: Option<&str>) -> Vec<String> {
+    let mut args = vec![
+        "status".to_string(),
+        "--short".to_string(),
+        "--branch".to_string(),
+        "--untracked-files=normal".to_string(),
+    ];
+    append_optional_path(&mut args, path);
+    args
+}
+
+fn build_diff_args(path: Option<&str>, staged: bool, context_lines: u32) -> Vec<String> {
+    let mut args = vec![
+        "diff".to_string(),
+        "--no-ext-diff".to_string(),
+        format!("--unified={context_lines}"),
+    ];
+    if staged {
+        args.push("--cached".to_string());
+    }
+    append_optional_path(&mut args, path);
+    args
+}
+
+fn build_log_args(path: Option<&str>, limit: u32) -> Vec<String> {
+    let mut args = vec![
+        "log".to_string(),
+        "--oneline".to_string(),
+        format!("-n{limit}"),
+    ];
+    append_optional_path(&mut args, path);
+    args
+}
+
+fn append_optional_path(args: &mut Vec<String>, path: Option<&str>) {
+    if let Some(path) = path.map(str::trim).filter(|path| !path.is_empty()) {
+        args.push("--".to_string());
+        args.push(path.to_string());
+    }
+}
+
 fn read_paths(input: &serde_json::Value) -> Result<Vec<String>, AppError> {
     let Some(values) = input["paths"].as_array() else {
         return Err(git_error(
@@ -319,6 +476,40 @@ fn read_paths(input: &serde_json::Value) -> Result<Vec<String>, AppError> {
     }
 
     Ok(paths)
+}
+
+fn read_optional_path(input: &serde_json::Value) -> Option<String> {
+    input["path"]
+        .as_str()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+}
+
+fn read_context_lines(input: &serde_json::Value) -> Result<u32, AppError> {
+    let raw = input["contextLines"].as_u64().unwrap_or(3);
+    if raw == 0 || raw > 20 {
+        return Err(git_error(
+            "git.diff.context_invalid",
+            "Git diff contextLines must be between 1 and 20",
+            false,
+        ));
+    }
+
+    Ok(raw as u32)
+}
+
+fn read_log_limit(input: &serde_json::Value) -> Result<u32, AppError> {
+    let raw = input["limit"].as_u64().unwrap_or(10);
+    if raw == 0 || raw > 100 {
+        return Err(git_error(
+            "git.log.limit_invalid",
+            "Git log limit must be between 1 and 100",
+            false,
+        ));
+    }
+
+    Ok(raw as u32)
 }
 
 fn stage_paths_sync(workspace_root: &Path, workspace_paths: &[String]) -> Result<(), AppError> {

--- a/src-tauri/src/core/executors/git.rs
+++ b/src-tauri/src/core/executors/git.rs
@@ -17,7 +17,7 @@ pub async fn execute(
 ) -> Result<ToolOutput, AppError> {
     match tool_name {
         "git_status" => {
-            let path = read_optional_path(input);
+            let path = read_optional_path(input)?;
             let result = git_status(workspace_path, path.as_deref()).await?;
             Ok(ToolOutput {
                 success: true,
@@ -25,7 +25,7 @@ pub async fn execute(
             })
         }
         "git_diff" => {
-            let path = read_optional_path(input);
+            let path = read_optional_path(input)?;
             let staged = input["staged"].as_bool().unwrap_or(false);
             let context_lines = read_context_lines(input)?;
             let result = git_diff(workspace_path, path.as_deref(), staged, context_lines).await?;
@@ -35,7 +35,7 @@ pub async fn execute(
             })
         }
         "git_log" => {
-            let path = read_optional_path(input);
+            let path = read_optional_path(input)?;
             let limit = read_log_limit(input)?;
             let result = git_log(workspace_path, path.as_deref(), limit).await?;
             Ok(ToolOutput {
@@ -478,12 +478,17 @@ fn read_paths(input: &serde_json::Value) -> Result<Vec<String>, AppError> {
     Ok(paths)
 }
 
-fn read_optional_path(input: &serde_json::Value) -> Option<String> {
-    input["path"]
+fn read_optional_path(input: &serde_json::Value) -> Result<Option<String>, AppError> {
+    let Some(path) = input["path"]
         .as_str()
         .map(str::trim)
         .filter(|path| !path.is_empty())
-        .map(str::to_string)
+    else {
+        return Ok(None);
+    };
+
+    validate_relative_git_path(path)?;
+    Ok(Some(path.to_string()))
 }
 
 fn read_context_lines(input: &serde_json::Value) -> Result<u32, AppError> {
@@ -510,6 +515,34 @@ fn read_log_limit(input: &serde_json::Value) -> Result<u32, AppError> {
     }
 
     Ok(raw as u32)
+}
+
+fn validate_relative_git_path(path: &str) -> Result<(), AppError> {
+    let candidate = Path::new(path);
+    if candidate.is_absolute() {
+        return Err(git_error(
+            "git.path.absolute_disallowed",
+            "Git helper path must be relative to the workspace",
+            false,
+        ));
+    }
+
+    if candidate.components().any(|component| {
+        matches!(
+            component,
+            std::path::Component::ParentDir
+                | std::path::Component::RootDir
+                | std::path::Component::Prefix(_)
+        )
+    }) {
+        return Err(git_error(
+            "git.path.traversal_disallowed",
+            "Git helper path must not escape the workspace",
+            false,
+        ));
+    }
+
+    Ok(())
 }
 
 fn stage_paths_sync(workspace_root: &Path, workspace_paths: &[String]) -> Result<(), AppError> {
@@ -1016,7 +1049,10 @@ fn upstream_matches_remote(upstream_name: Option<&str>, remote_branch_name: &str
 
 #[cfg(test)]
 mod tests {
-    use super::{select_push_remote, upstream_matches_remote, validate_local_branch_name};
+    use super::{
+        select_push_remote, upstream_matches_remote, validate_local_branch_name,
+        validate_relative_git_path,
+    };
 
     #[test]
     fn validate_local_branch_name_accepts_conventional_names() {
@@ -1038,6 +1074,21 @@ mod tests {
                 "{branch_name}"
             );
         }
+    }
+
+    #[test]
+    fn validate_relative_git_path_accepts_normal_relative_paths() {
+        assert!(validate_relative_git_path("src/lib.rs").is_ok());
+        assert!(validate_relative_git_path("src/nested/module.rs").is_ok());
+    }
+
+    #[test]
+    fn validate_relative_git_path_rejects_absolute_and_traversal_paths() {
+        let absolute = validate_relative_git_path("/tmp/outside.rs").unwrap_err();
+        assert_eq!(absolute.error_code, "git.path.absolute_disallowed");
+
+        let traversal = validate_relative_git_path("../outside.rs").unwrap_err();
+        assert_eq!(traversal.error_code, "git.path.traversal_disallowed");
     }
 
     #[test]

--- a/src-tauri/src/core/executors/mod.rs
+++ b/src-tauri/src/core/executors/mod.rs
@@ -36,8 +36,10 @@ pub async fn execute_tool(
         "edit" => edit::edit_file(input, workspace_path, writable_roots).await,
         "patch" => edit::edit_file(input, workspace_path, writable_roots).await,
         "shell" => process::run_command(input, workspace_path).await,
-        "git_add" | "git_stage" | "git_unstage" | "git_commit" | "git_fetch" | "git_pull"
-        | "git_push" => git::execute(tool_name, input, workspace_path).await,
+        "git_status" | "git_diff" | "git_log" | "git_add" | "git_stage" | "git_unstage"
+        | "git_commit" | "git_fetch" | "git_pull" | "git_push" => {
+            git::execute(tool_name, input, workspace_path).await
+        }
         "term_status" | "term_output" | "term_write" | "term_restart" | "term_close" => {
             let manager = terminal_manager.ok_or_else(|| {
                 AppError::internal(

--- a/src-tauri/src/core/subagent/mod.rs
+++ b/src-tauri/src/core/subagent/mod.rs
@@ -1,9 +1,13 @@
 pub mod orchestrator;
+pub mod review_contract;
 pub mod runtime_orchestration;
 
 pub use orchestrator::{
     HelperAgentOrchestrator, HelperRunRequest, HelperRunResult, SubagentActivityStatus,
     SubagentProgressSnapshot,
+};
+pub use review_contract::{
+    extract_review_report, render_parent_summary, ReviewReport, ReviewRequest,
 };
 pub use runtime_orchestration::{
     runtime_orchestration_tools, RuntimeOrchestrationTool, SubagentProfile,

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -10,6 +10,7 @@ use tokio::sync::Mutex;
 
 use crate::core::agent_session::ResolvedModelRole;
 use crate::core::executors::ToolOutput;
+use crate::core::subagent::review_contract::{extract_review_report, render_parent_summary};
 use crate::core::subagent::runtime_orchestration::{RuntimeOrchestrationTool, SubagentProfile};
 use crate::core::tool_gateway::{
     ToolExecutionOptions, ToolExecutionRequest, ToolGateway, ToolGatewayResult,
@@ -36,6 +37,7 @@ pub struct HelperRunRequest {
 
 pub struct HelperRunResult {
     pub summary: String,
+    pub raw_summary: Option<String>,
     pub snapshot: SubagentProgressSnapshot,
 }
 
@@ -377,6 +379,7 @@ impl HelperAgentOrchestrator {
             let usage = Usage::default();
             let snapshot = snapshot_from_progress(&progress_state);
             run_helper_repo::mark_completed(&self.pool, &helper_id, &summary, &usage).await?;
+            let raw_summary = summary.clone();
 
             let _ = request.event_tx.send(ThreadStreamEvent::SubagentCompleted {
                 run_id: request.run_id,
@@ -387,13 +390,24 @@ impl HelperAgentOrchestrator {
                 snapshot: snapshot.clone(),
             });
 
-            return Ok(HelperRunResult { summary, snapshot });
+            return Ok(HelperRunResult {
+                summary,
+                raw_summary: Some(raw_summary),
+                snapshot,
+            });
         }
 
         match result {
             Ok(messages) => {
-                let summary = extract_summary(&messages)
+                let raw_summary = extract_summary(&messages)
                     .unwrap_or_else(|| "Helper completed without a textual summary.".to_string());
+                let summary = if helper_profile == SubagentProfile::Review {
+                    extract_review_report(&raw_summary)
+                        .map(|report| render_parent_summary(&report))
+                        .unwrap_or_else(|| raw_summary.clone())
+                } else {
+                    raw_summary.clone()
+                };
                 let usage = extract_usage(&messages).unwrap_or_default();
                 let snapshot = snapshot_from_progress(&progress_state);
 
@@ -408,7 +422,11 @@ impl HelperAgentOrchestrator {
                     snapshot: snapshot.clone(),
                 });
 
-                Ok(HelperRunResult { summary, snapshot })
+                Ok(HelperRunResult {
+                    summary,
+                    raw_summary: Some(raw_summary),
+                    snapshot,
+                })
             }
             Err(error) => {
                 let interrupted = error.to_string().to_lowercase().contains("aborted");
@@ -602,6 +620,45 @@ fn describe_subagent_action(
                 failed_message: format!("Failed finding files matching \"{pattern}\""),
             }
         }
+        "git_status" => {
+            let path = input
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("repository");
+            SubagentActionDescriptor {
+                current_action: format!("checking git status for {path}"),
+                started_message: format!("Checking git status for {path}"),
+                succeeded_message: format!("Finished checking git status for {path}"),
+                failed_message: format!("Failed checking git status for {path}"),
+            }
+        }
+        "git_diff" => {
+            let path = input
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("current changes");
+            SubagentActionDescriptor {
+                current_action: format!("reading git diff for {path}"),
+                started_message: format!("Reading git diff for {path}"),
+                succeeded_message: format!("Finished reading git diff for {path}"),
+                failed_message: format!("Failed reading git diff for {path}"),
+            }
+        }
+        "git_log" => {
+            let path = input
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or("repository");
+            SubagentActionDescriptor {
+                current_action: format!("reading git history for {path}"),
+                started_message: format!("Reading git history for {path}"),
+                succeeded_message: format!("Finished reading git history for {path}"),
+                failed_message: format!("Failed reading git history for {path}"),
+            }
+        }
         "term_status" => SubagentActionDescriptor {
             current_action: "checking the thread Terminal panel status".to_string(),
             started_message: "Inspecting the thread Terminal panel status".to_string(),
@@ -695,25 +752,30 @@ fn build_helper_system_prompt(
     helper_profile: SubagentProfile,
 ) -> String {
     let inherited_prompt = inherited_helper_prompt_sections(parent_system_prompt);
+    let output_tail = match helper_profile {
+        SubagentProfile::Explore => {
+            "Your output will be consumed by the parent agent, not the user. \
+Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
+If the inherited prompt specifies a response language, write your entire output in that language. \
+Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
+Reference specific file paths and code locations where relevant. Skip preamble."
+        }
+        SubagentProfile::Review => {
+            "Your output will be consumed by the parent agent, not the user. \
+Follow any response language instructions inherited above unless the parent explicitly overrides them. \
+If the inherited prompt specifies a response language, use that language in all natural-language JSON fields. \
+Follow the review helper's JSON contract exactly. Do not add markdown fences, headings, or prose outside the JSON object."
+        }
+    };
 
     if inherited_prompt.trim().is_empty() {
-        format!(
-            "{}\n\nYour output will be consumed by the parent agent, not the user. \
-Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
-If the inherited prompt specifies a response language, write your entire output in that language. \
-Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
-Reference specific file paths and code locations where relevant. Skip preamble.",
-            helper_profile.system_prompt()
-        )
+        format!("{}\n\n{}", helper_profile.system_prompt(), output_tail)
     } else {
         format!(
-            "{}\n\n{}\n\nYour output will be consumed by the parent agent, not the user. \
-Follow any response language and response style instructions inherited above unless the parent explicitly overrides them. \
-If the inherited prompt specifies a response language, write your entire output in that language. \
-Produce a concise, structured summary. Lead with the key conclusion, then supporting details. \
-Reference specific file paths and code locations where relevant. Skip preamble.",
+            "{}\n\n{}\n\n{}",
             inherited_prompt,
-            helper_profile.system_prompt()
+            helper_profile.system_prompt(),
+            output_tail
         )
     }
 }

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -375,11 +375,11 @@ impl HelperAgentOrchestrator {
         unsubscribe();
         self.remove_helper(&request.run_id, &agent).await;
 
-        if let Some(summary) = take_escalation_summary(&escalation_summary) {
+        if let Some(raw_summary) = take_escalation_summary(&escalation_summary) {
             let usage = Usage::default();
             let snapshot = snapshot_from_progress(&progress_state);
+            let summary = finalize_helper_summary(helper_profile, &raw_summary);
             run_helper_repo::mark_completed(&self.pool, &helper_id, &summary, &usage).await?;
-            let raw_summary = summary.clone();
 
             let _ = request.event_tx.send(ThreadStreamEvent::SubagentCompleted {
                 run_id: request.run_id,
@@ -401,13 +401,7 @@ impl HelperAgentOrchestrator {
             Ok(messages) => {
                 let raw_summary = extract_summary(&messages)
                     .unwrap_or_else(|| "Helper completed without a textual summary.".to_string());
-                let summary = if helper_profile == SubagentProfile::Review {
-                    extract_review_report(&raw_summary)
-                        .map(|report| render_parent_summary(&report))
-                        .unwrap_or_else(|| raw_summary.clone())
-                } else {
-                    raw_summary.clone()
-                };
+                let summary = finalize_helper_summary(helper_profile, &raw_summary);
                 let usage = extract_usage(&messages).unwrap_or_default();
                 let snapshot = snapshot_from_progress(&progress_state);
 
@@ -477,6 +471,16 @@ impl HelperAgentOrchestrator {
                 active.remove(run_id);
             }
         }
+    }
+}
+
+fn finalize_helper_summary(helper_profile: SubagentProfile, raw_summary: &str) -> String {
+    if helper_profile == SubagentProfile::Review {
+        extract_review_report(raw_summary)
+            .map(|report| render_parent_summary(&report))
+            .unwrap_or_else(|| raw_summary.to_string())
+    } else {
+        raw_summary.to_string()
     }
 }
 
@@ -885,7 +889,8 @@ fn helper_agent_error_result(message: impl Into<String>) -> AgentToolResult {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_helper_system_prompt, collect_prompt_sections, inherited_helper_prompt_sections,
+        build_helper_system_prompt, collect_prompt_sections, describe_subagent_action,
+        finalize_helper_summary, inherited_helper_prompt_sections,
     };
     use crate::core::subagent::SubagentProfile;
 
@@ -954,5 +959,29 @@ mod tests {
         assert_eq!(sections[1].0, "Two");
         assert!(sections[1].1.contains("beta\nline two"));
         assert_eq!(sections[2].0, "Three");
+    }
+
+    #[test]
+    fn finalize_helper_summary_renders_review_json() {
+        let summary = finalize_helper_summary(
+            SubagentProfile::Review,
+            r#"{"verdict":"pass","directFindings":[],"globalFindings":[],"verification":[],"coverage":{"diffReviewed":true,"globalScanPerformed":false,"changedFilesReviewed":[],"scannedPaths":[],"unscannedPaths":[],"limitations":[]},"followUp":[]}"#,
+        );
+
+        assert!(summary.contains("Verdict: PASS"));
+        assert!(summary.contains("Direct Diff Findings"));
+    }
+
+    #[test]
+    fn describe_subagent_action_supports_git_tools_with_and_without_paths() {
+        let status = describe_subagent_action("git_status", &serde_json::json!({}));
+        assert_eq!(status.current_action, "checking git status for repository");
+
+        let diff =
+            describe_subagent_action("git_diff", &serde_json::json!({ "path": "src/lib.rs" }));
+        assert_eq!(diff.current_action, "reading git diff for src/lib.rs");
+
+        let log = describe_subagent_action("git_log", &serde_json::json!({ "path": "" }));
+        assert_eq!(log.current_action, "reading git history for repository");
     }
 }

--- a/src-tauri/src/core/subagent/review_contract.rs
+++ b/src-tauri/src/core/subagent/review_contract.rs
@@ -132,9 +132,9 @@ impl ReviewRequest {
             return Err("missing helper task".to_string());
         }
 
-        let target = parse_target(tool_input.get("target"));
-        let review_scope = parse_scope(tool_input.get("reviewScope"), target);
-        let global_scan_mode = parse_global_scan(tool_input.get("globalScanMode"), review_scope);
+        let target = parse_target(tool_input.get("target"))?;
+        let review_scope = parse_scope(tool_input.get("reviewScope"), target)?;
+        let global_scan_mode = parse_global_scan(tool_input.get("globalScanMode"), review_scope)?;
 
         Ok(Self {
             task,
@@ -183,7 +183,7 @@ Return exactly one JSON object with this contract:
       \"title\": \"short title\",
       \"severity\": \"critical|high|medium|low\",
       \"path\": \"optional/path\",
-      \"line\": 123,
+      \"line\": null,
       \"summary\": \"what is wrong and why it matters\",
       \"evidence\": [\"specific evidence\"],
       \"suggestion\": \"optional concrete fix\"
@@ -194,7 +194,7 @@ Return exactly one JSON object with this contract:
       \"title\": \"short title\",
       \"severity\": \"critical|high|medium|low\",
       \"path\": \"optional/path\",
-      \"line\": 123,
+      \"line\": null,
       \"summary\": \"diff-adjacent system risk\",
       \"evidence\": [\"specific evidence\"],
       \"suggestion\": \"optional concrete fix\"
@@ -263,31 +263,37 @@ pub fn render_parent_summary(report: &ReviewReport) -> String {
     lines.join("\n\n")
 }
 
-fn parse_target(value: Option<&serde_json::Value>) -> ReviewTarget {
+fn parse_target(value: Option<&serde_json::Value>) -> Result<ReviewTarget, String> {
     match value.and_then(serde_json::Value::as_str).unwrap_or("code") {
-        "diff" => ReviewTarget::Diff,
-        _ => ReviewTarget::Code,
+        "code" => Ok(ReviewTarget::Code),
+        "diff" => Ok(ReviewTarget::Diff),
+        other => Err(format!("invalid review target: {other}")),
     }
 }
 
-fn parse_scope(value: Option<&serde_json::Value>, target: ReviewTarget) -> ReviewScope {
+fn parse_scope(
+    value: Option<&serde_json::Value>,
+    target: ReviewTarget,
+) -> Result<ReviewScope, String> {
     match value.and_then(serde_json::Value::as_str) {
-        Some("local") => ReviewScope::Local,
-        Some("diff_first_global") => ReviewScope::DiffFirstGlobal,
-        _ if target == ReviewTarget::Diff => ReviewScope::DiffFirstGlobal,
-        _ => ReviewScope::Local,
+        Some("local") => Ok(ReviewScope::Local),
+        Some("diff_first_global") => Ok(ReviewScope::DiffFirstGlobal),
+        Some(other) => Err(format!("invalid review scope: {other}")),
+        None if target == ReviewTarget::Diff => Ok(ReviewScope::DiffFirstGlobal),
+        None => Ok(ReviewScope::Local),
     }
 }
 
 fn parse_global_scan(
     value: Option<&serde_json::Value>,
     review_scope: ReviewScope,
-) -> GlobalScanMode {
+) -> Result<GlobalScanMode, String> {
     match value.and_then(serde_json::Value::as_str) {
-        Some("off") => GlobalScanMode::Off,
-        Some("auto") => GlobalScanMode::Auto,
-        _ if review_scope == ReviewScope::DiffFirstGlobal => GlobalScanMode::Auto,
-        _ => GlobalScanMode::Off,
+        Some("off") => Ok(GlobalScanMode::Off),
+        Some("auto") => Ok(GlobalScanMode::Auto),
+        Some(other) => Err(format!("invalid global scan mode: {other}")),
+        None if review_scope == ReviewScope::DiffFirstGlobal => Ok(GlobalScanMode::Auto),
+        None => Ok(GlobalScanMode::Off),
     }
 }
 
@@ -300,6 +306,7 @@ fn read_string_array(value: Option<&serde_json::Value>) -> Vec<String> {
                 .filter_map(serde_json::Value::as_str)
                 .map(str::trim)
                 .filter(|item| !item.is_empty())
+                .take(100)
                 .map(str::to_string)
                 .collect::<Vec<_>>()
         })
@@ -524,6 +531,62 @@ mod tests {
         .expect("report should parse");
 
         assert_eq!(report.verdict, ReviewVerdict::Pass);
+    }
+
+    #[test]
+    fn review_request_honors_explicit_scope_scan_and_arrays() {
+        let request = ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review with explicit knobs",
+            "target": "diff",
+            "reviewScope": "local",
+            "globalScanMode": "off",
+            "changedFiles": ["src/a.ts", " ", "", "src/b.ts"],
+            "preferredChecks": ["npm run typecheck", "   ", "cargo test"],
+            "riskHints": ["cross_platform", "", " persistence "]
+        }))
+        .expect("request should parse");
+
+        assert_eq!(request.target, ReviewTarget::Diff);
+        assert_eq!(request.review_scope, ReviewScope::Local);
+        assert_eq!(request.global_scan_mode, GlobalScanMode::Off);
+        assert_eq!(request.changed_files, vec!["src/a.ts", "src/b.ts"]);
+        assert_eq!(
+            request.preferred_checks,
+            vec!["npm run typecheck", "cargo test"]
+        );
+        assert_eq!(request.risk_hints, vec!["cross_platform", "persistence"]);
+    }
+
+    #[test]
+    fn review_request_rejects_missing_task_and_invalid_enums() {
+        assert!(ReviewRequest::from_tool_input(&serde_json::json!({})).is_err());
+        assert!(ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review",
+            "target": "unknown"
+        }))
+        .is_err());
+        assert!(ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review",
+            "reviewScope": "wide"
+        }))
+        .is_err());
+        assert!(ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review",
+            "globalScanMode": "sometimes"
+        }))
+        .is_err());
+    }
+
+    #[test]
+    fn extract_review_report_rejects_malformed_or_incomplete_inputs() {
+        assert!(extract_review_report("").is_none());
+        assert!(extract_review_report("   ").is_none());
+        assert!(extract_review_report("{not json").is_none());
+        assert!(extract_review_report(r#"{"directFindings":[]}"#).is_none());
+        assert!(extract_review_report("```json\n{\"verdict\":\"pass\"}").is_none());
+        assert!(
+            extract_review_report("before\n```json\n{\"verdict\":\"pass\"}\n```\nafter").is_none()
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/subagent/review_contract.rs
+++ b/src-tauri/src/core/subagent/review_contract.rs
@@ -1,0 +1,542 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewTarget {
+    #[default]
+    Code,
+    Diff,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewScope {
+    Local,
+    DiffFirstGlobal,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GlobalScanMode {
+    Off,
+    Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewVerdict {
+    Pass,
+    Fail,
+    NeedsAttention,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FindingSeverity {
+    Critical,
+    High,
+    Medium,
+    Low,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerificationStatus {
+    Passed,
+    Failed,
+    Skipped,
+    NotRun,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewRequest {
+    pub task: String,
+    pub target: ReviewTarget,
+    pub review_scope: ReviewScope,
+    pub global_scan_mode: GlobalScanMode,
+    #[serde(default)]
+    pub changed_files: Vec<String>,
+    #[serde(default)]
+    pub preferred_checks: Vec<String>,
+    #[serde(default)]
+    pub risk_hints: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewFinding {
+    pub title: String,
+    pub severity: FindingSeverity,
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub line: Option<u32>,
+    pub summary: String,
+    #[serde(default)]
+    pub evidence: Vec<String>,
+    #[serde(default)]
+    pub suggestion: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationResult {
+    pub command: String,
+    pub status: VerificationStatus,
+    pub summary: String,
+    #[serde(default)]
+    pub key_output: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CoverageNote {
+    pub diff_reviewed: bool,
+    pub global_scan_performed: bool,
+    #[serde(default)]
+    pub changed_files_reviewed: Vec<String>,
+    #[serde(default)]
+    pub scanned_paths: Vec<String>,
+    #[serde(default)]
+    pub unscanned_paths: Vec<String>,
+    #[serde(default)]
+    pub limitations: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewReport {
+    pub verdict: ReviewVerdict,
+    #[serde(default)]
+    pub direct_findings: Vec<ReviewFinding>,
+    #[serde(default)]
+    pub global_findings: Vec<ReviewFinding>,
+    #[serde(default)]
+    pub verification: Vec<VerificationResult>,
+    pub coverage: CoverageNote,
+    #[serde(default)]
+    pub follow_up: Vec<String>,
+}
+
+impl ReviewRequest {
+    pub fn from_tool_input(tool_input: &serde_json::Value) -> Result<Self, String> {
+        let task = tool_input
+            .get("task")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+
+        if task.is_empty() {
+            return Err("missing helper task".to_string());
+        }
+
+        let target = parse_target(tool_input.get("target"));
+        let review_scope = parse_scope(tool_input.get("reviewScope"), target);
+        let global_scan_mode = parse_global_scan(tool_input.get("globalScanMode"), review_scope);
+
+        Ok(Self {
+            task,
+            target,
+            review_scope,
+            global_scan_mode,
+            changed_files: read_string_array(tool_input.get("changedFiles")),
+            preferred_checks: read_string_array(tool_input.get("preferredChecks")),
+            risk_hints: read_string_array(tool_input.get("riskHints")),
+        })
+    }
+
+    pub fn to_helper_prompt(&self) -> String {
+        let changed_files = format_list(&self.changed_files, "discover from git_status + git_diff");
+        let preferred_checks = format_list(
+            &self.preferred_checks,
+            "infer from the repository instructions, scripts, and build files",
+        );
+        let risk_hints = format_list(&self.risk_hints, "none provided");
+
+        format!(
+            "Review request:
+- task: {task}
+- target: {target}
+- review_scope: {review_scope}
+- global_scan_mode: {global_scan_mode}
+- changed_files: {changed_files}
+- preferred_checks: {preferred_checks}
+- risk_hints: {risk_hints}
+
+Execution rules:
+- Adapt your review to the active repository instead of assuming a specific framework, language, or test runner.
+- If target=diff, start from the current workspace changes. Use `git_status` to enumerate changed files and `git_diff` to inspect exact diffs whenever changed_files is empty or incomplete.
+- Review direct diff risks first. Focus on correctness, regressions, edge cases, error handling, and consistency with existing patterns.
+- If review_scope=diff_first_global and global_scan_mode=auto, perform a limited global impact probe after the direct diff review.
+- Keep the global impact probe bounded: inspect at most one dependency hop and at most 8 additional files unless a smaller set is sufficient.
+- Use the global probe for shared exports, public interfaces, schemas, persistence boundaries, runtime commands, configuration, cross-platform paths, or tests that may be affected by the diff.
+- Run the necessary verification commands for this repository. Prefer preferred_checks when provided; otherwise infer the right type-check and test commands from workspace instructions, package scripts, manifests, and build files.
+- If verification or the global scan cannot be completed, record that honestly in coverage.limitations or verification with status=skipped/not_run.
+
+Return exactly one JSON object with this contract:
+{{
+  \"verdict\": \"pass|fail|needs_attention\",
+  \"directFindings\": [
+    {{
+      \"title\": \"short title\",
+      \"severity\": \"critical|high|medium|low\",
+      \"path\": \"optional/path\",
+      \"line\": 123,
+      \"summary\": \"what is wrong and why it matters\",
+      \"evidence\": [\"specific evidence\"],
+      \"suggestion\": \"optional concrete fix\"
+    }}
+  ],
+  \"globalFindings\": [
+    {{
+      \"title\": \"short title\",
+      \"severity\": \"critical|high|medium|low\",
+      \"path\": \"optional/path\",
+      \"line\": 123,
+      \"summary\": \"diff-adjacent system risk\",
+      \"evidence\": [\"specific evidence\"],
+      \"suggestion\": \"optional concrete fix\"
+    }}
+  ],
+  \"verification\": [
+    {{
+      \"command\": \"command string\",
+      \"status\": \"passed|failed|skipped|not_run\",
+      \"summary\": \"short outcome summary\",
+      \"keyOutput\": \"important output excerpt if helpful\"
+    }}
+  ],
+  \"coverage\": {{
+    \"diffReviewed\": true,
+    \"globalScanPerformed\": true,
+    \"changedFilesReviewed\": [\"path\"],
+    \"scannedPaths\": [\"path\"],
+    \"unscannedPaths\": [\"path\"],
+    \"limitations\": [\"what could not be completed\"]
+  }},
+  \"followUp\": [\"exact next step for the parent agent or user\"]
+}}
+
+Do not wrap the JSON in markdown fences and do not add prose before or after it.",
+            task = self.task,
+            target = review_target_label(self.target),
+            review_scope = review_scope_label(self.review_scope),
+            global_scan_mode = global_scan_mode_label(self.global_scan_mode),
+            changed_files = changed_files,
+            preferred_checks = preferred_checks,
+            risk_hints = risk_hints,
+        )
+    }
+}
+
+pub fn extract_review_report(text: &str) -> Option<ReviewReport> {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(report) = serde_json::from_str::<ReviewReport>(trimmed) {
+        return Some(report);
+    }
+
+    let stripped = strip_code_fence(trimmed);
+    serde_json::from_str::<ReviewReport>(stripped).ok()
+}
+
+pub fn render_parent_summary(report: &ReviewReport) -> String {
+    let mut lines = vec![format!("Verdict: {}", verdict_label(report.verdict))];
+
+    lines.push(render_findings_section(
+        "Direct Diff Findings",
+        &report.direct_findings,
+    ));
+    lines.push(render_findings_section(
+        "Global Impact Findings",
+        &report.global_findings,
+    ));
+    lines.push(render_verification_section(&report.verification));
+    lines.push(render_coverage_section(&report.coverage));
+    lines.push(render_follow_up_section(&report.follow_up));
+
+    lines.join("\n\n")
+}
+
+fn parse_target(value: Option<&serde_json::Value>) -> ReviewTarget {
+    match value.and_then(serde_json::Value::as_str).unwrap_or("code") {
+        "diff" => ReviewTarget::Diff,
+        _ => ReviewTarget::Code,
+    }
+}
+
+fn parse_scope(value: Option<&serde_json::Value>, target: ReviewTarget) -> ReviewScope {
+    match value.and_then(serde_json::Value::as_str) {
+        Some("local") => ReviewScope::Local,
+        Some("diff_first_global") => ReviewScope::DiffFirstGlobal,
+        _ if target == ReviewTarget::Diff => ReviewScope::DiffFirstGlobal,
+        _ => ReviewScope::Local,
+    }
+}
+
+fn parse_global_scan(
+    value: Option<&serde_json::Value>,
+    review_scope: ReviewScope,
+) -> GlobalScanMode {
+    match value.and_then(serde_json::Value::as_str) {
+        Some("off") => GlobalScanMode::Off,
+        Some("auto") => GlobalScanMode::Auto,
+        _ if review_scope == ReviewScope::DiffFirstGlobal => GlobalScanMode::Auto,
+        _ => GlobalScanMode::Off,
+    }
+}
+
+fn read_string_array(value: Option<&serde_json::Value>) -> Vec<String> {
+    value
+        .and_then(serde_json::Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .map(str::trim)
+                .filter(|item| !item.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn strip_code_fence(text: &str) -> &str {
+    text.strip_prefix("```json")
+        .and_then(|value| value.strip_suffix("```"))
+        .map(str::trim)
+        .or_else(|| {
+            text.strip_prefix("```")
+                .and_then(|value| value.strip_suffix("```"))
+                .map(str::trim)
+        })
+        .unwrap_or(text)
+}
+
+fn render_findings_section(title: &str, findings: &[ReviewFinding]) -> String {
+    if findings.is_empty() {
+        return format!("{title}:\n- none");
+    }
+
+    let lines = findings
+        .iter()
+        .map(|finding| {
+            let path = finding.path.as_deref().unwrap_or("unknown path");
+            let location = finding
+                .line
+                .map(|line| format!("{path}:{line}"))
+                .unwrap_or_else(|| path.to_string());
+            let suggestion = if finding.suggestion.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" Fix: {}", finding.suggestion.trim())
+            };
+            format!(
+                "- [{}] {} at {}. {}{}",
+                severity_label(finding.severity),
+                finding.title.trim(),
+                location,
+                finding.summary.trim(),
+                suggestion
+            )
+        })
+        .collect::<Vec<_>>();
+
+    format!("{title}:\n{}", lines.join("\n"))
+}
+
+fn render_verification_section(verification: &[VerificationResult]) -> String {
+    if verification.is_empty() {
+        return "Verification Results:\n- none recorded".to_string();
+    }
+
+    let lines = verification
+        .iter()
+        .map(|item| {
+            let extra = if item.key_output.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" Output: {}", item.key_output.trim())
+            };
+            format!(
+                "- [{}] `{}`: {}{}",
+                verification_status_label(item.status),
+                item.command.trim(),
+                item.summary.trim(),
+                extra
+            )
+        })
+        .collect::<Vec<_>>();
+
+    format!("Verification Results:\n{}", lines.join("\n"))
+}
+
+fn render_coverage_section(coverage: &CoverageNote) -> String {
+    let mut lines = vec![
+        format!("- diff_reviewed: {}", yes_no(coverage.diff_reviewed)),
+        format!(
+            "- global_scan_performed: {}",
+            yes_no(coverage.global_scan_performed)
+        ),
+        format!(
+            "- changed_files_reviewed: {}",
+            format_list(&coverage.changed_files_reviewed, "none recorded")
+        ),
+        format!(
+            "- scanned_paths: {}",
+            format_list(&coverage.scanned_paths, "none recorded")
+        ),
+    ];
+
+    if !coverage.unscanned_paths.is_empty() {
+        lines.push(format!(
+            "- unscanned_paths: {}",
+            coverage.unscanned_paths.join(", ")
+        ));
+    }
+
+    if !coverage.limitations.is_empty() {
+        lines.push(format!(
+            "- limitations: {}",
+            coverage.limitations.join(" | ")
+        ));
+    }
+
+    format!("Coverage Notes:\n{}", lines.join("\n"))
+}
+
+fn render_follow_up_section(follow_up: &[String]) -> String {
+    if follow_up.is_empty() {
+        return "Parent Follow-up:\n- none".to_string();
+    }
+
+    format!("Parent Follow-up:\n- {}", follow_up.join("\n- "))
+}
+
+fn format_list(items: &[String], empty_label: &str) -> String {
+    if items.is_empty() {
+        empty_label.to_string()
+    } else {
+        items.join(", ")
+    }
+}
+
+fn yes_no(value: bool) -> &'static str {
+    if value {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn review_target_label(target: ReviewTarget) -> &'static str {
+    match target {
+        ReviewTarget::Code => "code",
+        ReviewTarget::Diff => "diff",
+    }
+}
+
+fn review_scope_label(scope: ReviewScope) -> &'static str {
+    match scope {
+        ReviewScope::Local => "local",
+        ReviewScope::DiffFirstGlobal => "diff_first_global",
+    }
+}
+
+fn global_scan_mode_label(mode: GlobalScanMode) -> &'static str {
+    match mode {
+        GlobalScanMode::Off => "off",
+        GlobalScanMode::Auto => "auto",
+    }
+}
+
+fn verdict_label(verdict: ReviewVerdict) -> &'static str {
+    match verdict {
+        ReviewVerdict::Pass => "PASS",
+        ReviewVerdict::Fail => "FAIL",
+        ReviewVerdict::NeedsAttention => "NEEDS ATTENTION",
+    }
+}
+
+fn severity_label(severity: FindingSeverity) -> &'static str {
+    match severity {
+        FindingSeverity::Critical => "CRITICAL",
+        FindingSeverity::High => "HIGH",
+        FindingSeverity::Medium => "MEDIUM",
+        FindingSeverity::Low => "LOW",
+    }
+}
+
+fn verification_status_label(status: VerificationStatus) -> &'static str {
+    match status {
+        VerificationStatus::Passed => "passed",
+        VerificationStatus::Failed => "failed",
+        VerificationStatus::Skipped => "skipped",
+        VerificationStatus::NotRun => "not_run",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        extract_review_report, render_parent_summary, GlobalScanMode, ReviewRequest, ReviewScope,
+        ReviewTarget, ReviewVerdict,
+    };
+
+    #[test]
+    fn review_request_defaults_to_diff_first_global_for_diff_target() {
+        let request = ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review the current changes",
+            "target": "diff"
+        }))
+        .expect("request should parse");
+
+        assert_eq!(request.target, ReviewTarget::Diff);
+        assert_eq!(request.review_scope, ReviewScope::DiffFirstGlobal);
+        assert_eq!(request.global_scan_mode, GlobalScanMode::Auto);
+    }
+
+    #[test]
+    fn review_request_keeps_local_scope_for_code_target() {
+        let request = ReviewRequest::from_tool_input(&serde_json::json!({
+            "task": "review the implementation",
+            "target": "code"
+        }))
+        .expect("request should parse");
+
+        assert_eq!(request.target, ReviewTarget::Code);
+        assert_eq!(request.review_scope, ReviewScope::Local);
+        assert_eq!(request.global_scan_mode, GlobalScanMode::Off);
+    }
+
+    #[test]
+    fn extract_review_report_accepts_json_fence() {
+        let report = extract_review_report(
+            r#"```json
+{"verdict":"pass","directFindings":[],"globalFindings":[],"verification":[],"coverage":{"diffReviewed":true,"globalScanPerformed":false,"changedFilesReviewed":[],"scannedPaths":[],"unscannedPaths":[],"limitations":[]},"followUp":[]}
+```"#,
+        )
+        .expect("report should parse");
+
+        assert_eq!(report.verdict, ReviewVerdict::Pass);
+    }
+
+    #[test]
+    fn render_parent_summary_includes_direct_and_global_sections() {
+        let report = extract_review_report(
+            r#"{"verdict":"needs_attention","directFindings":[{"title":"Missing guard","severity":"high","path":"src/a.ts","line":9,"summary":"Can panic on empty input.","evidence":["new code assumes at least one item"],"suggestion":"Guard against empty input."}],"globalFindings":[{"title":"Shared type contract changed","severity":"medium","path":"src/shared.ts","line":null,"summary":"Downstream callers may rely on the old shape.","evidence":["exported interface changed"],"suggestion":"Review dependent call sites."}],"verification":[{"command":"npm run typecheck","status":"passed","summary":"Typecheck passed","keyOutput":""}],"coverage":{"diffReviewed":true,"globalScanPerformed":true,"changedFilesReviewed":["src/a.ts"],"scannedPaths":["src/a.ts","src/shared.ts"],"unscannedPaths":[],"limitations":[]},"followUp":["none"]}"#,
+        )
+        .expect("report should parse");
+
+        let summary = render_parent_summary(&report);
+        assert!(summary.contains("Verdict: NEEDS ATTENTION"));
+        assert!(summary.contains("Direct Diff Findings"));
+        assert!(summary.contains("Global Impact Findings"));
+        assert!(summary.contains("npm run typecheck"));
+    }
+}

--- a/src-tauri/src/core/subagent/runtime_orchestration.rs
+++ b/src-tauri/src/core/subagent/runtime_orchestration.rs
@@ -336,7 +336,12 @@ Return format:\n\
                         "properties": {
                             "path": { "type": "string", "description": "Optional relative path to inspect." },
                             "staged": { "type": "boolean", "description": "Set true to inspect staged changes instead of working tree changes." },
-                            "contextLines": { "type": "integer", "description": "Optional number of unified diff context lines. Defaults to 3 and is capped for safety." }
+                            "contextLines": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 20,
+                                "description": "Optional number of unified diff context lines. Defaults to 3 and is capped for safety."
+                            }
                         }
                     }),
                 ),
@@ -348,7 +353,12 @@ Return format:\n\
                         "type": "object",
                         "properties": {
                             "path": { "type": "string", "description": "Optional relative path to filter history." },
-                            "limit": { "type": "integer", "description": "Optional maximum number of commits to return. Defaults to 10 and is capped for safety." }
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 100,
+                                "description": "Optional maximum number of commits to return. Defaults to 10 and is capped for safety."
+                            }
                         }
                     }),
                 ),
@@ -464,6 +474,30 @@ mod tests {
         assert!(tool.description.contains("verification results"));
         assert!(task_description.contains("type-check or test commands"));
         assert_eq!(review_scope_enum.len(), 2);
+    }
+
+    #[test]
+    fn review_git_tool_schema_exposes_numeric_safety_bounds() {
+        let tools = SubagentProfile::Review.helper_tools();
+        let git_diff = tools
+            .iter()
+            .find(|tool| tool.name == "git_diff")
+            .expect("git_diff tool");
+        let git_log = tools
+            .iter()
+            .find(|tool| tool.name == "git_log")
+            .expect("git_log tool");
+
+        assert_eq!(
+            git_diff.parameters["properties"]["contextLines"]["minimum"],
+            1
+        );
+        assert_eq!(
+            git_diff.parameters["properties"]["contextLines"]["maximum"],
+            20
+        );
+        assert_eq!(git_log.parameters["properties"]["limit"]["minimum"], 1);
+        assert_eq!(git_log.parameters["properties"]["limit"]["maximum"], 100);
     }
 
     #[test]

--- a/src-tauri/src/core/subagent/runtime_orchestration.rs
+++ b/src-tauri/src/core/subagent/runtime_orchestration.rs
@@ -99,7 +99,32 @@ impl RuntimeOrchestrationTool {
                     "target": {
                         "type": "string",
                         "enum": ["code", "diff"],
-                        "description": "Review focus. Use 'code' for the current implementation or 'diff' for a patch-oriented pass. If omitted, review defaults to code-level review."
+                        "description": "Review focus. Use 'code' for the current implementation or 'diff' for a patch-oriented pass. Diff reviews default to a diff-first, global-aware pass."
+                    },
+                    "reviewScope": {
+                        "type": "string",
+                        "enum": ["local", "diff_first_global"],
+                        "description": "Choose 'local' for a focused implementation review or 'diff_first_global' to start from the diff and then do a bounded global impact scan."
+                    },
+                    "globalScanMode": {
+                        "type": "string",
+                        "enum": ["off", "auto"],
+                        "description": "Control the bounded global impact probe. Use 'auto' to inspect adjacent dependencies, exports, and tests when the diff suggests broader risk."
+                    },
+                    "changedFiles": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional relative file paths that are already known to be in scope for the review."
+                    },
+                    "preferredChecks": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional verification commands the helper should try first when they fit the active repository."
+                    },
+                    "riskHints": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional risk cues such as cross_platform, persistence, schema, runtime, config, or tests."
                     }
                 },
                 "required": ["task"]
@@ -123,7 +148,7 @@ impl SubagentProfile {
         }
     }
 
-    pub fn system_prompt(self) -> &'static str {
+    pub fn system_prompt(self) -> String {
         match self {
             Self::Explore => {
                 "You are an internal explore helper. Your job is to investigate the workspace and gather context for the parent agent.\n\
@@ -147,14 +172,17 @@ Examples:\n\
 - Bad tool calls: `search {}`, `read {}`, `find {}`, `search {\"path\":\"src\"}`, `read {\"query\":\"title\"}`.\n\
 - Good tool calls: `search {\"query\":\"thread title\"}`, `find {\"pattern\":\"*thread*title*\",\"path\":\"src\"}`, `read {\"path\":\"src/modules/workbench-shell/ui/runtime-thread-surface.tsx\"}`.\n\
 - Prefer this workflow when investigating code: first use `find` to locate likely files, then use `search` to locate relevant text or symbols, then use `read` to inspect the exact implementation. Only call a tool once you know the required arguments."
+                    .to_string()
             }
             Self::Review => {
                 "You are an internal review helper. Your job is to evaluate implemented code or diffs, run verification commands, and provide constructive feedback.\n\
 Guidelines:\n\
 - Do not modify any files. Only use the shell tool for read-only diagnostic commands.\n\
-- Use repository inspection tools. Check the current thread's Terminal panel output when it directly supports the review.\n\
-- Focus on correctness, edge cases, error handling, and consistency with existing patterns.\n\
-- Distinguish critical issues from suggestions. Be specific: reference file paths and line ranges.\n\
+- Prefer repository inspection tools over shell whenever they fit. Use `git_status`, `git_diff`, and `git_log` for Git-aware inspection, then `read`, `search`, and `find` for exact implementation context.\n\
+- Check the current thread's Terminal panel output when it directly supports the review.\n\
+- Focus on correctness, edge cases, error handling, consistency with existing patterns, and repository-appropriate conventions for the active project.\n\
+- Adapt to the current stack. Infer build, test, and project structure from repository files and instructions instead of assuming a particular framework.\n\
+- Distinguish direct diff problems from wider system-impact risks. Be specific: reference file paths and line ranges when available.\n\
 \n\
 Verification:\n\
 - After reviewing code or diffs, determine the necessary project type-check and test commands, then run them with the shell tool (e.g. `npm run typecheck`, `cargo test`, or whatever the project uses). This is mandatory, not optional.\n\
@@ -162,14 +190,25 @@ Verification:\n\
 - Treat this verification work as part of your core responsibility so the parent agent does not need to duplicate it by default.\n\
 - If the shell tool is unavailable or a command is rejected by the approval policy, explicitly state in your summary that manual verification is still needed and list the exact commands the parent agent should run.\n\
 \n\
+Diff-first, global-aware review behavior:\n\
+- When the request target is `diff`, begin from the current workspace changes. Use `git_status` and `git_diff` when the changed file list is not already provided.\n\
+- Review the changed code first.\n\
+- If the request asks for a bounded global scan, inspect adjacent callers, exports, shared types, tests, configs, or runtime boundaries that are plausibly affected by the diff.\n\
+- Keep that global scan bounded: at most one dependency hop and at most 8 additional files unless a smaller set is sufficient.\n\
+- If the bounded global scan cannot be completed, record that in the coverage limitations instead of pretending the review is complete.\n\
+\n\
 Return format:\n\
-- Structure your response so the parent agent can quickly assess implementation status.\n\
-- Lead with an overall verdict: PASS, FAIL, or NEEDS ATTENTION.\n\
-- Section 1 — Review findings: critical issues, warnings, and suggestions with file paths and line ranges.\n\
-- Section 2 — Verification results: for each command run, state the command, whether it passed or failed, and quote key error output (truncated if long). If verification was skipped, say so and list the commands that need manual execution.\n\
-- Section 3 — Parent agent follow-up: say `none` when verification is complete and the parent agent does not need to rerun the same type-check or test commands. Otherwise list the exact remaining verification commands, why they still need manual execution, and any other action the parent agent should take.\n\
-- Keep the summary concise. The parent agent needs actionable signal, not exhaustive logs.\n\
-- When reviewing documents, architecture specs, or design proposals (as opposed to code), prefer a discursive, paragraph-oriented format over bullet-heavy enumeration. Group related observations into themed paragraphs with clear topic sentences. Reserve bullet lists for genuinely discrete, independent items like a checklist of action items."
+- Return exactly one JSON object. Do not wrap it in markdown fences and do not add any prose before or after it.\n\
+- Required top-level keys: `verdict`, `directFindings`, `globalFindings`, `verification`, `coverage`, `followUp`.\n\
+- `verdict` must be one of `pass`, `fail`, or `needs_attention`.\n\
+- Findings must stay concrete, actionable, and repository-specific.\n\
+- Use `directFindings` for issues directly supported by the changed code or diff.\n\
+- Use `globalFindings` for bounded downstream or cross-cutting risks discovered during the global impact probe.\n\
+- `verification` must list every verification command you attempted, with command, status, summary, and key output when useful.\n\
+- `coverage` must say whether diff review happened, whether the global scan happened, which paths were scanned, which were left unscanned, and what limitations remain.\n\
+- `followUp` should be `[]` when nothing remains, otherwise list exact next steps for the parent agent or user.\n\
+- Keep the JSON concise. The parent agent needs actionable signal, not exhaustive logs."
+                    .to_string()
             }
         }
     }
@@ -278,6 +317,42 @@ Return format:\n\
         if self == Self::Review {
             tools.extend([
                 AgentTool::new(
+                    "git_status",
+                    "Git Status",
+                    "Inspect repository status in the current workspace without modifying anything. Use this to enumerate changed files before reading diffs.",
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "Optional relative path to narrow the status query." }
+                        }
+                    }),
+                ),
+                AgentTool::new(
+                    "git_diff",
+                    "Git Diff",
+                    "Read the current Git diff in the workspace, optionally scoped to a path or staged changes. Prefer this over shelling out for diff inspection.",
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "Optional relative path to inspect." },
+                            "staged": { "type": "boolean", "description": "Set true to inspect staged changes instead of working tree changes." },
+                            "contextLines": { "type": "integer", "description": "Optional number of unified diff context lines. Defaults to 3 and is capped for safety." }
+                        }
+                    }),
+                ),
+                AgentTool::new(
+                    "git_log",
+                    "Git Log",
+                    "Inspect recent Git history in the current workspace without modifying anything. Useful for understanding prior behavior or nearby changes.",
+                    serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "path": { "type": "string", "description": "Optional relative path to filter history." },
+                            "limit": { "type": "integer", "description": "Optional maximum number of commits to return. Defaults to 10 and is capped for safety." }
+                        }
+                    }),
+                ),
+                AgentTool::new(
                     "term_status",
                     "Terminal Status",
                     TERM_STATUS_TOOL_DESCRIPTION,
@@ -338,6 +413,9 @@ mod tests {
         let tools = SubagentProfile::Review.helper_tools();
         let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name.as_str()).collect();
 
+        assert!(tool_names.contains(&"git_status"));
+        assert!(tool_names.contains(&"git_diff"));
+        assert!(tool_names.contains(&"git_log"));
         assert!(tool_names.contains(&"term_status"));
         assert!(tool_names.contains(&"term_output"));
     }
@@ -378,10 +456,14 @@ mod tests {
         let task_description = tool.parameters["properties"]["task"]["description"]
             .as_str()
             .expect("task description should exist");
+        let review_scope_enum = tool.parameters["properties"]["reviewScope"]["enum"]
+            .as_array()
+            .expect("reviewScope enum should exist");
 
         assert!(tool.description.contains("type-check and test commands"));
         assert!(tool.description.contains("verification results"));
         assert!(task_description.contains("type-check or test commands"));
+        assert_eq!(review_scope_enum.len(), 2);
     }
 
     #[test]
@@ -390,7 +472,8 @@ mod tests {
 
         assert!(prompt.contains("This is mandatory, not optional"));
         assert!(prompt.contains("parent agent does not need to duplicate it by default"));
-        assert!(prompt.contains("Section 3 — Parent agent follow-up"));
-        assert!(prompt.contains("does not need to rerun the same type-check or test commands"));
+        assert!(prompt.contains("Return exactly one JSON object"));
+        assert!(prompt.contains("globalFindings"));
+        assert!(prompt.contains("followUp"));
     }
 }


### PR DESCRIPTION
## Summary
- add a structured review contract for diff-first, global-aware helper reviews
- add read-only Git helper tools (`git_status`, `git_diff`, `git_log`) for safer review workflows
- wire the new review contract into subagent orchestration and helper prompting

## What changed
- added `review_contract.rs` with typed review request/report parsing, helper prompt generation, and parent summary rendering
- added Git read-only executor support in `src-tauri/src/core/executors/git.rs` and registered the new Git tools
- updated subagent orchestration/runtime plumbing to support diff-targeted reviews, bounded global scans, and verification reporting
- adjusted agent session integration to use the new review flow

## Files of note
- `src-tauri/src/core/subagent/review_contract.rs`
- `src-tauri/src/core/executors/git.rs`
- `src-tauri/src/core/subagent/orchestrator.rs`
- `src-tauri/src/core/subagent/runtime_orchestration.rs`
- `src-tauri/src/core/agent_session.rs`

## Verification
- Not run as part of this PR creation task.