### PR TITLE
fix(macOS): 🐛 Fix traffic light buttons shrinking in release builds

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -52,11 +52,12 @@ fn reposition_traffic_lights(window: &tauri::Window) {
     };
 
     unsafe {
-        // Resize the title-bar container so the buttons have enough vertical room.
+        // Use a fixed title-bar container height so the result is stable
+        // across dev / release builds regardless of the initial button size.
+        let title_bar_frame_height = y + 20.0; // 40 pt total
+
         let title_bar_container = close.superview().and_then(|v| v.superview());
         if let Some(container) = title_bar_container {
-            let close_rect = NSView::frame(&close);
-            let title_bar_frame_height = close_rect.size.height + y;
             let mut title_bar_rect = NSView::frame(&container);
             title_bar_rect.size.height = title_bar_frame_height;
             title_bar_rect.origin.y =
@@ -65,9 +66,11 @@ fn reposition_traffic_lights(window: &tauri::Window) {
         }
 
         let close_rect = NSView::frame(&close);
+        let button_height = close_rect.size.height;
+        let button_y = ((title_bar_frame_height - button_height) / 2.0).max(0.0);
         let space_between = NSView::frame(&miniaturize).origin.x - close_rect.origin.x;
         for (i, button) in [&close, &miniaturize, &zoom].iter().enumerate() {
-            let origin = NSPoint::new(x + (i as f64 * space_between), close_rect.origin.y);
+            let origin = NSPoint::new(x + (i as f64 * space_between), button_y);
             button.setFrameOrigin(origin);
         }
     }


### PR DESCRIPTION
## Summary
- Use a fixed title-bar container height (40pt) instead of deriving it from the initial close-button frame, which differs between dev and release builds
- Vertically center traffic light buttons with a dynamic formula `((container_height - button_height) / 2.0).max(0.0)`
- Ensures consistent button size and position across dev server and production DMG installs

## Test Plan
- [ ] `cargo check` / `cargo fmt --check` pass
- [ ] `npm run dev` — traffic lights render at correct size and position
- [ ] Release build (DMG) — traffic lights match dev behavior
- [ ] Verify on Retina and non-Retina displays

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)