### PR TITLE
feat(workbench-shell): ✨ 优化任务历史与 Profile 选择器交互

### DIFF
--- a/src/modules/workbench-shell/ui/task-stage-history-card.tsx
+++ b/src/modules/workbench-shell/ui/task-stage-history-card.tsx
@@ -1,8 +1,13 @@
 "use client";
 
-import { CheckCircle2Icon, ListChecksIcon, XCircleIcon } from "lucide-react";
+import { CheckCircle2Icon, ChevronDownIcon, ListChecksIcon, XCircleIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 import { cn } from "@/shared/lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/shared/ui/collapsible";
 import type { TaskBoardDto } from "../model/task-board";
 import { computeProgress, hasFailedTasks, isBoardCompleted } from "../model/task-board";
 
@@ -96,13 +101,23 @@ export const TaskHistoryTimeline = ({
 
   return (
     <div className={cn("space-y-2", className)} {...props}>
-      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-2">
-        <ListChecksIcon className="size-3" />
-        <span>Task History</span>
-      </div>
-      {historyBoards.map((board) => (
-        <TaskStageHistoryCard key={board.id} board={board} />
-      ))}
+      <Collapsible defaultOpen={false}>
+        <CollapsibleTrigger className="group flex w-full items-center justify-between gap-2 rounded-md text-xs text-muted-foreground transition-colors hover:text-foreground">
+          <div className="flex items-center gap-2">
+            <ListChecksIcon className="size-3" />
+            <span>Task History</span>
+            <span className="rounded-md bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-subtle">
+              {historyBoards.length}
+            </span>
+          </div>
+          <ChevronDownIcon className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="space-y-2 pt-2 outline-none data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 data-[state=closed]:animate-out data-[state=open]:animate-in">
+          {historyBoards.map((board) => (
+            <TaskStageHistoryCard key={board.id} board={board} />
+          ))}
+        </CollapsibleContent>
+      </Collapsible>
     </div>
   );
 };

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1638,7 +1638,11 @@ export function WorkbenchPromptComposer({
                           <ProfileInlineIdentity badge={false} profile={activeProfile} providers={providers} showModel={false} />
                         </PromptInputButton>
                       </ModelSelectorTrigger>
-                      <ModelSelectorContent commandProps={{ value: activeAgentProfileId ?? undefined }} title="Profile Selector">
+                      <ModelSelectorContent
+                        commandProps={{ value: activeAgentProfileId ?? undefined }}
+                        showCloseButton={false}
+                        title="Profile Selector"
+                      >
                         <ModelSelectorList>
                           <ModelSelectorEmpty>{t("composer.noProfileAvailable")}</ModelSelectorEmpty>
                           <ModelSelectorGroup heading="Agent Profiles">


### PR DESCRIPTION
## Summary
- 将 Thread 中的 `Task History` 改为默认折叠，并支持点击标题展开。
- 移除会话页 `Agent Profiles` 选择面板右上角的关闭按钮，保持交互更简洁。
- 仅修改 `workbench-shell` 下两个 UI 组件，变更范围集中。

## Test Plan
- [x] 运行 `npm run typecheck`
- [x] 运行 `npm run test:unit -- --run --reporter=dot`
- [ ] 手动验证 Thread 页面中 `Task History` 默认折叠且可正常展开/收起
- [ ] 手动验证会话页 `Agent Profiles` 面板不再显示关闭按钮

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
