### PR TITLE
refactor(extensions): 🧹 remove pinning and unify sorting

### DIFF
--- a/src-tauri/src/commands/extensions.rs
+++ b/src-tauri/src/commands/extensions.rs
@@ -319,25 +319,6 @@ pub async fn skill_disable(
 }
 
 #[tauri::command]
-pub async fn skill_pin(
-    state: State<'_, AppState>,
-    id: String,
-    pinned: bool,
-    workspace_path: Option<String>,
-    scope: Option<String>,
-) -> Result<(), AppError> {
-    state
-        .extensions_manager
-        .pin_skill(
-            &id,
-            pinned,
-            workspace_path.as_deref(),
-            ConfigScope::from_option(scope.as_deref()),
-        )
-        .await
-}
-
-#[tauri::command]
 pub async fn skill_preview(
     state: State<'_, AppState>,
     id: String,

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::ffi::OsStr;
 use std::fs;
@@ -125,8 +126,8 @@ struct SkillStateStore {
     enabled: Vec<String>,
     #[serde(default)]
     disabled: Vec<String>,
-    #[serde(default)]
-    pinned: Vec<String>,
+    #[serde(default, alias = "pinned", skip_serializing)]
+    legacy_pinned: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
@@ -327,7 +328,7 @@ impl ExtensionsManager {
         items.extend(plugins);
         items.extend(mcps);
         items.extend(skills);
-        items.sort_by(|left, right| left.name.to_lowercase().cmp(&right.name.to_lowercase()));
+        items.sort_by(compare_extension_summaries);
         Ok(items)
     }
 
@@ -585,7 +586,7 @@ impl ExtensionsManager {
             results.push(state);
         }
 
-        results.sort_by(|left, right| left.label.to_lowercase().cmp(&right.label.to_lowercase()));
+        results.sort_by(compare_mcp_server_states);
         Ok(results)
     }
 
@@ -798,36 +799,6 @@ impl ExtensionsManager {
         .await
     }
 
-    pub async fn pin_skill(
-        &self,
-        id: &str,
-        pinned: bool,
-        workspace_path: Option<&str>,
-        scope: ConfigScope,
-    ) -> Result<(), AppError> {
-        if !self.skill_exists(id, workspace_path, scope).await? {
-            return Err(AppError::not_found(
-                ErrorSource::Settings,
-                format!("skill '{id}'"),
-            ));
-        }
-        let mut store = self.load_skill_state_store(workspace_path, scope).await?;
-        update_named_membership(&mut store.pinned, id, pinned);
-        self.save_skill_state_store(&store, workspace_path, scope)
-            .await?;
-        self.write_extension_audit(
-            if pinned {
-                "skill_pinned"
-            } else {
-                "skill_unpinned"
-            },
-            "skill",
-            id,
-            serde_json::json!({ "pinned": pinned }),
-        )
-        .await
-    }
-
     pub async fn preview_skill(
         &self,
         id: &str,
@@ -1022,7 +993,7 @@ impl ExtensionsManager {
             }
         }
 
-        items.sort_by(|left, right| left.name.to_lowercase().cmp(&right.name.to_lowercase()));
+        items.sort_by(compare_marketplace_items);
         Ok(items)
     }
 
@@ -2073,12 +2044,7 @@ impl ExtensionsManager {
             }
         }
 
-        results.sort_by(|left, right| {
-            left.record
-                .name
-                .to_lowercase()
-                .cmp(&right.record.name.to_lowercase())
-        });
+        results.sort_by(|left, right| compare_skill_records(&left.record, &right.record));
         Ok(results)
     }
 
@@ -3754,7 +3720,6 @@ fn parse_skill_markdown(
             source: source.to_string(),
             path: skill_dir.to_string_lossy().to_string(),
             enabled: true,
-            pinned: false,
             scope: "global".to_string(),
             content_preview: preview.clone(),
             prompt_budget_chars: preview.len(),
@@ -3803,15 +3768,55 @@ fn update_named_membership(values: &mut Vec<String>, id: &str, enabled: bool) {
     }
 }
 
+fn compare_extension_summaries(
+    left: &ExtensionSummaryDto,
+    right: &ExtensionSummaryDto,
+) -> Ordering {
+    let left_enabled = matches!(left.install_state, ExtensionInstallState::Enabled);
+    let right_enabled = matches!(right.install_state, ExtensionInstallState::Enabled);
+    right_enabled
+        .cmp(&left_enabled)
+        .then_with(|| {
+            let left_installed = !matches!(left.install_state, ExtensionInstallState::Discovered);
+            let right_installed = !matches!(right.install_state, ExtensionInstallState::Discovered);
+            right_installed.cmp(&left_installed)
+        })
+        .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn compare_mcp_server_states(left: &McpServerStateDto, right: &McpServerStateDto) -> Ordering {
+    right
+        .config
+        .enabled
+        .cmp(&left.config.enabled)
+        .then_with(|| left.label.to_lowercase().cmp(&right.label.to_lowercase()))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn compare_skill_records(left: &SkillRecordDto, right: &SkillRecordDto) -> Ordering {
+    right
+        .enabled
+        .cmp(&left.enabled)
+        .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+fn compare_marketplace_items(left: &MarketplaceItemDto, right: &MarketplaceItemDto) -> Ordering {
+    right
+        .enabled
+        .cmp(&left.enabled)
+        .then_with(|| right.installed.cmp(&left.installed))
+        .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
 fn apply_skill_state(record: &mut SkillRecordDto, state: &SkillStateStore) {
     if state.disabled.iter().any(|value| value == &record.id) {
         record.enabled = false;
     }
     if state.enabled.iter().any(|value| value == &record.id) {
         record.enabled = true;
-    }
-    if state.pinned.iter().any(|value| value == &record.id) {
-        record.pinned = true;
     }
 }
 

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -127,6 +127,7 @@ struct SkillStateStore {
     #[serde(default)]
     disabled: Vec<String>,
     #[serde(default, alias = "pinned", skip_serializing)]
+    #[allow(dead_code)]
     legacy_pinned: Vec<String>,
 }
 
@@ -5248,6 +5249,315 @@ mod tests {
         });
 
         (format!("http://{address}/mcp"), requests, handle)
+    }
+
+    #[test]
+    fn compare_extension_summaries_sorts_enabled_then_installed_then_name() {
+        let mut items = vec![
+            ExtensionSummaryDto {
+                id: "skill-zeta".to_string(),
+                kind: ExtensionKind::Skill,
+                name: "Zeta".to_string(),
+                version: "1.0.0".to_string(),
+                description: None,
+                source: ExtensionSourceDto::Builtin,
+                install_state: ExtensionInstallState::Discovered,
+                health: ExtensionHealth::Unknown,
+                permissions: Vec::new(),
+                tags: Vec::new(),
+            },
+            ExtensionSummaryDto {
+                id: "skill-bravo".to_string(),
+                kind: ExtensionKind::Skill,
+                name: "bravo".to_string(),
+                version: "1.0.0".to_string(),
+                description: None,
+                source: ExtensionSourceDto::Builtin,
+                install_state: ExtensionInstallState::Installed,
+                health: ExtensionHealth::Unknown,
+                permissions: Vec::new(),
+                tags: Vec::new(),
+            },
+            ExtensionSummaryDto {
+                id: "skill-alpha".to_string(),
+                kind: ExtensionKind::Skill,
+                name: "Alpha".to_string(),
+                version: "1.0.0".to_string(),
+                description: None,
+                source: ExtensionSourceDto::Builtin,
+                install_state: ExtensionInstallState::Enabled,
+                health: ExtensionHealth::Unknown,
+                permissions: Vec::new(),
+                tags: Vec::new(),
+            },
+        ];
+
+        items.sort_by(compare_extension_summaries);
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["skill-alpha", "skill-bravo", "skill-zeta"]
+        );
+    }
+
+    #[test]
+    fn compare_mcp_server_states_sorts_enabled_then_name() {
+        let mut items = vec![
+            McpServerStateDto {
+                id: "server-zeta".to_string(),
+                label: "Zeta".to_string(),
+                scope: "global".to_string(),
+                status: "ready".to_string(),
+                phase: "idle".to_string(),
+                tools: Vec::new(),
+                resources: Vec::new(),
+                stale_snapshot: false,
+                last_error: None,
+                updated_at: "2026-04-15T00:00:00Z".to_string(),
+                config: McpServerConfigDto {
+                    id: "server-zeta".to_string(),
+                    label: "Zeta".to_string(),
+                    transport: "stdio".to_string(),
+                    enabled: false,
+                    auto_start: false,
+                    command: None,
+                    args: Vec::new(),
+                    env: HashMap::new(),
+                    cwd: None,
+                    url: None,
+                    headers: HashMap::new(),
+                    timeout_ms: None,
+                },
+            },
+            McpServerStateDto {
+                id: "server-alpha".to_string(),
+                label: "Alpha".to_string(),
+                scope: "global".to_string(),
+                status: "ready".to_string(),
+                phase: "idle".to_string(),
+                tools: Vec::new(),
+                resources: Vec::new(),
+                stale_snapshot: false,
+                last_error: None,
+                updated_at: "2026-04-15T00:00:00Z".to_string(),
+                config: McpServerConfigDto {
+                    id: "server-alpha".to_string(),
+                    label: "Alpha".to_string(),
+                    transport: "stdio".to_string(),
+                    enabled: true,
+                    auto_start: true,
+                    command: None,
+                    args: Vec::new(),
+                    env: HashMap::new(),
+                    cwd: None,
+                    url: None,
+                    headers: HashMap::new(),
+                    timeout_ms: None,
+                },
+            },
+            McpServerStateDto {
+                id: "server-bravo".to_string(),
+                label: "bravo".to_string(),
+                scope: "global".to_string(),
+                status: "ready".to_string(),
+                phase: "idle".to_string(),
+                tools: Vec::new(),
+                resources: Vec::new(),
+                stale_snapshot: false,
+                last_error: None,
+                updated_at: "2026-04-15T00:00:00Z".to_string(),
+                config: McpServerConfigDto {
+                    id: "server-bravo".to_string(),
+                    label: "bravo".to_string(),
+                    transport: "stdio".to_string(),
+                    enabled: true,
+                    auto_start: true,
+                    command: None,
+                    args: Vec::new(),
+                    env: HashMap::new(),
+                    cwd: None,
+                    url: None,
+                    headers: HashMap::new(),
+                    timeout_ms: None,
+                },
+            },
+        ];
+
+        items.sort_by(compare_mcp_server_states);
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["server-alpha", "server-bravo", "server-zeta"]
+        );
+    }
+
+    #[test]
+    fn compare_skill_records_sorts_enabled_then_name() {
+        let mut items = vec![
+            SkillRecordDto {
+                id: "skill-zeta".to_string(),
+                name: "Zeta".to_string(),
+                description: None,
+                tags: Vec::new(),
+                triggers: Vec::new(),
+                tools: Vec::new(),
+                priority: None,
+                source: "builtin".to_string(),
+                path: "/tmp/zeta".to_string(),
+                enabled: false,
+                scope: "global".to_string(),
+                content_preview: String::new(),
+                prompt_budget_chars: 100,
+            },
+            SkillRecordDto {
+                id: "skill-alpha".to_string(),
+                name: "Alpha".to_string(),
+                description: None,
+                tags: Vec::new(),
+                triggers: Vec::new(),
+                tools: Vec::new(),
+                priority: None,
+                source: "builtin".to_string(),
+                path: "/tmp/alpha".to_string(),
+                enabled: true,
+                scope: "global".to_string(),
+                content_preview: String::new(),
+                prompt_budget_chars: 100,
+            },
+            SkillRecordDto {
+                id: "skill-bravo".to_string(),
+                name: "bravo".to_string(),
+                description: None,
+                tags: Vec::new(),
+                triggers: Vec::new(),
+                tools: Vec::new(),
+                priority: None,
+                source: "builtin".to_string(),
+                path: "/tmp/bravo".to_string(),
+                enabled: true,
+                scope: "global".to_string(),
+                content_preview: String::new(),
+                prompt_budget_chars: 100,
+            },
+        ];
+
+        items.sort_by(compare_skill_records);
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["skill-alpha", "skill-bravo", "skill-zeta"]
+        );
+    }
+
+    #[test]
+    fn compare_marketplace_items_sorts_enabled_then_installed_then_name() {
+        let mut items = vec![
+            MarketplaceItemDto {
+                id: "market-zeta".to_string(),
+                source_id: "source".to_string(),
+                source_name: "Source".to_string(),
+                kind: "plugin".to_string(),
+                name: "Zeta".to_string(),
+                version: "1.0.0".to_string(),
+                summary: "summary".to_string(),
+                description: "description".to_string(),
+                publisher: "publisher".to_string(),
+                tags: Vec::new(),
+                hooks: Vec::new(),
+                command_names: Vec::new(),
+                mcp_servers: Vec::new(),
+                skill_names: Vec::new(),
+                path: "/tmp/zeta".to_string(),
+                installable: true,
+                installed: false,
+                enabled: false,
+            },
+            MarketplaceItemDto {
+                id: "market-bravo".to_string(),
+                source_id: "source".to_string(),
+                source_name: "Source".to_string(),
+                kind: "plugin".to_string(),
+                name: "bravo".to_string(),
+                version: "1.0.0".to_string(),
+                summary: "summary".to_string(),
+                description: "description".to_string(),
+                publisher: "publisher".to_string(),
+                tags: Vec::new(),
+                hooks: Vec::new(),
+                command_names: Vec::new(),
+                mcp_servers: Vec::new(),
+                skill_names: Vec::new(),
+                path: "/tmp/bravo".to_string(),
+                installable: true,
+                installed: true,
+                enabled: false,
+            },
+            MarketplaceItemDto {
+                id: "market-alpha".to_string(),
+                source_id: "source".to_string(),
+                source_name: "Source".to_string(),
+                kind: "plugin".to_string(),
+                name: "Alpha".to_string(),
+                version: "1.0.0".to_string(),
+                summary: "summary".to_string(),
+                description: "description".to_string(),
+                publisher: "publisher".to_string(),
+                tags: Vec::new(),
+                hooks: Vec::new(),
+                command_names: Vec::new(),
+                mcp_servers: Vec::new(),
+                skill_names: Vec::new(),
+                path: "/tmp/alpha".to_string(),
+                installable: true,
+                installed: true,
+                enabled: true,
+            },
+        ];
+
+        items.sort_by(compare_marketplace_items);
+
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["market-alpha", "market-bravo", "market-zeta"]
+        );
+    }
+
+    #[test]
+    fn skill_state_store_deserializes_legacy_pinned_alias_without_serializing_it() {
+        let store: SkillStateStore = serde_json::from_value(serde_json::json!({
+            "enabled": ["skill-a"],
+            "disabled": ["skill-b"],
+            "pinned": ["skill-legacy"]
+        }))
+        .expect("deserialize skill state");
+
+        assert_eq!(store.enabled, vec!["skill-a"]);
+        assert_eq!(store.disabled, vec!["skill-b"]);
+        assert_eq!(store.legacy_pinned, vec!["skill-legacy"]);
+
+        let serialized = serde_json::to_value(&store).expect("serialize skill state");
+        assert_eq!(
+            serialized.get("enabled"),
+            Some(&serde_json::json!(["skill-a"]))
+        );
+        assert_eq!(
+            serialized.get("disabled"),
+            Some(&serde_json::json!(["skill-b"]))
+        );
+        assert!(serialized.get("pinned").is_none());
+        assert!(serialized.get("legacyPinned").is_none());
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -285,7 +285,6 @@ pub fn run() {
             commands::extensions::skill_rescan,
             commands::extensions::skill_enable,
             commands::extensions::skill_disable,
-            commands::extensions::skill_pin,
             commands::extensions::skill_preview,
             // Threads
             commands::thread::thread_list,

--- a/src-tauri/src/model/extensions.rs
+++ b/src-tauri/src/model/extensions.rs
@@ -209,7 +209,6 @@ pub struct SkillRecordDto {
     pub source: String,
     pub path: String,
     pub enabled: bool,
-    pub pinned: bool,
     pub scope: String,
     pub content_preview: String,
     pub prompt_budget_chars: usize,

--- a/src/modules/extensions-center/ui/extensions-center-overlay.tsx
+++ b/src/modules/extensions-center/ui/extensions-center-overlay.tsx
@@ -81,6 +81,16 @@ type PluginCollectionItem = {
   hooks: PluginHookGroup[];
 };
 
+function comparePluginCollectionItems(left: PluginCollectionItem, right: PluginCollectionItem) {
+  if (left.enabled !== right.enabled) {
+    return left.enabled ? -1 : 1;
+  }
+  if (left.installed !== right.installed) {
+    return left.installed ? -1 : 1;
+  }
+  return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+}
+
 function PluginIcon() {
   return (
     <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl border border-app-border bg-app-canvas shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
@@ -560,12 +570,7 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
         })),
     );
 
-    return combined.sort((left, right) => {
-      if (left.installed !== right.installed) {
-        return left.installed ? -1 : 1;
-      }
-      return left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
-    });
+    return combined.sort(comparePluginCollectionItems);
   }, [
     props.extensions,
     props.marketplaceItems,

--- a/src/shared/types/extensions.ts
+++ b/src/shared/types/extensions.ts
@@ -145,7 +145,6 @@ export type SkillRecord = {
   source: string;
   path: string;
   enabled: boolean;
-  pinned: boolean;
   scope: string;
   contentPreview: string;
   promptBudgetChars: number;


### PR DESCRIPTION
## Summary
- Remove legacy skill pinning state, command wiring, and exposed types.
- Standardize Extensions Center sorting to `enabled > installed > name` for skills, MCP, and plugins.
- Update the merged plugin list ordering in the Extensions Center UI to match backend behavior.

## Test Plan
- [x] Run `cargo fmt --manifest-path src-tauri/Cargo.toml`
- [x] Run `~/.nvm/versions/node/v22.14.0/bin/npm run typecheck`
- [ ] Manually verify Extensions Center ordering for skills, MCP, and plugins

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
