### PR TITLE
style(project-panel): 🎨 Remove decorative left border lines from treeview panel

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6053,9 +6053,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.6-rc.26041419"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7a3757fe155d9de6926c9e4f6c19fe3ded5346744e7196c2afb06ba46b9e09"
+checksum = "a7390a7acfbb706280f6c45692159f7c73a6167ad93ac201e74e498d64cfb146"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.6-rc.26041419"
+tiycore = "0.1.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -1064,8 +1064,7 @@ export function ProjectPanel({
           ) : null}
         </div>
 
-        <div className="relative mt-2.5 pl-5 pr-1 pb-2.5">
-          <div className="absolute bottom-0 left-[6px] top-0 w-px bg-app-border" />
+        <div className="relative mt-2.5 pr-1 pb-2.5">
           <div className="relative">
             <Input
               value={filterValue}
@@ -1120,8 +1119,7 @@ export function ProjectPanel({
         ref={treeScrollRef}
         className="min-h-0 flex-1 overflow-auto overscroll-none pr-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
       >
-        <div className="relative pl-5">
-          <div className="absolute bottom-0 left-[6px] top-0 w-px bg-app-border" />
+        <div className="relative">
           <div className={DRAWER_LIST_STACK_CLASS}>
             {isFiltering
               ? filterResults.map((match) => {


### PR DESCRIPTION
## Summary
- Remove decorative vertical border line from the filter input area
- Remove decorative vertical border line from the tree list area
- Reclaim the `pl-5` left padding space previously occupied by the border lines

## Test Plan
- [ ] Verify filter input has no left vertical line and uses full width
- [ ] Verify tree list has no left vertical line and uses full width

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)