### PR TITLE
feat(workbench): ✨ Enable terminal on New Thread page with workspace selected

### DIFF
--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -820,7 +820,9 @@ export function DashboardWorkbench() {
     });
     if (pendingThreadId && isTauri()) {
       terminalStore.removeSession(pendingThreadId);
-      void threadDelete(pendingThreadId).catch(() => {});
+      void threadDelete(pendingThreadId).catch((error) => {
+        console.warn("[terminal] failed to delete pending thread:", pendingThreadId, error);
+      });
     }
   }, []);
 
@@ -2442,23 +2444,7 @@ export function DashboardWorkbench() {
         onToggleSettingsSection={setOpenSettingsSection}
         onToggleSidebar={() => setSidebarOpen((current) => !current)}
         onToggleDrawer={() => setDrawerOpen((current) => !current)}
-        onToggleTerminal={() => {
-          if (
-            isNewThreadMode &&
-            isTerminalCollapsed &&
-            selectedProjectWorkspaceId &&
-            !resolvedTerminalThreadId
-          ) {
-            getOrCreateNewThreadId(selectedProjectWorkspaceId).catch(
-              (error) => {
-                setTerminalBootstrapError(
-                  getInvokeErrorMessage(error, "Failed to prepare terminal"),
-                );
-              },
-            );
-          }
-          setTerminalCollapsed((current) => !current);
-        }}
+        onToggleTerminal={() => setTerminalCollapsed((current) => !current)}
       />
 
       <div className="flex h-full min-h-0 pt-9">

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -561,6 +561,8 @@ export function DashboardWorkbench() {
     isTauri() ? {} : buildInitialWorkspaceThreadDisplayCounts(),
   );
   const newThreadCreationRef = useRef<Record<string, Promise<string>>>({});
+  const terminalThreadBindingsRef = useRef(terminalThreadBindings);
+  terminalThreadBindingsRef.current = terminalThreadBindings;
   const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
   const activeThread = getActiveThread(workspaces);
@@ -758,6 +760,9 @@ export function DashboardWorkbench() {
       visibleLimit: number,
     ): Promise<{ hasMore: boolean; threads: Array<ThreadSummaryDto> }> => {
       const desiredVisibleCount = visibleLimit + 1;
+      const pendingTerminalThreadIds = new Set(
+        Object.values(terminalThreadBindingsRef.current),
+      );
       const visibleThreads: Array<ThreadSummaryDto> = [];
       let offset = 0;
       let hasMoreRawThreads = true;
@@ -773,6 +778,9 @@ export function DashboardWorkbench() {
         hasMoreRawThreads = batch.length === rawLimit;
 
         for (const thread of batch) {
+          if (pendingTerminalThreadIds.has(thread.id)) {
+            continue;
+          }
           visibleThreads.push(thread);
 
           if (visibleThreads.length >= desiredVisibleCount) {
@@ -795,6 +803,7 @@ export function DashboardWorkbench() {
 
   const clearNewThreadBindingForWorkspace = useCallback((workspaceId: string) => {
     const bindingKey = getNewThreadTerminalBindingKey(workspaceId);
+    const pendingThreadId = terminalThreadBindingsRef.current[bindingKey] ?? null;
     newThreadCreationRef.current = Object.fromEntries(
       Object.entries(newThreadCreationRef.current).filter(
         ([candidateWorkspaceId]) => candidateWorkspaceId !== workspaceId,
@@ -809,6 +818,10 @@ export function DashboardWorkbench() {
       delete next[bindingKey];
       return next;
     });
+    if (pendingThreadId && isTauri()) {
+      terminalStore.removeSession(pendingThreadId);
+      void threadDelete(pendingThreadId).catch(() => {});
+    }
   }, []);
 
   const getOrCreateNewThreadId = useCallback(
@@ -856,6 +869,29 @@ export function DashboardWorkbench() {
     },
     [terminalThreadBindings],
   );
+
+  useEffect(() => {
+    if (
+      !isNewThreadMode ||
+      isTerminalCollapsed ||
+      !selectedProjectWorkspaceId ||
+      resolvedTerminalThreadId
+    ) {
+      return;
+    }
+
+    getOrCreateNewThreadId(selectedProjectWorkspaceId).catch((error) => {
+      setTerminalBootstrapError(
+        getInvokeErrorMessage(error, "Failed to prepare terminal"),
+      );
+    });
+  }, [
+    isNewThreadMode,
+    isTerminalCollapsed,
+    selectedProjectWorkspaceId,
+    resolvedTerminalThreadId,
+    getOrCreateNewThreadId,
+  ]);
 
   const syncWorkspaceSidebar = useCallback(
     async ({
@@ -1629,6 +1665,9 @@ export function DashboardWorkbench() {
   };
 
   const handleThreadSelect = (threadId: string) => {
+    if (isNewThreadMode && selectedProjectWorkspaceId) {
+      clearNewThreadBindingForWorkspace(selectedProjectWorkspaceId);
+    }
     setNewThreadMode(false);
     setActiveWorkspaceMenuId(null);
     setPendingDeleteThreadId(null);
@@ -2049,6 +2088,18 @@ export function DashboardWorkbench() {
         setNewThreadRunMode("default");
         setComposerValue("");
         setComposerError(null);
+        if (nextWorkspaceId) {
+          const bindingKey = getNewThreadTerminalBindingKey(nextWorkspaceId);
+          setTerminalThreadBindings((current) => {
+            if (!(bindingKey in current)) {
+              return current;
+            }
+
+            const next = { ...current };
+            delete next[bindingKey];
+            return next;
+          });
+        }
       })();
       return;
     }
@@ -2333,8 +2384,8 @@ export function DashboardWorkbench() {
     LANGUAGE_OPTIONS[1];
   const newThreadTerminalIdleMessage = !selectedProject
     ? t("dashboard.terminalDisabledHint")
-    : !resolvedWorkspaceId && !terminalBootstrapError
-      ? "Preparing workspace…"
+    : !resolvedTerminalThreadId && !terminalBootstrapError
+      ? "Preparing terminal…"
       : undefined;
 
   useEffect(() => {
@@ -2391,7 +2442,23 @@ export function DashboardWorkbench() {
         onToggleSettingsSection={setOpenSettingsSection}
         onToggleSidebar={() => setSidebarOpen((current) => !current)}
         onToggleDrawer={() => setDrawerOpen((current) => !current)}
-        onToggleTerminal={() => setTerminalCollapsed((current) => !current)}
+        onToggleTerminal={() => {
+          if (
+            isNewThreadMode &&
+            isTerminalCollapsed &&
+            selectedProjectWorkspaceId &&
+            !resolvedTerminalThreadId
+          ) {
+            getOrCreateNewThreadId(selectedProjectWorkspaceId).catch(
+              (error) => {
+                setTerminalBootstrapError(
+                  getInvokeErrorMessage(error, "Failed to prepare terminal"),
+                );
+              },
+            );
+          }
+          setTerminalCollapsed((current) => !current);
+        }}
       />
 
       <div className="flex h-full min-h-0 pt-9">


### PR DESCRIPTION
## Summary
- Allow terminal panel to open on the New Thread page when a workspace is already selected, without requiring a message to be sent first.
- Lazily create a backing thread via `getOrCreateNewThreadId` when the terminal is expanded (or when workspace is selected while terminal is open).
- Clean up the backing thread from DB when the user leaves New Thread mode without sending a message (thread select or re-enter New Thread), preventing ghost empty threads in the sidebar.

## Changes
### `src/modules/workbench-shell/ui/dashboard-workbench.tsx`
- **`onToggleTerminal`** — trigger `getOrCreateNewThreadId` when expanding terminal in New Thread mode with a workspace selected.
- **New `useEffect`** — fallback auto-trigger for the case where terminal is already expanded when user selects a workspace.
- **`listVisibleWorkspaceThreads`** — filter out pending terminal-only threads from sidebar listing as a safety net.
- **`clearNewThreadBindingForWorkspace`** — delete the backing DB thread and terminal session when clearing the binding (entering New Thread again or switching threads).
- **`handleThreadSelect`** — call `clearNewThreadBindingForWorkspace` before leaving New Thread mode.
- **`handleComposerSubmit`** — only clear the binding state (not delete the thread) when the user actually sends a message.
- **`newThreadTerminalIdleMessage`** — show "Preparing terminal…" while the backing thread is being created.

## Test Plan
- [ ] New Thread → select workspace → expand terminal → terminal initializes and accepts input
- [ ] New Thread → expand terminal → select workspace → terminal auto-initializes
- [ ] New Thread → expand terminal → switch to another thread → no ghost "新对话" in sidebar
- [ ] New Thread → expand terminal → click New Thread again → no ghost thread remains
- [ ] New Thread → expand terminal → send message → thread appears normally in sidebar, terminal continues working
- [ ] No workspace selected → expand terminal → shows disabled hint, no errors

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)