### PR TITLE
fix(settings): 🐛 Seed default profile when database has no records

### DIFF
--- a/src/modules/settings-center/model/use-settings-controller.ts
+++ b/src/modules/settings-center/model/use-settings-controller.ts
@@ -277,6 +277,17 @@ function resolveActiveProfileId(
   return profiles[0]?.id ?? DEFAULT_AGENT_PROFILES[0]?.id ?? "default-profile";
 }
 
+/** Check whether a Tauri invoke error carries a `.not_found` error code. */
+function isTauriNotFoundError(error: unknown): boolean {
+  return (
+    error !== null &&
+    typeof error === "object" &&
+    "errorCode" in error &&
+    typeof (error as Record<string, unknown>).errorCode === "string" &&
+    ((error as Record<string, unknown>).errorCode as string).includes(".not_found")
+  );
+}
+
 function mapProviderDto(provider: ProviderSettingsDto): ProviderEntry {
   return {
     id: provider.id,
@@ -654,14 +665,7 @@ export function useSettingsController() {
       .catch(async (error) => {
         // If the profile does not exist in the database (e.g., using a hardcoded default-profile ID),
         // create it first and then update the frontend state with the new persistent profile.
-        const isNotFoundError =
-          error &&
-          typeof error === "object" &&
-          "errorCode" in error &&
-          typeof (error as Record<string, unknown>).errorCode === "string" &&
-          ((error as Record<string, unknown>).errorCode as string).includes(".not_found");
-
-        if (!isNotFoundError) {
+        if (!isTauriNotFoundError(error)) {
           console.warn("Failed to update profile", error);
           return;
         }
@@ -673,14 +677,20 @@ export function useSettingsController() {
           // Persist the new profile ID as the active profile.
           await settingsSet(ACTIVE_AGENT_PROFILE_SETTING_KEY, JSON.stringify(mapped.id));
 
-          setSettings((current) => ({
-            ...current,
-            agentProfiles: current.agentProfiles.map((entry) =>
-              entry.id === id ? mapped : entry,
-            ),
-            activeAgentProfileId:
-              current.activeAgentProfileId === id ? mapped.id : current.activeAgentProfileId,
-          }));
+          setSettings((current) => {
+            // Replace the ghost profile if it exists, otherwise append the new one.
+            const found = current.agentProfiles.some((entry) => entry.id === id);
+            const nextProfiles = found
+              ? current.agentProfiles.map((entry) => (entry.id === id ? mapped : entry))
+              : [...current.agentProfiles, mapped];
+
+            return {
+              ...current,
+              agentProfiles: nextProfiles,
+              activeAgentProfileId:
+                current.activeAgentProfileId === id ? mapped.id : current.activeAgentProfileId,
+            };
+          });
         } catch (createError) {
           console.warn("Failed to create missing profile during update", createError);
         }

--- a/src/modules/settings-center/model/use-settings-controller.ts
+++ b/src/modules/settings-center/model/use-settings-controller.ts
@@ -419,6 +419,32 @@ export function useSettingsController() {
           );
         }
 
+        // When the database has no profiles yet (fresh install), seed the default profile
+        // into the database so the frontend always works with a real persisted record
+        // instead of the hardcoded DEFAULT_AGENT_PROFILES ghost ID.
+        let persistedProfiles = mappedProfiles;
+        let persistedActiveId = resolvedActiveProfileId;
+
+        if (mappedProfiles.length === 0) {
+          try {
+            const defaultInput = DEFAULT_AGENT_PROFILES[0];
+            if (defaultInput) {
+              const created = await profileCreate(
+                toProfileInput(defaultInput, true),
+              );
+              const mapped = mapProfileDto(created);
+              persistedProfiles = [mapped];
+              persistedActiveId = mapped.id;
+              await settingsSet(
+                ACTIVE_AGENT_PROFILE_SETTING_KEY,
+                JSON.stringify(mapped.id),
+              );
+            }
+          } catch (seedError) {
+            console.warn("Failed to seed default profile during hydration", seedError);
+          }
+        }
+
         if (cancelled) {
           return;
         }
@@ -433,9 +459,9 @@ export function useSettingsController() {
             commands: resolvedPromptCommands.map(mapPromptCommandDto),
           },
           policy: mappedPolicy,
-          agentProfiles: mappedProfiles.length > 0 ? mappedProfiles : DEFAULT_AGENT_PROFILES,
-          activeAgentProfileId: mappedProfiles.length > 0
-            ? resolvedActiveProfileId
+          agentProfiles: persistedProfiles.length > 0 ? persistedProfiles : DEFAULT_AGENT_PROFILES,
+          activeAgentProfileId: persistedProfiles.length > 0
+            ? persistedActiveId
             : DEFAULT_AGENT_PROFILES[0]?.id ?? "default-profile",
         }));
       } catch (error) {
@@ -625,8 +651,39 @@ export function useSettingsController() {
           ),
         }));
       })
-      .catch((error) => {
-        console.warn("Failed to update profile", error);
+      .catch(async (error) => {
+        // If the profile does not exist in the database (e.g., using a hardcoded default-profile ID),
+        // create it first and then update the frontend state with the new persistent profile.
+        const isNotFoundError =
+          error &&
+          typeof error === "object" &&
+          "errorCode" in error &&
+          typeof (error as Record<string, unknown>).errorCode === "string" &&
+          ((error as Record<string, unknown>).errorCode as string).includes(".not_found");
+
+        if (!isNotFoundError) {
+          console.warn("Failed to update profile", error);
+          return;
+        }
+
+        try {
+          const createdProfile = await profileCreate(toProfileInput(nextProfile, false));
+          const mapped = mapProfileDto(createdProfile);
+
+          // Persist the new profile ID as the active profile.
+          await settingsSet(ACTIVE_AGENT_PROFILE_SETTING_KEY, JSON.stringify(mapped.id));
+
+          setSettings((current) => ({
+            ...current,
+            agentProfiles: current.agentProfiles.map((entry) =>
+              entry.id === id ? mapped : entry,
+            ),
+            activeAgentProfileId:
+              current.activeAgentProfileId === id ? mapped.id : current.activeAgentProfileId,
+          }));
+        } catch (createError) {
+          console.warn("Failed to create missing profile during update", createError);
+        }
       });
   };
 


### PR DESCRIPTION
## Summary
- Auto-seed default profile during hydration when database has no records, eliminating ghost ID issue
- Add error recovery in updateAgentProfile to create profile on not_found errors
- Fix model selection lost after app restart on fresh Windows installs

## Root Cause
On fresh install, the `agent_profiles` database table was empty. The frontend fell back to hardcoded `DEFAULT_AGENT_PROFILES` with a ghost ID `"default-profile"` that never existed in the database. When users selected a model in the Onboarding wizard, `profileUpdate("default-profile", ...)` failed with 404, so the model selection was only stored in React state and lost on restart.

## Changes
### Hydration-time seeding
- When `profileList()` returns empty array, call `profileCreate()` with `DEFAULT_AGENT_PROFILES[0]`
- Persist the new real profile ID via `settingsSet(ACTIVE_AGENT_PROFILE_SETTING_KEY, ...)`
- Frontend now works with real persisted records from the start

### Error recovery fallback
- In `updateAgentProfile`, detect `not_found` errors via `errorCode.includes(".not_found")`
- Auto-create the profile on-the-fly when update fails
- Replace the ghost ID with the new real profile ID in frontend state

## Test Plan
- [x] `npm run typecheck` - passed
- [x] `npm run test:unit` - 14 tests passed
- [ ] Manual test: fresh install, onboarding model selection, restart, verify model persists

Generated with TiyCode (https://github.com/TiyAgents/tiycode)