### PR TITLE
fix(macos): 🐛 Fix traffic-light positioning and improve extensions reliability

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3232,8 +3232,38 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -3260,6 +3290,41 @@ dependencies = [
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-io-surface",
 ]
 
@@ -6026,6 +6091,8 @@ dependencies = [
  "globset",
  "ignore",
  "keepawake",
+ "objc2-app-kit",
+ "objc2-foundation",
  "portable-pty",
  "regex",
  "reqwest 0.12.28",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -56,6 +56,8 @@ tiycore = "0.1.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"
+objc2-app-kit = { version = "0.3", features = ["NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
+objc2-foundation = { version = "0.3", features = ["NSGeometry"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -23,6 +23,55 @@ use crate::core::desktop_runtime::{
     DesktopRuntimeState, LAUNCH_AT_LOGIN_SETTING_KEY, MINIMIZE_TO_TRAY_SETTING_KEY,
 };
 use crate::core::sleep_manager::PREVENT_SLEEP_WHILE_RUNNING_SETTING_KEY;
+
+/// Re-position the macOS traffic-light buttons (close / miniaturize / zoom)
+/// so that the layout stays consistent regardless of the SDK the binary was
+/// linked against. Older macOS SDKs render the buttons with a different size
+/// and offset, causing visual regressions in CI-built binaries.
+#[cfg(target_os = "macos")]
+fn reposition_traffic_lights(window: &tauri::Window) {
+    use objc2_app_kit::{NSView, NSWindow, NSWindowButton};
+    use objc2_foundation::NSPoint;
+
+    let Ok(ns_window_ptr) = window.ns_window() else {
+        return;
+    };
+    let ns_window: &NSWindow = unsafe { &*(ns_window_ptr as *const NSWindow) };
+
+    let (x, y) = (14.0_f64, 20.0_f64);
+
+    let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton) else {
+        return;
+    };
+    let Some(miniaturize) = ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton)
+    else {
+        return;
+    };
+    let Some(zoom) = ns_window.standardWindowButton(NSWindowButton::ZoomButton) else {
+        return;
+    };
+
+    unsafe {
+        // Resize the title-bar container so the buttons have enough vertical room.
+        let title_bar_container = close.superview().and_then(|v| v.superview());
+        if let Some(container) = title_bar_container {
+            let close_rect = NSView::frame(&close);
+            let title_bar_frame_height = close_rect.size.height + y;
+            let mut title_bar_rect = NSView::frame(&container);
+            title_bar_rect.size.height = title_bar_frame_height;
+            title_bar_rect.origin.y =
+                NSWindow::frame(ns_window).size.height - title_bar_frame_height;
+            container.setFrame(title_bar_rect);
+        }
+
+        let close_rect = NSView::frame(&close);
+        let space_between = NSView::frame(&miniaturize).origin.x - close_rect.origin.x;
+        for (i, button) in [&close, &miniaturize, &zoom].iter().enumerate() {
+            let origin = NSPoint::new(x + (i as f64 * space_between), close_rect.origin.y);
+            button.setFrameOrigin(origin);
+        }
+    }
+}
 #[cfg(target_os = "macos")]
 use crate::core::startup_manager;
 
@@ -463,6 +512,14 @@ pub fn run() {
                 let _ = window.set_decorations(false);
             }
 
+            // Re-apply traffic light position after window-state restoration so the
+            // values stay consistent regardless of the SDK the binary was linked
+            // against (older SDKs render smaller/offset traffic lights by default).
+            #[cfg(target_os = "macos")]
+            if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+                reposition_traffic_lights(&window.as_ref().window());
+            }
+
             Ok(())
         })
         .on_page_load(|webview, payload| {
@@ -479,12 +536,21 @@ pub fn run() {
                 return;
             }
 
-            if let WindowEvent::CloseRequested { api, .. } = event {
-                let runtime = window.state::<DesktopRuntimeState>();
-                if runtime.minimize_to_tray_enabled() && !runtime.is_quitting() {
-                    api.prevent_close();
-                    let _ = window.hide();
+            match event {
+                WindowEvent::CloseRequested { api, .. } => {
+                    let runtime = window.state::<DesktopRuntimeState>();
+                    if runtime.minimize_to_tray_enabled() && !runtime.is_quitting() {
+                        api.prevent_close();
+                        let _ = window.hide();
+                    }
                 }
+                // Re-apply traffic light position on resize/theme change since
+                // macOS may reset it when linked against an older SDK.
+                #[cfg(target_os = "macos")]
+                WindowEvent::Resized { .. } | WindowEvent::ThemeChanged { .. } => {
+                    reposition_traffic_lights(window);
+                }
+                _ => {}
             }
         })
         .on_menu_event(|app, event| match event.id().as_ref() {


### PR DESCRIPTION
## Summary
- Fix macOS traffic-light buttons drifting when linked against different SDK versions by programmatically repositioning them on launch, resize, and theme change.
- Inject login shell environment into MCP child processes so tools like nvm-managed Node are discoverable on macOS GUI apps.
- Auto-resolve enable/disable scope for MCP servers and skills (global-first, then workspace) instead of requiring explicit scope from the frontend.
- Bypass user-defined `command` functions in bash/zsh when resolving executable paths.
- Add per-MCP-card loading states and disable actions during pending operations to prevent double-clicks and improve UX.

## Test Plan
- [ ] Verify traffic-light buttons stay correctly positioned after launch, resize, and theme toggle on macOS
- [ ] Confirm MCP servers using nvm/fnm-managed Node connect successfully without manual PATH config
- [ ] Toggle enable/disable on global and workspace MCP servers — verify correct scope is resolved
- [ ] Click restart on an MCP card — verify spinner appears and buttons are disabled during the operation
- [ ] Run `cargo test --manifest-path src-tauri/Cargo.toml`
- [ ] Run `npm run typecheck`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)