### PR TITLE
fix(git): 🐛 Increase default history limit from 24 to 32

### DIFF
--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -21,7 +21,7 @@ use crate::model::git::{
     GitFileStatusDto, GitRepoCapabilitiesDto, GitSnapshotDto,
 };
 
-const DEFAULT_HISTORY_LIMIT: usize = 24;
+const DEFAULT_HISTORY_LIMIT: usize = 32;
 const MAX_DIFF_LINES: usize = 1200;
 const GIT_STREAM_BUFFER: usize = 32;
 const OVERLAY_CACHE_TTL: Duration = Duration::from_secs(10);


### PR DESCRIPTION
## Summary
- Increase `DEFAULT_HISTORY_LIMIT` constant from 24 to 32 in `git_manager.rs`
- Fixes Git panel showing only 24 recent commits instead of the expected 32+

## Root Cause
The backend constant `DEFAULT_HISTORY_LIMIT` was still 24. While the frontend already requested 32 items via `gitGetHistory(workspaceId, 32)` on initial load, the WebSocket `snapshot_updated` event overwrote the history with `snapshot.recentCommits`, which was capped by the backend default of 24.

## Test Plan
- [ ] Open Git panel and verify 32 commits appear in history
- [ ] Trigger a Git refresh and confirm history still shows 32 items (not reverting to 24)
- [ ] Verify `git_get_history` with no limit param returns 32 entries

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)