### PR TITLE
chore(platform): standardize log paths and app db filename

### DIFF
--- a/.tiy/skills/tiycode-guide/SKILL.md
+++ b/.tiy/skills/tiycode-guide/SKILL.md
@@ -630,7 +630,53 @@ When reviewing code, check for:
 
 ---
 
-## 8. Workspace & Git
+## 8. Logs & Diagnostics
+
+TiyCode's native backend logs are produced by the Rust/Tauri process through `tracing`. These file logs are **platform-native operational logs**, not files inside `~/.tiy/`.
+
+### 8.1 Log Directories
+
+| Platform | Directory | Notes |
+|----------|-----------|-------|
+| macOS | `~/Library/Logs/TiyAgents/` | Created automatically on startup if missing |
+| Windows | `%LOCALAPPDATA%/TiyAgents/logs/` | Uses the current user's Local AppData directory |
+| Linux / other Unix | `$XDG_STATE_HOME/tiy-agents/logs/` | Preferred state directory |
+| Linux fallback | `~/.local/state/tiy-agents/logs/` | Used when `XDG_STATE_HOME` is not set |
+
+### 8.2 File Naming, Format, and Retention
+
+| Rule | Behavior |
+|------|----------|
+| File prefix | `tiycode` |
+| File suffix | `log` |
+| Format | Structured JSON logs |
+| Default level | `info` (`sqlx=warn`) unless overridden by environment |
+| Rotation | Daily |
+| Retention | Keep at most **5** log files |
+| Cleanup | Older rotated files beyond the 5-file limit are removed automatically by the rolling appender |
+
+### 8.3 What Gets Recorded in Logs
+
+The file logs are primarily for operational diagnostics. They commonly include:
+
+- App startup and readiness events such as agent startup, database readiness, and migration completion.
+- Workspace, thread, and run lifecycle events such as workspace added/removed, thread created/deleted, run cancellation, and context compression activity.
+- Tool execution metadata such as `tool_call_id`, tool name, and success/failure status.
+- Desktop/runtime warnings such as tray visibility issues, launch-at-login sync failures, sleep-prevention failures, and terminal session recovery or shutdown failures.
+- Provider/catalog/extension warnings such as catalog refresh/load failures, plugin command parse failures, and skill file read/parse failures.
+- Error objects and diagnostic metadata such as local file paths, workspace/thread/run IDs, provider/model IDs, counts, setting keys, and error messages.
+
+The current Rust tracing is mostly **metadata-oriented**, not intended as a full conversation transcript dump. Even so, users should review logs before sharing them externally because they may contain local paths, IDs, tool names, and operational error details.
+
+### 8.4 How the Agent Should Use This Information
+
+- When a user asks where logs are stored, answer with the platform-specific directory above rather than pointing them to `~/.tiy/`.
+- When troubleshooting startup, provider catalog, terminal, tray, or extension loading issues, ask the user for the newest `tiycode*.log` file from the platform-native log directory.
+- If a user asks whether old logs are cleaned automatically, explain the daily rotation + 5-file retention rule.
+
+---
+
+## 9. Workspace & Git
 
 ### Workspaces
 
@@ -655,7 +701,7 @@ The `/commit` command triggers AI-powered commit message generation.
 
 ---
 
-## 9. Terminal
+## 10. Terminal
 
 TiyCode includes a built-in Terminal panel.
 
@@ -687,7 +733,7 @@ TiyCode includes a built-in Terminal panel.
 
 ---
 
-## 10. Theme & Language
+## 11. Theme & Language
 
 ### Theme
 
@@ -712,7 +758,7 @@ TiyCode includes a built-in Terminal panel.
 
 ---
 
-## 11. Common User Scenarios
+## 12. Common User Scenarios
 
 ### "Command not found" in terminal
 
@@ -830,7 +876,7 @@ Use `shell` to run `git status`, `git diff`, `git log --oneline -10`, etc.
 
 ---
 
-## 12. Capability Summary
+## 13. Capability Summary
 
 ### What the Agent CAN Do Directly
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6053,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.4-rc.26041210"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938b1eae1872f80e86c651505e72de96fe28686492ecf9298449a05ea7bfc2ea"
+checksum = "35e1b1d6db568c98f818a64f6a7e5f1bd0d051f2ad1584f8787e853e53d50f0f"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.4-rc.26041210"
+tiycore = "0.1.5"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/migrations/20260316000001_initial_schema.sql
+++ b/src-tauri/migrations/20260316000001_initial_schema.sql
@@ -1,7 +1,7 @@
 -- Tiy Agent Initial Schema
 -- Date: 2026-03-16
 -- Description: Creates all core tables for the Tiy Agent desktop application.
--- Storage location: $HOME/.tiy/db/tiy-agent.db
+-- Storage location: $HOME/.tiy/db/tiycode.db
 
 --------------------------------------------------------------------------------
 -- 0. Pragmas (applied at connection time, not in migration)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -333,7 +333,7 @@ pub fn run() {
         ])
         .setup(move |app| {
             // 4. Initialize database (async, on the tokio runtime that Tauri provides)
-            let db_path = tiy_home.join("db/tiy-agent.db");
+            let db_path = tiy_home.join("db/tiycode.db");
 
             let pool = tauri::async_runtime::block_on(async {
                 persistence::init_database(&db_path).await

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,20 +48,20 @@ fn log_dir() -> PathBuf {
     {
         dirs::home_dir()
             .expect("cannot resolve HOME directory")
-            .join("Library/Logs/TiyAgent")
+            .join("Library/Logs/TiyAgents")
     }
     #[cfg(target_os = "windows")]
     {
         dirs::data_local_dir()
             .expect("cannot resolve LOCALAPPDATA")
-            .join("TiyAgent/logs")
+            .join("TiyAgents/logs")
     }
     #[cfg(not(any(target_os = "macos", target_os = "windows")))]
     {
         dirs::state_dir()
             .or_else(|| dirs::home_dir().map(|h| h.join(".local/state")))
             .expect("cannot resolve state directory")
-            .join("tiy-agent/logs")
+            .join("tiy-agents/logs")
     }
 }
 
@@ -97,7 +97,7 @@ fn init_logging() {
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)
         .max_log_files(5)
-        .filename_prefix("app")
+        .filename_prefix("tiycode")
         .filename_suffix("log")
         .build(&log_path)
         .expect("failed to create log appender");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,8 @@ const MAIN_WINDOW_LABEL: &str = "main";
 const MAIN_TRAY_ID: &str = "main-tray";
 const TRAY_SHOW_ID: &str = "tray-show";
 const TRAY_QUIT_ID: &str = "tray-quit";
+const LOG_FILE_PREFIX: &str = "tiycode";
+const LOG_FILE_SUFFIX: &str = "log";
 
 fn persisted_window_state_flags() -> StateFlags {
     StateFlags::SIZE | StateFlags::POSITION | StateFlags::MAXIMIZED | StateFlags::FULLSCREEN
@@ -97,8 +99,8 @@ fn init_logging() {
     let file_appender = RollingFileAppender::builder()
         .rotation(Rotation::DAILY)
         .max_log_files(5)
-        .filename_prefix("tiycode")
-        .filename_suffix("log")
+        .filename_prefix(LOG_FILE_PREFIX)
+        .filename_suffix(LOG_FILE_SUFFIX)
         .build(&log_path)
         .expect("failed to create log appender");
 
@@ -512,4 +514,69 @@ pub fn run() {
             }
             _ => {}
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{log_dir, LOG_FILE_PREFIX, LOG_FILE_SUFFIX};
+    use std::io::Write;
+    use tracing_appender::rolling::{RollingFileAppender, Rotation};
+
+    #[test]
+    fn log_dir_uses_platform_native_location() {
+        let path = log_dir();
+
+        #[cfg(target_os = "macos")]
+        assert!(
+            path.ends_with("Library/Logs/TiyAgents"),
+            "expected macOS logs under ~/Library/Logs/TiyAgents, got {}",
+            path.display()
+        );
+
+        #[cfg(target_os = "windows")]
+        assert!(
+            path.ends_with("TiyAgents/logs"),
+            "expected Windows logs under %LOCALAPPDATA%/TiyAgents/logs, got {}",
+            path.display()
+        );
+
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        assert!(
+            path.ends_with("tiy-agents/logs"),
+            "expected Unix logs under state dir/tiy-agents/logs, got {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn log_file_uses_tiycode_prefix_and_log_suffix() {
+        let temp_dir = tempfile::tempdir().expect("should create tempdir");
+        let mut appender = RollingFileAppender::builder()
+            .rotation(Rotation::DAILY)
+            .filename_prefix(LOG_FILE_PREFIX)
+            .filename_suffix(LOG_FILE_SUFFIX)
+            .build(temp_dir.path())
+            .expect("should create rolling file appender");
+
+        writeln!(appender, "test log line").expect("should write log line");
+        appender.flush().expect("should flush log output");
+
+        let entries = std::fs::read_dir(temp_dir.path())
+            .expect("should read log directory")
+            .collect::<Result<Vec<_>, _>>()
+            .expect("should collect log directory entries");
+
+        assert_eq!(entries.len(), 1, "expected a single log file");
+
+        let file_name = entries[0].file_name();
+        let file_name = file_name.to_string_lossy();
+        assert!(
+            file_name.starts_with(LOG_FILE_PREFIX),
+            "expected log file to start with {LOG_FILE_PREFIX}, got {file_name}"
+        );
+        assert!(
+            file_name.ends_with(&format!(".{LOG_FILE_SUFFIX}")),
+            "expected log file to end with .{LOG_FILE_SUFFIX}, got {file_name}"
+        );
+    }
 }

--- a/src-tauri/tests/m1_1_infrastructure.rs
+++ b/src-tauri/tests/m1_1_infrastructure.rs
@@ -1,7 +1,7 @@
 //! M1.1 — Project infrastructure & database layer tests
 //!
 //! Acceptance criteria:
-//! - `cargo build` passes; app startup creates `$HOME/.tiy/db/tiy-agent.db` with 17 tables
+//! - `cargo build` passes; app startup creates `$HOME/.tiy/db/tiycode.db` with 17 tables
 //! - Logs written to platform-specific log path (macOS ~/Library/Logs/TiyAgents/)
 //! - `cargo test` persistence module passes
 

--- a/src-tauri/tests/m1_1_infrastructure.rs
+++ b/src-tauri/tests/m1_1_infrastructure.rs
@@ -2,7 +2,7 @@
 //!
 //! Acceptance criteria:
 //! - `cargo build` passes; app startup creates `$HOME/.tiy/db/tiy-agent.db` with 17 tables
-//! - Logs written to platform-specific log path (macOS ~/Library/Logs/TiyAgent/)
+//! - Logs written to platform-specific log path (macOS ~/Library/Logs/TiyAgents/)
 //! - `cargo test` persistence module passes
 
 mod test_helpers;


### PR DESCRIPTION
## Summary
- standardize native Rust/Tauri log directories to use the `TiyAgents` / `tiy-agents` naming across macOS, Windows, and Linux
- rename rotated log files to use the `tiycode*.log` prefix while keeping the existing daily rotation behavior
- rename the app database file from `tiy-agent.db` to `tiycode.db` and update related migration/test references
- bump `tiycore` to `0.1.5` and update the TiyCode guide plus infrastructure expectations for the new paths

## Testing
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml --test m1_1_infrastructure --quiet`