### PR TITLE
fix(extensions): 🐛 Support legacy workspace config paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 dist
 dist-ssr
 *.local
+*.local.json
 .npm-cache
 .tmp-tauri-scaffold
 .superpowers

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -1684,7 +1684,7 @@ impl ExtensionsManager {
     ) -> Result<Vec<McpServerConfigInput>, AppError> {
         let file = match scope {
             ConfigScope::Global => global_mcp_path(),
-            ConfigScope::Workspace => workspace_mcp_path(workspace_path)?,
+            ConfigScope::Workspace => workspace_mcp_read_path(workspace_path)?,
         };
         Ok(self
             .read_json_file_with_diagnostics::<McpConfigFile>(&file, "mcp", scope)?
@@ -2089,7 +2089,7 @@ impl ExtensionsManager {
     ) -> Result<SkillStateStore, AppError> {
         let file = match scope {
             ConfigScope::Global => global_skills_config_path(),
-            ConfigScope::Workspace => workspace_skills_config_path(workspace_path)?,
+            ConfigScope::Workspace => workspace_skills_read_path(workspace_path)?,
         };
         Ok(self
             .read_json_file_with_diagnostics(&file, "skills", scope)?
@@ -3537,7 +3537,29 @@ fn workspace_mcp_path(workspace_path: Option<&str>) -> Result<PathBuf, AppError>
             "workspace path is required for workspace-scoped MCP config",
         )
     })?;
+    Ok(PathBuf::from(workspace_path).join(".tiy/mcp.local.json"))
+}
+
+fn legacy_workspace_mcp_path(workspace_path: Option<&str>) -> Result<PathBuf, AppError> {
+    let workspace_path = workspace_path.ok_or_else(|| {
+        AppError::validation(
+            ErrorSource::Settings,
+            "workspace path is required for workspace-scoped MCP config",
+        )
+    })?;
     Ok(PathBuf::from(workspace_path).join(".tiy/mcp.json"))
+}
+
+fn workspace_mcp_read_path(workspace_path: Option<&str>) -> Result<PathBuf, AppError> {
+    let path = workspace_mcp_path(workspace_path)?;
+    if path.exists() {
+        return Ok(path);
+    }
+    let legacy_path = legacy_workspace_mcp_path(workspace_path)?;
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+    Ok(path)
 }
 
 fn global_skills_config_path() -> PathBuf {
@@ -3551,7 +3573,29 @@ fn workspace_skills_config_path(workspace_path: Option<&str>) -> Result<PathBuf,
             "workspace path is required for workspace-scoped skill config",
         )
     })?;
+    Ok(PathBuf::from(workspace_path).join(".tiy/skills.local.json"))
+}
+
+fn legacy_workspace_skills_config_path(workspace_path: Option<&str>) -> Result<PathBuf, AppError> {
+    let workspace_path = workspace_path.ok_or_else(|| {
+        AppError::validation(
+            ErrorSource::Settings,
+            "workspace path is required for workspace-scoped skill config",
+        )
+    })?;
     Ok(PathBuf::from(workspace_path).join(".tiy/skills.json"))
+}
+
+fn workspace_skills_read_path(workspace_path: Option<&str>) -> Result<PathBuf, AppError> {
+    let path = workspace_skills_config_path(workspace_path)?;
+    if path.exists() {
+        return Ok(path);
+    }
+    let legacy_path = legacy_workspace_skills_config_path(workspace_path)?;
+    if legacy_path.exists() {
+        return Ok(legacy_path);
+    }
+    Ok(path)
 }
 
 fn global_marketplace_sources_path() -> PathBuf {


### PR DESCRIPTION
## Summary
- Read workspace MCP config from `.tiy/mcp.local.json` first and fall back to the legacy `.tiy/mcp.json` path.
- Read workspace skills config from `.tiy/skills.local.json` first and fall back to the legacy `.tiy/skills.json` path.
- Ignore `*.local.json` workspace-local config files in git.

## Test Plan
- [ ] Verify workspace-scoped MCP config loads from `.tiy/mcp.local.json`.
- [ ] Verify legacy `.tiy/mcp.json` still loads when no local file exists.
- [ ] Verify workspace-scoped skills config follows the same fallback behavior.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
