### PR TITLE
refactor(prompt): move current date from message injection to system prompt

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -959,25 +959,13 @@ fn configure_agent(agent: &Arc<Agent>, spec: &AgentSessionSpec, weak_self: Weak<
     agent.set_security_config(runtime_security_config());
 
     // Context compression: automatically trim messages to fit the context window.
-    // Also injects a stable runtime-context reminder (current date) at the end of the
-    // message list so that the system prompt stays unchanged for better prefix caching.
     let compression_settings = crate::core::context_compression::CompressionSettings::new(
         spec.model_plan.primary.model.context_window,
     );
-    let runtime_date = chrono::Local::now().format("%Y-%m-%d").to_string();
     agent.set_transform_context(move |messages| {
         let settings = compression_settings.clone();
-        let date = runtime_date.clone();
         async move {
-            let mut messages =
-                crate::core::context_compression::compress_context(messages, &settings);
-            // Inject the current-date reminder as the last message so that it never
-            // disrupts the stable prefix used by LLM prompt caching.
-            messages.push(tiycore::agent::AgentMessage::User(
-                tiycore::types::UserMessage::text(format!(
-                    "[system-reminder] Current date: {date}"
-                )),
-            ));
+            let messages = crate::core::context_compression::compress_context(messages, &settings);
             messages
         }
     });

--- a/src-tauri/src/core/prompt/providers.rs
+++ b/src-tauri/src/core/prompt/providers.rs
@@ -427,6 +427,7 @@ fn truncate_chars(value: &str, max_chars: usize) -> (String, bool) {
 
 fn build_system_environment_body(tools: &[ToolAvailability]) -> String {
     let shell = current_shell();
+    let current_date = chrono::Local::now().format("%Y-%m-%d").to_string();
     let tool_lines = tools
         .iter()
         .map(|tool| match (&tool.path, &tool.version) {
@@ -440,10 +441,11 @@ fn build_system_environment_body(tools: &[ToolAvailability]) -> String {
         .join("\n");
 
     format!(
-        "- Operating system: {}\n- Architecture: {}\n- Default shell: {}\n- Common CLI tools:\n{}",
+        "- Operating system: {}\n- Architecture: {}\n- Default shell: {}\n- Current date: {}\n- Common CLI tools:\n{}",
         std::env::consts::OS,
         std::env::consts::ARCH,
         shell,
+        current_date,
         tool_lines
     )
 }


### PR DESCRIPTION
## Summary

将当前日期从消息列表末尾注入改为放入 System Environment section，避免干扰模型注意力。

## Problem

此前为了优化 prompt caching，将  作为 User Message 插入到消息列表末尾。但这种方式存在问题：

1. **干扰注意力** - 模型误以为这是用户补充的重要信息需要回应
2. **语义错误** - 日期是环境信息，不应以用户消息形式出现
3. **用户体验差** - 用户可能困惑这条消息的来源

## Solution

将日期移动到 System Prompt 的 EnvironmentProvider 中，与其他系统环境信息（操作系统、架构、Shell）放在一起：

```
## System Environment
- Operating system: macos
- Architecture: aarch64
- Default shell: /bin/zsh
- Current date: 2026-04-14  ← 新增
- Common CLI tools: ...
```

## Tradeoffs

- **Cache 影响**：日期变化时 system prompt 会变，影响缓存命中
- **影响可控**：日期每天只变一次，首次请求 cache miss 后，后续 24 小时内都能正常命中

## Files Changed

- `src-tauri/src/core/agent_session.rs` - 移除消息末尾注入日期的逻辑
- `src-tauri/src/core/prompt/providers.rs` - 将日期添加到 System Environment section