### PR TITLE
fix(config): enforce LF line endings for sqlx migrations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Auto detect text files and normalize to LF
+* text=auto eol=lf
+
+# Force LF for SQL migrations (critical for sqlx checksum verification)
+*.sql text eol=lf
+
+# Also enforce LF for Rust and config files
+*.rs text eol=lf
+*.toml text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf


### PR DESCRIPTION
## Summary
- Add `.gitattributes` to enforce LF line endings for SQL migration files
- Resolves sqlx migration checksum mismatch on Windows where git uses CRLF by default
- Ensures CI builds and local dev builds produce identical migration checksums

## Background
The `sqlx::migrate!` macro computes SHA-256 checksums of migration files at compile time. On Windows, git may checkout files with CRLF line endings, causing checksum mismatches with CI-built binaries (Linux uses LF). This results in the error:

```
migration 20260316000001 was previously applied but has been modified
```

## Test Plan
- [ ] Verify `.gitattributes` is committed
- [ ] Delete existing database on Windows (`~/.tiy/db`)
- [ ] Run `npm run dev` - database should be created successfully
- [ ] Install new CI build - should also work with same database

Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
