### PR TITLE
fix(llm): disable reasoning and bump token budget for lightweight generation tasks

### DIFF
--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -24,6 +24,7 @@ use crate::model::workspace::WorkspaceRecord;
 use crate::persistence::repo::{audit_repo, workspace_repo};
 
 const COMMIT_MESSAGE_MAX_TOKENS: u32 = 512;
+const COMMIT_MESSAGE_MAX_TOKENS_REASONING: u32 = 1536;
 const COMMIT_MESSAGE_TIMEOUT: Duration = Duration::from_secs(30);
 const COMMIT_MESSAGE_FILE_LIMIT: usize = 24;
 const COMMIT_MESSAGE_DIFF_CHAR_BUDGET: usize = 48_000;
@@ -1078,6 +1079,16 @@ async fn generate_with_lite_model(
     system_prompt: &str,
     user_prompt: &str,
 ) -> Result<String, AppError> {
+    // Lightweight generation (commit messages, branch names) does not benefit from
+    // reasoning/thinking tokens.  Disable reasoning so the protocol layer omits
+    // thinking/reasoning parameters, preventing reasoning tokens from consuming
+    // the COMMIT_MESSAGE_MAX_TOKENS budget.
+    // If the original model had reasoning enabled, bump max_tokens as a fallback —
+    // some reasoning-only models ignore the disable and still produce reasoning tokens.
+    let was_reasoning = model_role.model.reasoning;
+    let mut model_role = model_role.clone();
+    model_role.model.reasoning = false;
+
     let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
         AppError::recoverable(
             ErrorSource::Settings,
@@ -1097,7 +1108,11 @@ async fn generate_with_lite_model(
 
     let options = TiyStreamOptions {
         api_key: model_role.api_key.clone(),
-        max_tokens: Some(COMMIT_MESSAGE_MAX_TOKENS),
+        max_tokens: Some(if was_reasoning {
+            COMMIT_MESSAGE_MAX_TOKENS_REASONING
+        } else {
+            COMMIT_MESSAGE_MAX_TOKENS
+        }),
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         ..TiyStreamOptions::default()

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -41,7 +41,9 @@ use crate::persistence::repo::{message_repo, profile_repo, run_repo, thread_repo
 const TITLE_GENERATION_TIMEOUT: Duration = Duration::from_secs(12);
 const COMPACT_SUMMARY_TIMEOUT: Duration = Duration::from_secs(20);
 const TITLE_GENERATION_MAX_TOKENS: u32 = 32;
+const TITLE_GENERATION_MAX_TOKENS_REASONING: u32 = 512;
 const COMPACT_SUMMARY_MAX_TOKENS: u32 = 700;
+const COMPACT_SUMMARY_MAX_TOKENS_REASONING: u32 = 2048;
 const TITLE_CONTEXT_MAX_CHARS: usize = 1_200;
 const COMPACT_SUMMARY_CONTEXT_MAX_CHARS: usize = 18_000;
 const FRONTEND_EVENT_BUFFER_SIZE: usize = 2048;
@@ -1490,6 +1492,15 @@ async fn generate_compact_summary(
     history: &[AgentMessage],
     instructions: Option<&str>,
 ) -> Result<Option<String>, AppError> {
+    // Compact summary generation does not benefit from reasoning/thinking tokens.
+    // Disable reasoning so the protocol layer omits thinking/reasoning parameters,
+    // preventing reasoning tokens from consuming the COMPACT_SUMMARY_MAX_TOKENS budget.
+    // If the original model had reasoning enabled, bump max_tokens as a fallback —
+    // some reasoning-only models ignore the disable and still produce reasoning tokens.
+    let was_reasoning = model_role.model.reasoning;
+    let mut model_role = model_role.clone();
+    model_role.model.reasoning = false;
+
     let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
         AppError::recoverable(
             ErrorSource::Settings,
@@ -1509,7 +1520,11 @@ async fn generate_compact_summary(
 
     let options = TiyStreamOptions {
         api_key: model_role.api_key.clone(),
-        max_tokens: Some(COMPACT_SUMMARY_MAX_TOKENS),
+        max_tokens: Some(if was_reasoning {
+            COMPACT_SUMMARY_MAX_TOKENS_REASONING
+        } else {
+            COMPACT_SUMMARY_MAX_TOKENS
+        }),
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         ..TiyStreamOptions::default()
@@ -1880,6 +1895,22 @@ async fn generate_thread_title(
     response_language: Option<&str>,
     response_style: ProfileResponseStyle,
 ) -> Result<Option<String>, AppError> {
+    // Lightweight title generation does not benefit from reasoning/thinking tokens.
+    // When the lightweight model is a reasoning-capable model (e.g. DeepSeek R1, o1),
+    // the reasoning tokens count against `max_tokens` and can exhaust the entire
+    // token budget (TITLE_GENERATION_MAX_TOKENS = 32), leaving no room for the
+    // actual title output.
+    //
+    // Strategy: 1) Explicitly disable reasoning so the protocol layer omits
+    // thinking/reasoning parameters from the API request.  2) If the original
+    // model had reasoning enabled, bump max_tokens as a fallback — some
+    // reasoning-only models (e.g. o1) ignore the disable and still produce
+    // reasoning tokens, so the larger budget ensures the title can still be
+    // returned.
+    let was_reasoning = model_role.model.reasoning;
+    let mut model_role = model_role.clone();
+    model_role.model.reasoning = false;
+
     let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
         AppError::recoverable(
             ErrorSource::Settings,
@@ -1907,7 +1938,11 @@ async fn generate_thread_title(
 
     let options = TiyStreamOptions {
         api_key: model_role.api_key.clone(),
-        max_tokens: Some(TITLE_GENERATION_MAX_TOKENS),
+        max_tokens: Some(if was_reasoning {
+            TITLE_GENERATION_MAX_TOKENS_REASONING
+        } else {
+            TITLE_GENERATION_MAX_TOKENS
+        }),
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         ..TiyStreamOptions::default()


### PR DESCRIPTION
## Problem

When a reasoning-capable model (e.g. DeepSeek R1, OpenAI o1/o3-mini) is configured as the lightweight model, its reasoning/thinking tokens count against `max_tokens` and can exhaust the entire token budget — especially `TITLE_GENERATION_MAX_TOKENS = 32` — leaving no room for the actual output. This causes title generation to return empty or truncated results, and the same risk applies to compact summary and commit message generation.

## Solution

Apply a **combined strategy** to all three lightweight generation paths:

1. **Disable reasoning** — Clone the `model_role` and set `model.reasoning = false` so the protocol layer omits thinking/reasoning parameters from the API request.
2. **Bump `max_tokens` as fallback** — If the original model had reasoning enabled, use a larger token budget to ensure output can still be returned even if a reasoning-only model ignores the disable.

### Token budgets

| Scenario | Regular | Reasoning fallback |
|---|---|---|
| Title generation | 32 | 512 |
| Compact summary | 700 | 2 048 |
| Commit message | 512 | 1 536 |

## Changed files

- `src-tauri/src/core/agent_run_manager.rs` — `generate_thread_title()` and `generate_compact_summary()`
- `src-tauri/src/commands/git.rs` — `generate_with_lite_model()`

## Verification

- `cargo check` passes
- 197/198 tests pass (1 pre-existing MCP spawn environment failure unrelated to this change)