### PR TITLE
fix(subagent): 🐛 apply URL policy to subagent LLM requests

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -2589,7 +2589,7 @@ fn normalize_provider_options(value: Option<serde_json::Value>) -> Option<serde_
     })
 }
 
-fn runtime_security_config() -> tiycore::types::SecurityConfig {
+pub(crate) fn runtime_security_config() -> tiycore::types::SecurityConfig {
     let mut security = tiycore::types::SecurityConfig::default();
     security.agent.tool_execution_timeout_secs = SUBAGENT_TOOL_TIMEOUT_SECS;
     security.url = crate::core::tiycode_url_policy();

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -141,6 +141,11 @@ impl HelperAgentOrchestrator {
         // Inject default TiyCode identification headers for all LLM API requests.
         agent.set_custom_headers(crate::core::tiycode_default_headers());
 
+        // Apply the same URL policy (including HTTPS exemptions for .oa.com domains)
+        // used by the main agent so that subagent LLM requests are not rejected
+        // when connecting to internal HTTP-only endpoints.
+        agent.set_security_config(crate::core::agent_session::runtime_security_config());
+
         if let Some(provider_options) = request.model_role.provider_options.clone() {
             agent.set_on_payload(move |payload, _model| {
                 let provider_options = provider_options.clone();


### PR DESCRIPTION
## Summary
- Subagent 创建 LLM 请求时未传递 URL 安全策略（含 `.oa.com` 域名 HTTPS 豁免），导致请求内部 HTTP-only 端点时被 Provider 校验拒绝
- 在 orchestrator 中为 subagent 添加 `set_security_config` 调用，使其继承与主 agent 相同的 URL policy
- 将 `runtime_security_config` 改为 `pub(crate)` 以便 subagent 模块可访问

## Changes
- `src-tauri/src/core/subagent/orchestrator.rs`：在 `set_custom_headers` 之后添加 `agent.set_security_config(crate::core::agent_session::runtime_security_config())`
- `src-tauri/src/core/agent_session.rs`：将 `runtime_security_config` 从 `fn` 改为 `pub(crate) fn`

## Test Plan
- [x] `cargo build` 编译通过
- [x] `cargo test --manifest-path src-tauri/Cargo.toml` 全部测试通过（13 passed）
- [ ] 手动验证：subagent 调用 `http://v2.open.venus.oa.com/llmproxy` 不再报 HTTPS 校验错误

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)