### PR TITLE
fix(tool-gateway): 🐛 Decouple tool execution timeout from approval wait

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -394,13 +394,15 @@ impl AgentSession {
         let event_tx = self.event_tx.clone();
         let run_id = self.spec.run_id.clone();
         let tool_call_id_owned = tool_call_id.to_string();
-        let tool_timeout = standard_tool_timeout();
-        let outcome = tokio::time::timeout(
-            tool_timeout,
-            self.tool_gateway.execute_tool_call(
+        let outcome = self
+            .tool_gateway
+            .execute_tool_call(
                 request,
                 self.abort_signal.clone(),
-                ToolExecutionOptions::default(),
+                ToolExecutionOptions {
+                    allow_user_approval: true,
+                    execution_timeout: Some(standard_tool_timeout()),
+                },
                 move |approval: ApprovalRequest| {
                     let _ = event_tx.send(ThreadStreamEvent::ApprovalRequired {
                         run_id: approval.run_id,
@@ -421,36 +423,8 @@ impl AgentSession {
                         });
                     }
                 },
-            ),
-        )
-        .await;
-
-        let outcome = match outcome {
-            Ok(outcome) => outcome,
-            Err(_) => {
-                let message = format!(
-                    "Tool '{}' timed out after {}s",
-                    tool_name, STANDARD_TOOL_TIMEOUT_SECS
-                );
-                let result = serde_json::json!({ "error": message.clone() });
-                tool_call_repo::update_result(
-                    &self.pool,
-                    tool_call_id,
-                    &result.to_string(),
-                    "failed",
-                )
-                .await
-                .ok();
-
-                let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
-                    run_id: self.spec.run_id.clone(),
-                    tool_call_id: tool_call_id.to_string(),
-                    error: message.clone(),
-                });
-
-                return agent_error_result(message);
-            }
-        };
+            )
+            .await;
 
         match outcome {
             Ok(outcome) => {
@@ -490,6 +464,26 @@ impl AgentSession {
                     }
                     ToolGatewayResult::Cancelled { .. } => {
                         let message = "Tool execution cancelled".to_string();
+                        let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
+                            run_id: self.spec.run_id.clone(),
+                            tool_call_id: tool_call_id.to_string(),
+                            error: message.clone(),
+                        });
+                        agent_error_result(message)
+                    }
+                    ToolGatewayResult::TimedOut { timeout_secs, .. } => {
+                        let message =
+                            format!("Tool '{}' timed out after {}s", tool_name, timeout_secs);
+                        let result = serde_json::json!({ "error": message.clone() });
+                        tool_call_repo::update_result(
+                            &self.pool,
+                            tool_call_id,
+                            &result.to_string(),
+                            "failed",
+                        )
+                        .await
+                        .ok();
+
                         let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
                             run_id: self.spec.run_id.clone(),
                             tool_call_id: tool_call_id.to_string(),

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -325,6 +325,10 @@ impl HelperAgentOrchestrator {
                             );
                             helper_agent_error_result("Helper tool execution cancelled")
                         }
+                        // NOTE: Currently unreachable because subagent passes
+                        // `execution_timeout: None`. This arm exists for forward-
+                        // compatibility so enabling a timeout later won't cause a
+                        // non-exhaustive match error.
                         ToolGatewayResult::TimedOut { timeout_secs, .. } => {
                             let message =
                                 format!("Helper tool timed out after {timeout_secs}s");

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -239,6 +239,7 @@ impl HelperAgentOrchestrator {
                         tiycore::agent::AbortSignal::new(),
                         ToolExecutionOptions {
                             allow_user_approval: false,
+                            execution_timeout: None,
                         },
                         |_| {},
                         || {},
@@ -323,6 +324,24 @@ impl HelperAgentOrchestrator {
                                 },
                             );
                             helper_agent_error_result("Helper tool execution cancelled")
+                        }
+                        ToolGatewayResult::TimedOut { timeout_secs, .. } => {
+                            let message =
+                                format!("Helper tool timed out after {timeout_secs}s");
+                            emit_subagent_progress(
+                                &progress_event_tx,
+                                &helper_run_id,
+                                &helper_id_for_events,
+                                &helper_kind,
+                                &helper_started_at_for_events,
+                                SubagentActivityStatus::Failed,
+                                &progress_state_ref,
+                                message.clone(),
+                                |progress| {
+                                    progress.record_finished(Some(message.clone()))
+                                },
+                            );
+                            helper_agent_error_result(message)
                         }
                     },
                     Err(error) => {

--- a/src-tauri/src/core/tool_gateway.rs
+++ b/src-tauri/src/core/tool_gateway.rs
@@ -194,36 +194,14 @@ impl ToolGateway {
 
                 on_execution_started();
 
-                let output = if let Some(timeout) = options.execution_timeout {
-                    match tokio::time::timeout(
-                        timeout,
-                        self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref()),
-                    )
-                    .await
-                    {
-                        Ok(result) => result?,
-                        Err(_) => {
-                            return Ok(ToolGatewayOutcome {
-                                approval_required: false,
-                                result: ToolGatewayResult::TimedOut {
-                                    tool_call_id: request.tool_call_id,
-                                    timeout_secs: timeout.as_secs(),
-                                },
-                            });
-                        }
-                    }
-                } else {
-                    self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
-                        .await?
-                };
-
-                Ok(ToolGatewayOutcome {
-                    approval_required: false,
-                    result: ToolGatewayResult::Executed {
-                        tool_call_id: request.tool_call_id,
-                        output,
-                    },
-                })
+                self.execute_with_timeout(
+                    request,
+                    &policy_json,
+                    resolved_tool.as_ref(),
+                    options.execution_timeout,
+                    false,
+                )
+                .await
             }
             PolicyVerdict::RequireApproval { reason } => {
                 if !options.allow_user_approval {
@@ -309,40 +287,14 @@ impl ToolGateway {
                             });
                         }
 
-                        let output = if let Some(timeout) = options.execution_timeout {
-                            match tokio::time::timeout(
-                                timeout,
-                                self.execute_and_audit(
-                                    &request,
-                                    &policy_json,
-                                    resolved_tool.as_ref(),
-                                ),
-                            )
-                            .await
-                            {
-                                Ok(result) => result?,
-                                Err(_) => {
-                                    return Ok(ToolGatewayOutcome {
-                                        approval_required: true,
-                                        result: ToolGatewayResult::TimedOut {
-                                            tool_call_id: request.tool_call_id,
-                                            timeout_secs: timeout.as_secs(),
-                                        },
-                                    });
-                                }
-                            }
-                        } else {
-                            self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
-                                .await?
-                        };
-
-                        Ok(ToolGatewayOutcome {
-                            approval_required: true,
-                            result: ToolGatewayResult::Executed {
-                                tool_call_id: request.tool_call_id,
-                                output,
-                            },
-                        })
+                        self.execute_with_timeout(
+                            request,
+                            &policy_json,
+                            resolved_tool.as_ref(),
+                            options.execution_timeout,
+                            true,
+                        )
+                        .await
                     }
                     Some(false) => {
                         tool_call_repo::update_approval(
@@ -403,6 +355,50 @@ impl ToolGateway {
                 }
             }
         }
+    }
+
+    /// Execute a tool with an optional timeout, returning a `ToolGatewayOutcome`.
+    ///
+    /// This helper centralises the timeout-wrapping logic so the `AutoAllow`
+    /// and `RequireApproval(approved)` branches do not duplicate it.
+    async fn execute_with_timeout(
+        &self,
+        request: ToolExecutionRequest,
+        policy_json: &str,
+        resolved_tool: Option<&ResolvedTool>,
+        execution_timeout: Option<std::time::Duration>,
+        approval_required: bool,
+    ) -> Result<ToolGatewayOutcome, crate::model::errors::AppError> {
+        let output = if let Some(timeout) = execution_timeout {
+            match tokio::time::timeout(
+                timeout,
+                self.execute_and_audit(&request, policy_json, resolved_tool),
+            )
+            .await
+            {
+                Ok(result) => result?,
+                Err(_) => {
+                    return Ok(ToolGatewayOutcome {
+                        approval_required,
+                        result: ToolGatewayResult::TimedOut {
+                            tool_call_id: request.tool_call_id,
+                            timeout_secs: timeout.as_secs(),
+                        },
+                    });
+                }
+            }
+        } else {
+            self.execute_and_audit(&request, policy_json, resolved_tool)
+                .await?
+        };
+
+        Ok(ToolGatewayOutcome {
+            approval_required,
+            result: ToolGatewayResult::Executed {
+                tool_call_id: request.tool_call_id,
+                output,
+            },
+        })
     }
 
     /// Resolve a pending approval. Returns `true` when a waiter was found.

--- a/src-tauri/src/core/tool_gateway.rs
+++ b/src-tauri/src/core/tool_gateway.rs
@@ -54,12 +54,16 @@ pub struct ToolGatewayOutcome {
 #[derive(Debug, Clone)]
 pub struct ToolExecutionOptions {
     pub allow_user_approval: bool,
+    /// Timeout applied only to actual tool execution (after approval).
+    /// `None` means no timeout.
+    pub execution_timeout: Option<std::time::Duration>,
 }
 
 impl Default for ToolExecutionOptions {
     fn default() -> Self {
         Self {
             allow_user_approval: true,
+            execution_timeout: None,
         }
     }
 }
@@ -83,6 +87,11 @@ pub enum ToolGatewayResult {
     },
     /// Tool was cancelled before approval or execution could finish.
     Cancelled { tool_call_id: String },
+    /// Tool execution timed out (timeout applies only to actual execution, not approval wait).
+    TimedOut {
+        tool_call_id: String,
+        timeout_secs: u64,
+    },
 }
 
 pub struct ToolGateway {
@@ -185,9 +194,28 @@ impl ToolGateway {
 
                 on_execution_started();
 
-                let output = self
-                    .execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
-                    .await?;
+                let output = if let Some(timeout) = options.execution_timeout {
+                    match tokio::time::timeout(
+                        timeout,
+                        self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref()),
+                    )
+                    .await
+                    {
+                        Ok(result) => result?,
+                        Err(_) => {
+                            return Ok(ToolGatewayOutcome {
+                                approval_required: false,
+                                result: ToolGatewayResult::TimedOut {
+                                    tool_call_id: request.tool_call_id,
+                                    timeout_secs: timeout.as_secs(),
+                                },
+                            });
+                        }
+                    }
+                } else {
+                    self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
+                        .await?
+                };
 
                 Ok(ToolGatewayOutcome {
                     approval_required: false,
@@ -281,9 +309,32 @@ impl ToolGateway {
                             });
                         }
 
-                        let output = self
-                            .execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
-                            .await?;
+                        let output = if let Some(timeout) = options.execution_timeout {
+                            match tokio::time::timeout(
+                                timeout,
+                                self.execute_and_audit(
+                                    &request,
+                                    &policy_json,
+                                    resolved_tool.as_ref(),
+                                ),
+                            )
+                            .await
+                            {
+                                Ok(result) => result?,
+                                Err(_) => {
+                                    return Ok(ToolGatewayOutcome {
+                                        approval_required: true,
+                                        result: ToolGatewayResult::TimedOut {
+                                            tool_call_id: request.tool_call_id,
+                                            timeout_secs: timeout.as_secs(),
+                                        },
+                                    });
+                                }
+                            }
+                        } else {
+                            self.execute_and_audit(&request, &policy_json, resolved_tool.as_ref())
+                                .await?
+                        };
 
                         Ok(ToolGatewayOutcome {
                             approval_required: true,

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -866,6 +866,7 @@ async fn test_tool_gateway_can_fold_approval_into_escalation() {
             tiycore::agent::AbortSignal::new(),
             ToolExecutionOptions {
                 allow_user_approval: false,
+                execution_timeout: None,
             },
             {
                 let approval_prompted = Arc::clone(&approval_prompted);
@@ -1009,6 +1010,9 @@ async fn test_search_repo_allows_relative_directory_within_workspace() {
         ToolGatewayResult::Cancelled { .. } => {
             panic!("search should not be cancelled");
         }
+        ToolGatewayResult::TimedOut { .. } => {
+            panic!("search should not time out");
+        }
     }
 }
 
@@ -1119,6 +1123,9 @@ async fn test_search_repo_ignores_wildcard_file_pattern_and_limits_preview() {
         ToolGatewayResult::Cancelled { .. } => {
             panic!("wildcard file pattern search should not be cancelled");
         }
+        ToolGatewayResult::TimedOut { .. } => {
+            panic!("wildcard file pattern search should not time out");
+        }
     }
 }
 
@@ -1219,6 +1226,9 @@ async fn test_search_repo_treats_regex_metacharacters_as_literal_text() {
         ToolGatewayResult::Cancelled { .. } => {
             panic!("literal metacharacter search should not be cancelled");
         }
+        ToolGatewayResult::TimedOut { .. } => {
+            panic!("literal metacharacter search should not time out");
+        }
     }
 }
 
@@ -1309,6 +1319,9 @@ async fn test_search_repo_supports_regex_count_mode_and_case_insensitive_matchin
         }
         ToolGatewayResult::Cancelled { .. } => {
             panic!("regex count-mode search should not be cancelled");
+        }
+        ToolGatewayResult::TimedOut { .. } => {
+            panic!("regex count-mode search should not time out");
         }
     }
 }

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -1325,3 +1325,91 @@ async fn test_search_repo_supports_regex_count_mode_and_case_insensitive_matchin
         }
     }
 }
+
+// =========================================================================
+// T1.6.x — Execution timeout fires for slow tool
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_execution_timeout_fires_for_slow_tool() {
+    use std::time::Duration;
+    use tiycode::core::terminal_manager::TerminalManager;
+    use tiycode::core::tool_gateway::{
+        ToolExecutionOptions, ToolExecutionRequest, ToolGateway, ToolGatewayResult,
+    };
+
+    let pool = test_helpers::setup_test_pool().await;
+    let workspace_root = std::env::temp_dir().join(format!("tiy-timeout-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&workspace_root).unwrap();
+    let workspace_root = std::fs::canonicalize(&workspace_root).unwrap();
+
+    test_helpers::seed_workspace(&pool, "ws-timeout", workspace_root.to_str().unwrap()).await;
+    test_helpers::seed_thread(&pool, "t-timeout", "ws-timeout").await;
+    test_helpers::seed_run(&pool, "r-timeout", "t-timeout", "running", "default").await;
+    test_helpers::seed_tool_call(
+        &pool,
+        "tc-timeout",
+        "r-timeout",
+        "t-timeout",
+        "shell",
+        "requested",
+    )
+    .await;
+
+    let terminal_manager = Arc::new(TerminalManager::new(pool.clone()));
+    let gateway = Arc::new(ToolGateway::new(pool, terminal_manager));
+
+    // Use a shell command that sleeps but with a very short execution_timeout.
+    // The shell executor's own internal timeout (60s) is much longer, so our
+    // execution_timeout (1s) fires first via execute_with_timeout.
+    //
+    // We also set the shell's input `timeout` to 3s so the child process is
+    // cleaned up promptly even if our outer future-drop doesn't kill it.
+    eprintln!("[test-timeout] calling execute_tool_call...");
+    let gateway_for_approval = Arc::clone(&gateway);
+    let tool_call_id = "tc-timeout".to_string();
+    // Spawn a task that auto-approves the shell tool after a brief delay,
+    // so execution actually begins and the 1s execution_timeout fires.
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let _ = gateway_for_approval
+            .resolve_approval(&tool_call_id, true)
+            .await;
+    });
+    let outcome = gateway
+        .execute_tool_call(
+            ToolExecutionRequest {
+                run_id: "r-timeout".into(),
+                thread_id: "t-timeout".into(),
+                tool_call_id: "tc-timeout".into(),
+                tool_name: "shell".into(),
+                tool_input: serde_json::json!({
+                    "command": "sleep 30",
+                    "timeout": 3,
+                }),
+                workspace_path: workspace_root.display().to_string(),
+                run_mode: "default".into(),
+            },
+            tiycore::agent::AbortSignal::new(),
+            ToolExecutionOptions {
+                allow_user_approval: true,
+                execution_timeout: Some(Duration::from_secs(1)),
+            },
+            |_| {},
+            || {},
+        )
+        .await
+        .unwrap();
+
+    eprintln!("[test-timeout] execute_tool_call returned, checking result...");
+    match outcome.result {
+        ToolGatewayResult::TimedOut {
+            timeout_secs,
+            tool_call_id,
+        } => {
+            assert_eq!(tool_call_id, "tc-timeout");
+            assert_eq!(timeout_secs, 1);
+        }
+        _ => panic!("expected TimedOut, got a different variant"),
+    }
+}


### PR DESCRIPTION
## Summary
- Fix tool execution timeout (120s) incorrectly covering the entire tool call lifecycle including approval wait, causing `Tool 'shell' timed out after 120s` errors when users haven't yet responded to approval prompts.
- Move timeout from the outer `agent_session` layer into `tool_gateway` internals, wrapping only the actual `execute_and_audit` calls after approval is granted.
- Add `execution_timeout` field to `ToolExecutionOptions` and a new `TimedOut` variant to `ToolGatewayResult` for structured timeout handling.

## Test Plan
- [x] `cargo fmt` — no formatting issues
- [x] `cargo test` — all 17 backend tests pass
- [ ] Manual: issue a shell command requiring approval, wait >120s before approving, confirm it no longer times out

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)