### PR TITLE
ci(release): 👷 Select latest Xcode for macOS release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,13 @@ jobs:
           node-version: "22"
           cache: "npm"
 
+      - name: Select latest Xcode
+        if: matrix.platform == 'macos'
+        run: |
+          LATEST_XCODE=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
+          sudo xcode-select -s "$LATEST_XCODE"
+          echo "Using $(xcodebuild -version | head -1)"
+
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- Add a `Select latest Xcode` step in macOS release builds to ensure the latest SDK is linked
- Fixes traffic light buttons rendering smaller in CI-built releases vs local builds due to older SDK compatibility mode
- Runs before Rust toolchain setup on both `macos-latest` and `macos-14` runners

## Test Plan
- [ ] Trigger a release build and verify traffic light button size matches local builds
- [ ] Verify both aarch64 and x86_64 macOS builds succeed

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)