### PR TITLE
fix(sleep-manager): 🐛 Add display wake lock to prevent screen off during active runs

### DIFF
--- a/src-tauri/src/core/sleep_manager.rs
+++ b/src-tauri/src/core/sleep_manager.rs
@@ -45,6 +45,7 @@ fn refresh_wake_lock(state: &mut SleepManagerState) {
         let mut builder = Builder::default();
         builder
             .idle(true)
+            .display(true)
             .reason("Active TiyCode run")
             .app_name("TiyCode")
             .app_reverse_domain("ai.tiy.tiycode");


### PR DESCRIPTION
## Summary
- Add `.display(true)` to the `keepawake` builder in `sleep_manager.rs` to prevent the screen from turning off while an agent run is active.
- Previously only `.idle(true)` was set, which prevented system sleep but allowed the display to turn off.
- The `keepawake` crate's `display` option is cross-platform compatible (macOS / Windows / Linux).

## Test Plan
- [ ] Verify screen stays on during an active agent run with "Prevent sleep while running" enabled
- [ ] Verify screen turns off normally when no agent run is active
- [ ] Test on macOS, Windows, and Linux

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)