### PR TITLE
fix(titlebar): 🐛 Remove macOS traffic light repositioning and refine top bar layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-26
             platform: macos
             arch: aarch64
             target: aarch64-apple-darwin

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,57 +24,6 @@ use crate::core::desktop_runtime::{
 };
 use crate::core::sleep_manager::PREVENT_SLEEP_WHILE_RUNNING_SETTING_KEY;
 
-/// Re-position the macOS traffic-light buttons (close / miniaturize / zoom)
-/// so that the layout stays consistent regardless of the SDK the binary was
-/// linked against. Older macOS SDKs render the buttons with a different size
-/// and offset, causing visual regressions in CI-built binaries.
-#[cfg(target_os = "macos")]
-fn reposition_traffic_lights(window: &tauri::Window) {
-    use objc2_app_kit::{NSView, NSWindow, NSWindowButton};
-    use objc2_foundation::NSPoint;
-
-    let Ok(ns_window_ptr) = window.ns_window() else {
-        return;
-    };
-    let ns_window: &NSWindow = unsafe { &*(ns_window_ptr as *const NSWindow) };
-
-    let (x, y) = (14.0_f64, 20.0_f64);
-
-    let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton) else {
-        return;
-    };
-    let Some(miniaturize) = ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton)
-    else {
-        return;
-    };
-    let Some(zoom) = ns_window.standardWindowButton(NSWindowButton::ZoomButton) else {
-        return;
-    };
-
-    unsafe {
-        // Use a fixed title-bar container height so the result is stable
-        // across dev / release builds regardless of the initial button size.
-        let title_bar_frame_height = y + 20.0; // 40 pt total
-
-        let title_bar_container = close.superview().and_then(|v| v.superview());
-        if let Some(container) = title_bar_container {
-            let mut title_bar_rect = NSView::frame(&container);
-            title_bar_rect.size.height = title_bar_frame_height;
-            title_bar_rect.origin.y =
-                NSWindow::frame(ns_window).size.height - title_bar_frame_height;
-            container.setFrame(title_bar_rect);
-        }
-
-        let close_rect = NSView::frame(&close);
-        let button_height = close_rect.size.height;
-        let button_y = ((title_bar_frame_height - button_height) / 2.0).max(0.0);
-        let space_between = NSView::frame(&miniaturize).origin.x - close_rect.origin.x;
-        for (i, button) in [&close, &miniaturize, &zoom].iter().enumerate() {
-            let origin = NSPoint::new(x + (i as f64 * space_between), button_y);
-            button.setFrameOrigin(origin);
-        }
-    }
-}
 #[cfg(target_os = "macos")]
 use crate::core::startup_manager;
 
@@ -515,14 +464,6 @@ pub fn run() {
                 let _ = window.set_decorations(false);
             }
 
-            // Re-apply traffic light position after window-state restoration so the
-            // values stay consistent regardless of the SDK the binary was linked
-            // against (older SDKs render smaller/offset traffic lights by default).
-            #[cfg(target_os = "macos")]
-            if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
-                reposition_traffic_lights(&window.as_ref().window());
-            }
-
             Ok(())
         })
         .on_page_load(|webview, payload| {
@@ -546,12 +487,6 @@ pub fn run() {
                         api.prevent_close();
                         let _ = window.hide();
                     }
-                }
-                // Re-apply traffic light position on resize/theme change since
-                // macOS may reset it when linked against an older SDK.
-                #[cfg(target_os = "macos")]
-                WindowEvent::Resized { .. } | WindowEvent::ThemeChanged { .. } => {
-                    reposition_traffic_lights(window);
                 }
                 _ => {}
             }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,10 +22,6 @@
         "visible": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": {
-          "x": 14,
-          "y": 20
-        },
         "decorations": true,
         "transparent": false,
         "windowEffects": {

--- a/src/modules/workbench-shell/ui/workbench-top-bar.tsx
+++ b/src/modules/workbench-shell/ui/workbench-top-bar.tsx
@@ -141,7 +141,7 @@ export function WorkbenchTopBar({
   return (
     <header className="fixed inset-x-0 top-0 z-30 h-9 border-b border-app-border bg-app-chrome backdrop-blur-xl">
       <div className={cn("grid h-full grid-cols-[auto_1fr_auto] items-center gap-2 px-2.5", isWindows && "pr-0")}>
-        <div className={cn("relative z-10 flex h-full shrink-0 items-center", isMacOS ? "w-[150px]" : "w-[132px]")}>
+        <div className={cn("relative z-10 flex h-full shrink-0 items-center", isMacOS && "w-[150px]")}>
         </div>
 
         <div

--- a/src/modules/workbench-shell/ui/workbench-top-bar.tsx
+++ b/src/modules/workbench-shell/ui/workbench-top-bar.tsx
@@ -26,8 +26,6 @@ import { Button } from "@/shared/ui/button";
 import { cn } from "@/shared/lib/utils";
 import {
   LANGUAGE_OPTIONS,
-  MAC_USER_MENU_OFFSET,
-  MAC_USER_MENU_POPOVER_OFFSET,
   MENU_SUBMENU_GROUP_CLASS,
   MENU_SUBMENU_ICON_CLASS,
   MENU_SUBMENU_LABEL_CLASS,
@@ -143,146 +141,149 @@ export function WorkbenchTopBar({
   return (
     <header className="fixed inset-x-0 top-0 z-30 h-9 border-b border-app-border bg-app-chrome backdrop-blur-xl">
       <div className={cn("grid h-full grid-cols-[auto_1fr_auto] items-center gap-2 px-2.5", isWindows && "pr-0")}>
-        <div className={cn("relative z-10 flex h-full shrink-0 items-center", isMacOS ? "w-[150px]" : "w-[132px]")} ref={userMenuRef}>
-          <Button
-            size="icon"
-            variant="ghost"
-            className={cn(
-              "size-7 rounded-full text-app-subtle transition-[color,background-color,border-color] duration-200 hover:bg-app-surface-hover hover:text-app-foreground",
-              isMacOS ? MAC_USER_MENU_OFFSET : "ml-2",
-              isOverlayOpen && "pointer-events-none invisible",
-              isUserMenuOpen && "bg-app-surface-hover text-app-foreground",
-            )}
-            aria-label={t("topBar.openMenu")}
-            title={t("topBar.openMenu")}
-            aria-expanded={isUserMenuOpen}
-            aria-haspopup="menu"
-            onClick={onToggleUserMenu}
-          >
-            <Settings className="size-4" />
-          </Button>
-
-          {isUserMenuOpen ? (
-            <div className={cn("absolute left-0 top-full z-30 mt-2 w-[248px] rounded-2xl border border-app-border bg-app-menu p-1.5 shadow-[0_20px_48px_rgba(15,23,42,0.18)] dark:shadow-[0_20px_48px_rgba(0,0,0,0.42)]", isMacOS ? MAC_USER_MENU_POPOVER_OFFSET : "left-2")}>
-
-              <button
-                type="button"
-                className={cn(MENU_TRIGGER_CLASS, "text-app-foreground")}
-                aria-expanded={openSettingsSection === "theme"}
-                onClick={() => onToggleSettingsSection((current) => (current === "theme" ? null : "theme"))}
-              >
-                <Palette className={MENU_TRIGGER_ICON_CLASS} />
-                <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.theme")}</span>
-                <span className="shrink-0 text-xs text-app-subtle">{selectedThemeSummary}</span>
-              </button>
-
-              {openSettingsSection === "theme" ? (
-                <div className={MENU_SUBMENU_GROUP_CLASS}>
-                  <div className="space-y-0.5">
-                    {THEME_OPTIONS.map((option) => {
-                      const OptionIcon = option.icon === Moon ? Moon : option.icon === Sun ? Sun : option.icon;
-                      const isSelected = theme === option.value;
-
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          className={cn(
-                            MENU_SUBMENU_OPTION_CLASS,
-                            isSelected
-                              ? "bg-app-surface-hover/80 text-app-foreground"
-                              : "text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
-                          )}
-                          onClick={() => onSelectTheme(option.value)}
-                        >
-                          <OptionIcon className={MENU_SUBMENU_ICON_CLASS} />
-                          <span className={MENU_SUBMENU_LABEL_CLASS}>{t(option.labelKey)}</span>
-                          {isSelected ? <Check className="size-3.5 shrink-0 text-app-foreground" /> : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-
-              <button
-                type="button"
-                className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground")}
-                aria-expanded={openSettingsSection === "language"}
-                onClick={() => onToggleSettingsSection((current) => (current === "language" ? null : "language"))}
-              >
-                <Globe className={MENU_TRIGGER_ICON_CLASS} />
-                <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.language")}</span>
-                <span className="shrink-0 text-xs text-app-subtle">{selectedLanguageLabel}</span>
-              </button>
-
-              {openSettingsSection === "language" ? (
-                <div className={MENU_SUBMENU_GROUP_CLASS}>
-                  <div className="space-y-0.5">
-                    {LANGUAGE_OPTIONS.map((option) => {
-                      const OptionIcon = option.icon;
-                      const isSelected = language === option.value;
-
-                      return (
-                        <button
-                          key={option.value}
-                          type="button"
-                          className={cn(
-                            MENU_SUBMENU_OPTION_CLASS,
-                            isSelected
-                              ? "bg-app-surface-hover/80 text-app-foreground"
-                              : "text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
-                          )}
-                          onClick={() => onSelectLanguage(option.value)}
-                        >
-                          <OptionIcon className={MENU_SUBMENU_ICON_CLASS} />
-                          <span className={MENU_SUBMENU_LABEL_CLASS}>{option.label}</span>
-                          {isSelected ? <Check className="size-3.5 shrink-0 text-app-foreground" /> : null}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ) : null}
-
-              <button
-                type="button"
-                className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground", isCheckingUpdates && "cursor-wait")}
-                onClick={onCheckUpdates}
-              >
-                {isCheckingUpdates ? (
-                  <LoaderCircle className={cn(MENU_TRIGGER_ICON_CLASS, "animate-spin")} />
-                ) : (
-                  <RefreshCw className={MENU_TRIGGER_ICON_CLASS} />
-                )}
-                <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.checkUpdates")}</span>
-              </button>
-
-              <button
-                type="button"
-                className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground", isOverlayOpen && "bg-app-surface-hover")}
-                onClick={onOpenSettings}
-              >
-                <MoreHorizontal className={MENU_TRIGGER_ICON_CLASS} />
-                <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.moreSettings")}</span>
-              </button>
-
-              {updateStatus ? (
-                <div className="px-3 pb-1 pt-2 text-xs text-app-subtle">{updateStatus}</div>
-              ) : null}
-            </div>
-          ) : null}
+        <div className={cn("relative z-10 flex h-full shrink-0 items-center", isMacOS ? "w-[150px]" : "w-[132px]")}>
         </div>
 
         <div
-          className="relative z-10 flex h-full items-center justify-center"
+          className={cn("relative z-10 flex h-full items-center", isWindows ? "justify-start" : "justify-center")}
           data-tauri-drag-region=""
         >
           <img src="/app-icon.png" alt="" className="mr-1.5 size-4 shrink-0 select-none" draggable={false} data-tauri-drag-region="" />
           <span className="select-none text-[13px] font-semibold tracking-[0.02em] text-app-foreground" data-tauri-drag-region="">TiyCode</span>
         </div>
 
-        <div className="relative z-10 flex items-center justify-end gap-0.5">
+        <div className="relative z-10 flex items-center justify-end gap-0.5" ref={userMenuRef}>
+          <div className="relative">
+            <Button
+              size="icon"
+              variant="ghost"
+              className={cn(
+                panelToggleButtonClass,
+                "rounded-full",
+                isOverlayOpen && "pointer-events-none invisible",
+                isUserMenuOpen && "bg-app-surface-hover text-app-foreground",
+              )}
+              aria-label={t("topBar.openMenu")}
+              title={t("topBar.openMenu")}
+              aria-expanded={isUserMenuOpen}
+              aria-haspopup="menu"
+              onClick={onToggleUserMenu}
+            >
+              <Settings className="size-4" />
+            </Button>
+
+            {isUserMenuOpen ? (
+              <div className="absolute right-0 top-full z-30 mt-2 w-[248px] rounded-2xl border border-app-border bg-app-menu p-1.5 shadow-[0_20px_48px_rgba(15,23,42,0.18)] dark:shadow-[0_20px_48px_rgba(0,0,0,0.42)]">
+
+                <button
+                  type="button"
+                  className={cn(MENU_TRIGGER_CLASS, "text-app-foreground")}
+                  aria-expanded={openSettingsSection === "theme"}
+                  onClick={() => onToggleSettingsSection((current) => (current === "theme" ? null : "theme"))}
+                >
+                  <Palette className={MENU_TRIGGER_ICON_CLASS} />
+                  <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.theme")}</span>
+                  <span className="shrink-0 text-xs text-app-subtle">{selectedThemeSummary}</span>
+                </button>
+
+                {openSettingsSection === "theme" ? (
+                  <div className={MENU_SUBMENU_GROUP_CLASS}>
+                    <div className="space-y-0.5">
+                      {THEME_OPTIONS.map((option) => {
+                        const OptionIcon = option.icon === Moon ? Moon : option.icon === Sun ? Sun : option.icon;
+                        const isSelected = theme === option.value;
+
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            className={cn(
+                              MENU_SUBMENU_OPTION_CLASS,
+                              isSelected
+                                ? "bg-app-surface-hover/80 text-app-foreground"
+                                : "text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
+                            )}
+                            onClick={() => onSelectTheme(option.value)}
+                          >
+                            <OptionIcon className={MENU_SUBMENU_ICON_CLASS} />
+                            <span className={MENU_SUBMENU_LABEL_CLASS}>{t(option.labelKey)}</span>
+                            {isSelected ? <Check className="size-3.5 shrink-0 text-app-foreground" /> : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+
+                <button
+                  type="button"
+                  className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground")}
+                  aria-expanded={openSettingsSection === "language"}
+                  onClick={() => onToggleSettingsSection((current) => (current === "language" ? null : "language"))}
+                >
+                  <Globe className={MENU_TRIGGER_ICON_CLASS} />
+                  <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.language")}</span>
+                  <span className="shrink-0 text-xs text-app-subtle">{selectedLanguageLabel}</span>
+                </button>
+
+                {openSettingsSection === "language" ? (
+                  <div className={MENU_SUBMENU_GROUP_CLASS}>
+                    <div className="space-y-0.5">
+                      {LANGUAGE_OPTIONS.map((option) => {
+                        const OptionIcon = option.icon;
+                        const isSelected = language === option.value;
+
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            className={cn(
+                              MENU_SUBMENU_OPTION_CLASS,
+                              isSelected
+                                ? "bg-app-surface-hover/80 text-app-foreground"
+                                : "text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
+                            )}
+                            onClick={() => onSelectLanguage(option.value)}
+                          >
+                            <OptionIcon className={MENU_SUBMENU_ICON_CLASS} />
+                            <span className={MENU_SUBMENU_LABEL_CLASS}>{option.label}</span>
+                            {isSelected ? <Check className="size-3.5 shrink-0 text-app-foreground" /> : null}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                ) : null}
+
+                <button
+                  type="button"
+                  className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground", isCheckingUpdates && "cursor-wait")}
+                  onClick={onCheckUpdates}
+                >
+                  {isCheckingUpdates ? (
+                    <LoaderCircle className={cn(MENU_TRIGGER_ICON_CLASS, "animate-spin")} />
+                  ) : (
+                    <RefreshCw className={MENU_TRIGGER_ICON_CLASS} />
+                  )}
+                  <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.checkUpdates")}</span>
+                </button>
+
+                <button
+                  type="button"
+                  className={cn(MENU_TRIGGER_CLASS, "mt-1 text-app-foreground", isOverlayOpen && "bg-app-surface-hover")}
+                  onClick={onOpenSettings}
+                >
+                  <MoreHorizontal className={MENU_TRIGGER_ICON_CLASS} />
+                  <span className={MENU_TRIGGER_LABEL_CLASS}>{t("topBar.moreSettings")}</span>
+                </button>
+
+                {updateStatus ? (
+                  <div className="px-3 pb-1 pt-2 text-xs text-app-subtle">{updateStatus}</div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
           <Button
             size="icon"
             variant="ghost"


### PR DESCRIPTION
## Summary
- Remove manual `reposition_traffic_lights` function and all its call sites (setup, Resized, ThemeChanged) that caused traffic light jitter during window resize
- Remove `trafficLightPosition` from `tauri.conf.json`, relying on macOS native positioning
- Move the settings menu button from the left column to the right column (before the sidebar toggle), with the popover now right-aligned
- On Windows, align the logo + app name to the left instead of center

## Test Plan
- [ ] macOS: verify traffic lights no longer jitter during window resize
- [ ] macOS: verify traffic light default position is acceptable with Overlay title bar
- [ ] Verify settings menu opens correctly from its new right-side position
- [ ] Verify popover alignment (right-aligned) renders properly
- [ ] Windows: verify logo + app name is left-aligned in the title bar
- [ ] Theme and language switching still work from the settings menu

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)