### PR TITLE
fix(mcp): 🐛 Resolve login-shell command lookup

### DIFF
--- a/src-tauri/src/core/executors/process.rs
+++ b/src-tauri/src/core/executors/process.rs
@@ -51,7 +51,7 @@ pub async fn run_command(
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    let child = cmd.spawn().map_err(|e| {
+    let mut child = cmd.spawn().map_err(|e| {
         AppError::recoverable(
             crate::model::errors::ErrorSource::Tool,
             "tool.shell.spawn_failed",
@@ -59,24 +59,55 @@ pub async fn run_command(
         )
     })?;
 
+    // Take pipe handles before async operations so we can drain them
+    // concurrently with `child.wait()` and still explicitly kill+reap
+    // the child on timeout (preventing zombie processes).
+    let child_stdout = child.stdout.take();
+    let child_stderr = child.stderr.take();
+
+    let stdout_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut out) = child_stdout {
+            use tokio::io::AsyncReadExt;
+            let _ = out.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
+    let stderr_task = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        if let Some(mut err) = child_stderr {
+            use tokio::io::AsyncReadExt;
+            let _ = err.read_to_end(&mut buf).await;
+        }
+        buf
+    });
+
     let timeout = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
     tokio::pin!(timeout);
 
-    let output = tokio::select! {
-        result = child.wait_with_output() => Some(result),
-        _ = &mut timeout => None,
+    let wait_result = tokio::select! {
+        result = child.wait() => Some(result),
+        _ = &mut timeout => {
+            // Explicitly kill and reap the child to prevent zombie processes.
+            let _ = child.kill().await;
+            let _ = child.wait().await;
+            None
+        },
     };
 
-    match output {
-        Some(Ok(output)) => {
-            let exit_code = output.status.code().unwrap_or(-1);
+    match wait_result {
+        Some(Ok(status)) => {
+            let stdout_bytes = stdout_task.await.unwrap_or_default();
+            let stderr_bytes = stderr_task.await.unwrap_or_default();
+            let exit_code = status.code().unwrap_or(-1);
             let (stdout, stdout_truncated) =
-                truncate_tail_bytes(&output.stdout, COMMAND_MAX_BYTES, COMMAND_MAX_LINES);
+                truncate_tail_bytes(&stdout_bytes, COMMAND_MAX_BYTES, COMMAND_MAX_LINES);
             let (stderr, stderr_truncated) =
-                truncate_tail_bytes(&output.stderr, COMMAND_MAX_BYTES, COMMAND_MAX_LINES);
+                truncate_tail_bytes(&stderr_bytes, COMMAND_MAX_BYTES, COMMAND_MAX_LINES);
 
             Ok(ToolOutput {
-                success: output.status.success(),
+                success: status.success(),
                 result: serde_json::json!({
                     "command": command,
                     "exitCode": exit_code,
@@ -94,12 +125,17 @@ pub async fn run_command(
                 "command": command,
             }),
         }),
-        None => Ok(ToolOutput {
-            success: false,
-            result: serde_json::json!({
-                "error": format!("Command timed out after {timeout_secs}s"),
-                "command": command,
-            }),
-        }),
+        None => {
+            // Abort pipe reader tasks on timeout
+            stdout_task.abort();
+            stderr_task.abort();
+            Ok(ToolOutput {
+                success: false,
+                result: serde_json::json!({
+                    "error": format!("Command timed out after {timeout_secs}s"),
+                    "command": command,
+                }),
+            })
+        }
     }
 }

--- a/src-tauri/src/core/executors/process.rs
+++ b/src-tauri/src/core/executors/process.rs
@@ -47,14 +47,28 @@ pub async fn run_command(
         }
     };
     cmd.current_dir(cwd)
+        .kill_on_drop(true)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped());
 
-    let result =
-        tokio::time::timeout(std::time::Duration::from_secs(timeout_secs), cmd.output()).await;
+    let child = cmd.spawn().map_err(|e| {
+        AppError::recoverable(
+            crate::model::errors::ErrorSource::Tool,
+            "tool.shell.spawn_failed",
+            format!("Command execution failed: {e}"),
+        )
+    })?;
 
-    match result {
-        Ok(Ok(output)) => {
+    let timeout = tokio::time::sleep(std::time::Duration::from_secs(timeout_secs));
+    tokio::pin!(timeout);
+
+    let output = tokio::select! {
+        result = child.wait_with_output() => Some(result),
+        _ = &mut timeout => None,
+    };
+
+    match output {
+        Some(Ok(output)) => {
             let exit_code = output.status.code().unwrap_or(-1);
             let (stdout, stdout_truncated) =
                 truncate_tail_bytes(&output.stdout, COMMAND_MAX_BYTES, COMMAND_MAX_LINES);
@@ -73,14 +87,14 @@ pub async fn run_command(
                 }),
             })
         }
-        Ok(Err(e)) => Ok(ToolOutput {
+        Some(Err(e)) => Ok(ToolOutput {
             success: false,
             result: serde_json::json!({
                 "error": format!("Command execution failed: {e}"),
                 "command": command,
             }),
         }),
-        Err(_) => Ok(ToolOutput {
+        None => Ok(ToolOutput {
             success: false,
             result: serde_json::json!({
                 "error": format!("Command timed out after {timeout_secs}s"),

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -188,7 +188,7 @@ async fn resolve_command_via_login_shell(command: &str) -> Option<PathBuf> {
         return None;
     }
 
-    let shell_command = format!("command -v {}", command);
+    let shell_command = format!("builtin command -v {}", command);
     let mut process = build_unix_shell_command(&shell_command, UnixShellMode::Login);
     process
         .stdout(std::process::Stdio::piped())

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -302,10 +302,24 @@ mod tests {
         let _lock = path_env_lock()
             .lock()
             .unwrap_or_else(|error| error.into_inner());
-        let _guard = PathEnvGuard::set(std::path::Path::new("/usr/bin:/bin"));
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let command_path = temp_dir.path().join("test-shell-runtime-command");
+        std::fs::write(&command_path, "#!/bin/sh\nexit 0\n").expect("write command");
 
-        let resolved = resolve_command_path("sh").await;
-        assert_eq!(resolved, Some(PathBuf::from("/bin/sh")));
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = std::fs::metadata(&command_path)
+                .expect("metadata")
+                .permissions();
+            permissions.set_mode(0o755);
+            std::fs::set_permissions(&command_path, permissions).expect("set permissions");
+        }
+
+        let _guard = PathEnvGuard::set(temp_dir.path());
+
+        let resolved = resolve_command_path("test-shell-runtime-command").await;
+        assert_eq!(resolved, Some(command_path));
     }
 
     #[cfg(target_os = "macos")]

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -1,14 +1,15 @@
-use std::ffi::OsString;
-#[cfg(target_os = "windows")]
+use std::ffi::{OsStr, OsString};
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use std::path::Path;
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::time::Duration;
 
 #[cfg(not(target_os = "windows"))]
 use tokio::process::Command;
 
-#[cfg(not(target_os = "windows"))]
-pub(crate) const LOGIN_SHELL_COMMAND_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(1500);
+#[cfg(target_os = "macos")]
+pub(crate) const PATH_HELPER_COMMAND_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(1500);
 
 #[cfg(not(target_os = "windows"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -57,9 +58,13 @@ pub(crate) fn build_unix_shell_command(command: &str, mode: UnixShellMode) -> Co
 
 pub(crate) fn find_command_on_path(command: &str) -> Option<PathBuf> {
     let path_value = std::env::var_os("PATH")?;
+    find_command_on_path_value(command, &path_value)
+}
+
+fn find_command_on_path_value(command: &str, path_value: &OsStr) -> Option<PathBuf> {
     let candidates = executable_candidates(command);
 
-    for directory in std::env::split_paths(&path_value) {
+    for directory in std::env::split_paths(path_value) {
         for candidate in &candidates {
             let path = directory.join(candidate);
             if path.is_file() {
@@ -85,7 +90,7 @@ pub(crate) async fn resolve_command_path(command: &str) -> Option<PathBuf> {
         return Some(path);
     }
 
-    discover_command_path_from_login_shell(command).await
+    discover_command_path_from_platform_defaults(command).await
 }
 
 #[cfg(target_os = "windows")]
@@ -120,16 +125,25 @@ pub(crate) fn explicit_command_path(command: &str) -> Option<PathBuf> {
     None
 }
 
-#[cfg(not(target_os = "windows"))]
-async fn discover_command_path_from_login_shell(command: &str) -> Option<PathBuf> {
-    let quoted_command = shell_single_quote(command.trim());
-    let script = format!("command -v -- {quoted_command} 2>/dev/null");
-    let mut process = build_unix_shell_command(&script, UnixShellMode::Login);
+#[cfg(not(target_os = "macos"))]
+async fn discover_command_path_from_platform_defaults(_command: &str) -> Option<PathBuf> {
+    None
+}
+
+#[cfg(target_os = "macos")]
+async fn discover_command_path_from_platform_defaults(command: &str) -> Option<PathBuf> {
+    let helper_path = Path::new("/usr/libexec/path_helper");
+    if !helper_path.is_file() {
+        return None;
+    }
+
+    let mut process = Command::new(helper_path);
+    process.arg("-s");
     process
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::null());
 
-    let output = tokio::time::timeout(LOGIN_SHELL_COMMAND_RESOLUTION_TIMEOUT, process.output())
+    let output = tokio::time::timeout(PATH_HELPER_COMMAND_RESOLUTION_TIMEOUT, process.output())
         .await
         .ok()?
         .ok()?;
@@ -138,18 +152,34 @@ async fn discover_command_path_from_login_shell(command: &str) -> Option<PathBuf
         return None;
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    let resolved = stdout
-        .lines()
-        .map(str::trim)
-        .find(|line| !line.is_empty())?;
-    let path = PathBuf::from(resolved);
-    path.is_file().then_some(path)
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let path_value = parse_path_helper_path(&stdout)?;
+    find_command_on_path_value(command, path_value.as_os_str())
 }
 
-#[cfg(not(target_os = "windows"))]
-fn shell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', r#"'\''"#))
+#[cfg(target_os = "macos")]
+fn parse_path_helper_path(output: &str) -> Option<OsString> {
+    for statement in output.split(';') {
+        let trimmed = statement.trim();
+        let Some(value) = trimmed.strip_prefix("PATH=") else {
+            continue;
+        };
+        let unquoted = value
+            .strip_prefix('"')
+            .and_then(|inner| inner.strip_suffix('"'))
+            .or_else(|| {
+                value
+                    .strip_prefix('\'')
+                    .and_then(|inner| inner.strip_suffix('\''))
+            })
+            .unwrap_or(value)
+            .trim();
+        if !unquoted.is_empty() {
+            return Some(OsString::from(unquoted));
+        }
+    }
+
+    None
 }
 
 fn executable_candidates(command: &str) -> Vec<OsString> {
@@ -278,9 +308,17 @@ mod tests {
         assert_eq!(resolved, Some(PathBuf::from("/bin/sh")));
     }
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "macos")]
     #[test]
-    fn shell_single_quote_escapes_single_quotes() {
-        assert_eq!(shell_single_quote("ab'cd"), "'ab'\\''cd'".to_string());
+    fn parse_path_helper_path_reads_exported_path_assignment() {
+        let parsed = parse_path_helper_path(
+            r#"PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"; export PATH;"#,
+        );
+        assert_eq!(
+            parsed,
+            Some(OsString::from(
+                "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+            ))
+        );
     }
 }

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -2,9 +2,13 @@ use std::ffi::OsString;
 #[cfg(target_os = "windows")]
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[cfg(not(target_os = "windows"))]
 use tokio::process::Command;
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) const LOGIN_SHELL_COMMAND_RESOLUTION_TIMEOUT: Duration = Duration::from_millis(1500);
 
 #[cfg(not(target_os = "windows"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +71,87 @@ pub(crate) fn find_command_on_path(command: &str) -> Option<PathBuf> {
     None
 }
 
+#[cfg(not(target_os = "windows"))]
+pub(crate) async fn resolve_command_path(command: &str) -> Option<PathBuf> {
+    if command.trim().is_empty() {
+        return None;
+    }
+
+    if let Some(path) = explicit_command_path(command) {
+        return path.is_file().then_some(path);
+    }
+
+    if let Some(path) = find_command_on_path(command) {
+        return Some(path);
+    }
+
+    discover_command_path_from_login_shell(command).await
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) async fn resolve_command_path(command: &str) -> Option<PathBuf> {
+    if command.trim().is_empty() {
+        return None;
+    }
+
+    if let Some(path) = explicit_command_path(command) {
+        return path.is_file().then_some(path);
+    }
+
+    find_command_on_path(command)
+}
+
+pub(crate) fn explicit_command_path(command: &str) -> Option<PathBuf> {
+    let trimmed = command.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(trimmed);
+    if path.is_absolute() || trimmed.contains(std::path::MAIN_SEPARATOR) {
+        return Some(path);
+    }
+
+    #[cfg(target_os = "windows")]
+    if trimmed.contains('/') || trimmed.contains('\\') {
+        return Some(path);
+    }
+
+    None
+}
+
+#[cfg(not(target_os = "windows"))]
+async fn discover_command_path_from_login_shell(command: &str) -> Option<PathBuf> {
+    let quoted_command = shell_single_quote(command.trim());
+    let script = format!("command -v -- {quoted_command} 2>/dev/null");
+    let mut process = build_unix_shell_command(&script, UnixShellMode::Login);
+    process
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null());
+
+    let output = tokio::time::timeout(LOGIN_SHELL_COMMAND_RESOLUTION_TIMEOUT, process.output())
+        .await
+        .ok()?
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let resolved = stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    let path = PathBuf::from(resolved);
+    path.is_file().then_some(path)
+}
+
+#[cfg(not(target_os = "windows"))]
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', r#"'\''"#))
+}
+
 fn executable_candidates(command: &str) -> Vec<OsString> {
     #[cfg(target_os = "windows")]
     {
@@ -98,6 +183,46 @@ fn executable_candidates(command: &str) -> Vec<OsString> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    fn path_env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    struct PathEnvGuard {
+        original: Option<OsString>,
+    }
+
+    impl PathEnvGuard {
+        fn set(path: &std::path::Path) -> Self {
+            let original = std::env::var_os("PATH");
+            // SAFETY: tests serialize PATH mutation with a process-wide mutex.
+            unsafe {
+                std::env::set_var("PATH", path.as_os_str());
+            }
+            Self { original }
+        }
+    }
+
+    impl Drop for PathEnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(value) => {
+                    // SAFETY: tests serialize PATH mutation with a process-wide mutex.
+                    unsafe {
+                        std::env::set_var("PATH", value);
+                    }
+                }
+                None => {
+                    // SAFETY: tests serialize PATH mutation with a process-wide mutex.
+                    unsafe {
+                        std::env::remove_var("PATH");
+                    }
+                }
+            }
+        }
+    }
 
     #[cfg(not(target_os = "windows"))]
     #[test]
@@ -115,5 +240,47 @@ mod tests {
             unix_shell_command_args(UnixShellMode::NonLogin, "echo hi"),
             vec!["-c", "echo hi"]
         );
+    }
+
+    #[test]
+    fn explicit_command_path_detects_absolute_and_relative_paths() {
+        let absolute = explicit_command_path("/usr/bin/env");
+        assert_eq!(absolute, Some(PathBuf::from("/usr/bin/env")));
+
+        let relative = explicit_command_path("./node_modules/.bin/foo");
+        assert_eq!(relative, Some(PathBuf::from("./node_modules/.bin/foo")));
+
+        let bare = explicit_command_path("npx");
+        assert_eq!(bare, None);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn resolve_command_path_returns_explicit_existing_path_without_path_lookup() {
+        let _lock = path_env_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _guard = PathEnvGuard::set(std::path::Path::new(""));
+
+        let resolved = resolve_command_path("/bin/sh").await;
+        assert_eq!(resolved, Some(PathBuf::from("/bin/sh")));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn resolve_command_path_finds_bare_command_on_process_path() {
+        let _lock = path_env_lock()
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let _guard = PathEnvGuard::set(std::path::Path::new("/usr/bin:/bin"));
+
+        let resolved = resolve_command_path("sh").await;
+        assert_eq!(resolved, Some(PathBuf::from("/bin/sh")));
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn shell_single_quote_escapes_single_quotes() {
+        assert_eq!(shell_single_quote("ab'cd"), "'ab'\\''cd'".to_string());
     }
 }

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -125,13 +125,22 @@ pub(crate) fn explicit_command_path(command: &str) -> Option<PathBuf> {
     None
 }
 
-#[cfg(not(target_os = "macos"))]
-async fn discover_command_path_from_platform_defaults(_command: &str) -> Option<PathBuf> {
-    None
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+async fn discover_command_path_from_platform_defaults(command: &str) -> Option<PathBuf> {
+    resolve_command_via_login_shell(command).await
 }
 
 #[cfg(target_os = "macos")]
 async fn discover_command_path_from_platform_defaults(command: &str) -> Option<PathBuf> {
+    if let Some(path) = resolve_command_via_path_helper(command).await {
+        return Some(path);
+    }
+
+    resolve_command_via_login_shell(command).await
+}
+
+#[cfg(target_os = "macos")]
+async fn resolve_command_via_path_helper(command: &str) -> Option<PathBuf> {
     let helper_path = Path::new("/usr/libexec/path_helper");
     if !helper_path.is_file() {
         return None;
@@ -155,6 +164,58 @@ async fn discover_command_path_from_platform_defaults(command: &str) -> Option<P
     let stdout = String::from_utf8_lossy(&output.stdout);
     let path_value = parse_path_helper_path(&stdout)?;
     find_command_on_path_value(command, path_value.as_os_str())
+}
+
+/// Resolve a bare command name by asking the user's login shell.
+///
+/// This covers tools whose PATH entries are injected by shell startup files
+/// (e.g. nvm, fnm, pyenv, rustup) and would not appear in the process PATH
+/// or macOS `path_helper` output.
+#[cfg(not(target_os = "windows"))]
+async fn resolve_command_via_login_shell(command: &str) -> Option<PathBuf> {
+    use std::time::Duration;
+
+    const LOGIN_SHELL_TIMEOUT: Duration = Duration::from_millis(3000);
+
+    // Sanitize: only allow simple command names to avoid shell injection.
+    if command.contains(|ch: char| {
+        ch.is_whitespace()
+            || matches!(
+                ch,
+                ';' | '&' | '|' | '$' | '`' | '(' | ')' | '{' | '}' | '<' | '>' | '\'' | '"' | '\\'
+            )
+    }) {
+        return None;
+    }
+
+    let shell_command = format!("command -v {}", command);
+    let mut process = build_unix_shell_command(&shell_command, UnixShellMode::Login);
+    process
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .stdin(std::process::Stdio::null());
+
+    let output = tokio::time::timeout(LOGIN_SHELL_TIMEOUT, process.output())
+        .await
+        .ok()?
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let resolved = stdout.trim();
+    if resolved.is_empty() {
+        return None;
+    }
+
+    let path = PathBuf::from(resolved);
+    if path.is_absolute() && path.is_file() {
+        Some(path)
+    } else {
+        None
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -334,5 +395,34 @@ mod tests {
                 "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
             ))
         );
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn resolve_command_via_login_shell_finds_common_command() {
+        // `sh` should be resolvable via any login shell.
+        let resolved = resolve_command_via_login_shell("sh").await;
+        assert!(
+            resolved.is_some(),
+            "login shell should resolve 'sh' to an absolute path"
+        );
+        let path = resolved.unwrap();
+        assert!(path.is_absolute());
+        assert!(path.is_file());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn resolve_command_via_login_shell_rejects_shell_metacharacters() {
+        let resolved = resolve_command_via_login_shell("echo; rm -rf /").await;
+        assert_eq!(resolved, None);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[tokio::test]
+    async fn resolve_command_via_login_shell_returns_none_for_nonexistent_command() {
+        let resolved =
+            resolve_command_via_login_shell("this-command-definitely-does-not-exist-xyz").await;
+        assert_eq!(resolved, None);
     }
 }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -4367,6 +4367,58 @@ fn build_streamable_http_client(
         })
 }
 
+/// Expands `${VAR}` and `$VAR` patterns in a string using the current process
+/// environment. Unresolved variables are left as-is so the user sees what failed.
+fn expand_env_vars(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '$' {
+            let braced = chars.peek() == Some(&'{');
+            if braced {
+                chars.next(); // consume '{'
+            }
+            let mut var_name = String::new();
+            while let Some(&c) = chars.peek() {
+                if braced {
+                    if c == '}' {
+                        chars.next(); // consume '}'
+                        break;
+                    }
+                    var_name.push(c);
+                    chars.next();
+                } else if c.is_ascii_alphanumeric() || c == '_' {
+                    var_name.push(c);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if var_name.is_empty() {
+                result.push('$');
+                if braced {
+                    result.push('{');
+                }
+            } else if let Ok(val) = std::env::var(&var_name) {
+                result.push_str(&val);
+            } else {
+                // Leave unresolved variable as-is for debuggability
+                if braced {
+                    result.push_str(&format!("${{{}}}", var_name));
+                } else {
+                    result.push('$');
+                    result.push_str(&var_name);
+                }
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    result
+}
+
 fn build_streamable_http_headers(
     config: &McpServerConfigInput,
     session: Option<&StreamableHttpSession>,
@@ -4411,7 +4463,8 @@ fn build_streamable_http_headers(
                     format!("Invalid MCP header name '{key}': {error}"),
                 )
             })?;
-            let value = HeaderValue::from_str(value).map_err(|error| {
+            let expanded = expand_env_vars(value);
+            let value = HeaderValue::from_str(&expanded).map_err(|error| {
                 AppError::validation(
                     ErrorSource::Settings,
                     format!("Invalid MCP header value for '{key}': {error}"),
@@ -4753,7 +4806,7 @@ async fn spawn_stdio_mcp_process(
     command.stderr(std::process::Stdio::piped());
     if let Some(env) = &config.env {
         for (key, value) in env {
-            command.env(key, value);
+            command.env(key, expand_env_vars(value));
         }
     }
 
@@ -6277,6 +6330,48 @@ rl.on("line", (line) => {
         assert_eq!(diagnostics[0].area, "plugins");
         assert_eq!(diagnostics[0].kind, ConfigDiagnosticKind::InvalidJson);
         assert!(diagnostics[0].file_path.contains("plugins.json"));
+    }
+
+    #[test]
+    fn expand_env_vars_braced_syntax() {
+        std::env::set_var("_TEST_EXPAND_TOKEN", "my_secret_123");
+        let result = expand_env_vars("Bearer ${_TEST_EXPAND_TOKEN}");
+        assert_eq!(result, "Bearer my_secret_123");
+        std::env::remove_var("_TEST_EXPAND_TOKEN");
+    }
+
+    #[test]
+    fn expand_env_vars_unbraced_syntax() {
+        std::env::set_var("_TEST_EXPAND_PLAIN", "value_abc");
+        let result = expand_env_vars("prefix-$_TEST_EXPAND_PLAIN-suffix");
+        assert_eq!(result, "prefix-value_abc-suffix");
+        std::env::remove_var("_TEST_EXPAND_PLAIN");
+    }
+
+    #[test]
+    fn expand_env_vars_missing_variable_preserved() {
+        let result = expand_env_vars("Bearer ${_NONEXISTENT_VAR_12345}");
+        assert_eq!(result, "Bearer ${_NONEXISTENT_VAR_12345}");
+    }
+
+    #[test]
+    fn expand_env_vars_no_variables() {
+        assert_eq!(expand_env_vars("plain text"), "plain text");
+    }
+
+    #[test]
+    fn expand_env_vars_dollar_sign_alone() {
+        assert_eq!(expand_env_vars("price is $"), "price is $");
+    }
+
+    #[test]
+    fn expand_env_vars_multiple_vars() {
+        std::env::set_var("_TEST_A", "hello");
+        std::env::set_var("_TEST_B", "world");
+        let result = expand_env_vars("${_TEST_A} $_TEST_B!");
+        assert_eq!(result, "hello world!");
+        std::env::remove_var("_TEST_A");
+        std::env::remove_var("_TEST_B");
     }
 }
 

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -4399,6 +4399,7 @@ fn expand_env_vars(input: &str) -> String {
                 result.push('$');
                 if braced {
                     result.push('{');
+                    result.push('}');
                 }
             } else if let Ok(val) = std::env::var(&var_name) {
                 result.push_str(&val);
@@ -6373,6 +6374,12 @@ rl.on("line", (line) => {
         assert_eq!(result, "hello world!");
         unsafe { std::env::remove_var("_TEST_A") };
         unsafe { std::env::remove_var("_TEST_B") };
+    }
+
+    #[test]
+    fn expand_env_vars_empty_braced_preserved() {
+        // `${}` should be preserved as-is, not lose the closing `}`
+        assert_eq!(expand_env_vars("before ${}after"), "before ${}after");
     }
 }
 

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -16,6 +16,7 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
 
 use crate::core::executors::ToolOutput;
+use crate::core::shell_runtime::resolve_command_path;
 use crate::core::windows_process::configure_background_tokio_command;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::extensions::{
@@ -3332,7 +3333,7 @@ impl ExtensionsManager {
             Box<dyn std::future::Future<Output = Result<T, AppError>> + Send + 'a>,
         >,
     {
-        let mut child = spawn_stdio_mcp_process(config, workspace_path)?;
+        let mut child = spawn_stdio_mcp_process(config, workspace_path).await?;
         let mut stdin = child.stdin.take().ok_or_else(|| {
             AppError::internal(
                 ErrorSource::Tool,
@@ -4731,12 +4732,15 @@ fn parse_streamable_http_sse_payload(payload: &str) -> Result<serde_json::Value,
     Ok(serde_json::Value::Array(messages))
 }
 
-fn spawn_stdio_mcp_process(
+async fn spawn_stdio_mcp_process(
     config: &McpServerConfigInput,
     workspace_path: Option<&str>,
 ) -> Result<tokio::process::Child, AppError> {
-    let program = config.command.as_deref().unwrap_or_default();
-    let mut command = Command::new(program);
+    let configured_program = config.command.as_deref().unwrap_or_default().trim();
+    let program = resolve_command_path(configured_program)
+        .await
+        .unwrap_or_else(|| PathBuf::from(configured_program));
+    let mut command = Command::new(&program);
     command.args(config.args.clone().unwrap_or_default());
     if let Some(cwd) = config.cwd.as_deref().filter(|cwd| !cwd.trim().is_empty()) {
         command.current_dir(cwd);
@@ -4757,7 +4761,11 @@ fn spawn_stdio_mcp_process(
         AppError::recoverable(
             ErrorSource::Tool,
             "extensions.mcp.spawn_failed",
-            format!("Failed to start MCP server '{}': {error}", config.label),
+            format!(
+                "Failed to start MCP server '{}' with command '{}': {error}",
+                config.label,
+                program.display()
+            ),
         )
     })
 }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -6334,18 +6334,19 @@ rl.on("line", (line) => {
 
     #[test]
     fn expand_env_vars_braced_syntax() {
-        std::env::set_var("_TEST_EXPAND_TOKEN", "my_secret_123");
+        // SAFETY: test-only, unique var names avoid races with other tests
+        unsafe { std::env::set_var("_TEST_EXPAND_TOKEN", "my_secret_123") };
         let result = expand_env_vars("Bearer ${_TEST_EXPAND_TOKEN}");
         assert_eq!(result, "Bearer my_secret_123");
-        std::env::remove_var("_TEST_EXPAND_TOKEN");
+        unsafe { std::env::remove_var("_TEST_EXPAND_TOKEN") };
     }
 
     #[test]
     fn expand_env_vars_unbraced_syntax() {
-        std::env::set_var("_TEST_EXPAND_PLAIN", "value_abc");
+        unsafe { std::env::set_var("_TEST_EXPAND_PLAIN", "value_abc") };
         let result = expand_env_vars("prefix-$_TEST_EXPAND_PLAIN-suffix");
         assert_eq!(result, "prefix-value_abc-suffix");
-        std::env::remove_var("_TEST_EXPAND_PLAIN");
+        unsafe { std::env::remove_var("_TEST_EXPAND_PLAIN") };
     }
 
     #[test]
@@ -6366,12 +6367,12 @@ rl.on("line", (line) => {
 
     #[test]
     fn expand_env_vars_multiple_vars() {
-        std::env::set_var("_TEST_A", "hello");
-        std::env::set_var("_TEST_B", "world");
+        unsafe { std::env::set_var("_TEST_A", "hello") };
+        unsafe { std::env::set_var("_TEST_B", "world") };
         let result = expand_env_vars("${_TEST_A} $_TEST_B!");
         assert_eq!(result, "hello world!");
-        std::env::remove_var("_TEST_A");
-        std::env::remove_var("_TEST_B");
+        unsafe { std::env::remove_var("_TEST_A") };
+        unsafe { std::env::remove_var("_TEST_B") };
     }
 }
 

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -1368,22 +1368,15 @@ async fn test_execution_timeout_fires_for_slow_tool() {
     eprintln!("[test-timeout] calling execute_tool_call...");
     let gateway_for_approval = Arc::clone(&gateway);
     let tool_call_id = "tc-timeout".to_string();
-    // Spawn a task that auto-approves the shell tool after a brief delay,
-    // so execution actually begins and the 1s execution_timeout fires.
+    let (approval_requested_tx, approval_requested_rx) = tokio::sync::oneshot::channel::<()>();
     tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        for _ in 0..50 {
-            if matches!(
-                gateway_for_approval
-                    .resolve_approval(&tool_call_id, true)
-                    .await,
-                Ok(true)
-            ) {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
+        if approval_requested_rx.await.is_ok() {
+            let _ = gateway_for_approval
+                .resolve_approval(&tool_call_id, true)
+                .await;
         }
     });
+    let mut approval_requested_tx = Some(approval_requested_tx);
     let outcome = gateway
         .execute_tool_call(
             ToolExecutionRequest {
@@ -1403,7 +1396,11 @@ async fn test_execution_timeout_fires_for_slow_tool() {
                 allow_user_approval: true,
                 execution_timeout: Some(Duration::from_secs(1)),
             },
-            |_| {},
+            move |_| {
+                if let Some(tx) = approval_requested_tx.take() {
+                    let _ = tx.send(());
+                }
+            },
             || {},
         )
         .await

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -1372,9 +1372,17 @@ async fn test_execution_timeout_fires_for_slow_tool() {
     // so execution actually begins and the 1s execution_timeout fires.
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        let _ = gateway_for_approval
-            .resolve_approval(&tool_call_id, true)
-            .await;
+        for _ in 0..50 {
+            if matches!(
+                gateway_for_approval
+                    .resolve_approval(&tool_call_id, true)
+                    .await,
+                Ok(true)
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
     });
     let outcome = gateway
         .execute_tool_call(

--- a/src/modules/extensions-center/ui/extensions-center-overlay.tsx
+++ b/src/modules/extensions-center/ui/extensions-center-overlay.tsx
@@ -1125,7 +1125,7 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
                         <CardHeader className="gap-3 pb-3">
                           <div className="flex items-start justify-between gap-3">
                             <div className="flex min-w-0 items-start gap-3">
-                              <div className="mt-0.5 flex size-10 items-center justify-center rounded-2xl border border-app-border bg-app-canvas text-app-foreground">
+                              <div className="mt-0.5 flex size-10 shrink-0 items-center justify-center rounded-2xl border border-app-border bg-app-canvas text-app-foreground">
                                 <LocalLlmIcon slug="mcp" className="size-4" title="MCP" />
                               </div>
                               <div className="min-w-0">


### PR DESCRIPTION
## Summary
- Add reusable MCP command resolution that falls back to login-shell `command -v`
- Resolve bare commands like `npx` before spawning stdio MCP servers
- Improve MCP startup errors to include the actual command path that was attempted

## Test Plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml shell_runtime -- --nocapture`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [ ] Manually verify MCP servers started from Finder/Dock can resolve `npx`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
