### PR TITLE
chore(deps): 🔧 Bump tiycore to v0.1.7

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6120,9 +6120,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7390a7acfbb706280f6c45692159f7c73a6167ad93ac201e74e498d64cfb146"
+checksum = "715650f7b19213b381a1acaf6424dcdd262bfe035def69e5fcb600be24fb402b"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,7 +52,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.6"
+tiycore = "0.1.7"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"


### PR DESCRIPTION
## Summary
- Bump `tiycore` from `0.1.6` to `0.1.7` in `src-tauri/Cargo.toml`
- Sync `src-tauri/Cargo.lock` with the new version

## Test Plan
- [ ] `cargo build --manifest-path src-tauri/Cargo.toml`
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml`
- [ ] `npm run dev` 冒烟验证

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)