### PR TITLE
feat(workbench): ✨ Render branch selector on new thread empty state

### DIFF
--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2725,12 +2725,23 @@ export function DashboardWorkbench() {
                     <div className="relative min-h-0 flex-1 overflow-hidden bg-app-canvas">
                       <div className="pointer-events-none absolute left-1/2 top-0 h-56 w-[72rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(120,180,255,0.11),transparent_68%)] blur-3xl" />
                       <div className="relative flex h-full min-h-0 flex-col">
-                        <div className="flex min-h-0 flex-1 items-center justify-center px-6 pb-8 pt-6">
+                        <div className="relative z-10 flex min-h-0 flex-1 items-center justify-center px-6 pb-8 pt-6">
                           <NewThreadEmptyState
                             recentProjects={recentProjects}
                             selectedProject={selectedProject}
                             isOverlayOpen={isOverlayOpen}
                             onSelectProject={handleProjectSelect}
+                            branchSlot={
+                              resolvedWorkspaceId &&
+                              topBarGitSnapshot?.capabilities.repoAvailable &&
+                              topBarGitSnapshot?.capabilities.gitCliAvailable ? (
+                                <BranchSelector
+                                  workspaceId={resolvedWorkspaceId}
+                                  snapshot={branchSnapshot}
+                                  modelPlan={commitMessageModelPlan}
+                                />
+                              ) : null
+                            }
                           />
                         </div>
 

--- a/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
+++ b/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, Folder, FolderPlus } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useT } from "@/i18n";
@@ -11,11 +11,13 @@ export function NewThreadEmptyState({
   selectedProject,
   isOverlayOpen,
   onSelectProject,
+  branchSlot,
 }: {
   recentProjects: ReadonlyArray<ProjectOption>;
   selectedProject: ProjectOption | null;
   isOverlayOpen: boolean;
   onSelectProject: (project: ProjectOption) => void;
+  branchSlot?: ReactNode;
 }) {
   const t = useT();
   const [isMenuOpen, setMenuOpen] = useState(false);
@@ -195,6 +197,12 @@ export function NewThreadEmptyState({
             </div>
           ) : null}
         </div>
+
+        {branchSlot ? (
+          <div className="flex w-full max-w-[24rem] justify-end">
+            {branchSlot}
+          </div>
+        ) : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Expose a `branchSlot` prop on `NewThreadEmptyState` so the empty state can render a trailing slot right-aligned under the workspace selector.
- Wire the existing `BranchSelector` into `DashboardWorkbench`'s new-thread branch, reusing the live `resolvedWorkspaceId`, `branchSnapshot`, and `commitMessageModelPlan` from the thread top bar.
- Only render the selector when the chosen workspace is a git repo and local git CLI is available (`repoAvailable && gitCliAvailable`), so non-git folders stay clean.
- Lift the empty-state container to `relative z-10` to keep the branch dropdown above the composer, and keep the slot mounted while the workspace dropdown is open to avoid layout jitter.

## Test Plan
- [ ] Open the app with no active thread and pick a git-enabled workspace — branch selector appears under the workspace picker, right-aligned.
- [ ] Switch to a non-git folder — branch selector is hidden.
- [ ] Create / switch branches from the new thread view and confirm the thread top bar stays in sync after sending the first message.
- [ ] Toggle the workspace dropdown — the branch row stays in place (no vertical jump) and the workspace menu still overlays it.
- [ ] Open the branch dropdown — it renders above the composer instead of being clipped.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)