### PR TITLE
perf(startup): ⚡️ Optimize Windows startup and TreeView loading latency

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6087,6 +6087,7 @@ dependencies = [
  "chrono",
  "dirs 6.0.0",
  "dunce",
+ "futures",
  "git2",
  "globset",
  "ignore",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ tauri-plugin-process = "2"
 
 # Async runtime
 tokio = { version = "1", features = ["full"] }
+futures = "0.3"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # Database

--- a/src-tauri/src/commands/index.rs
+++ b/src-tauri/src/commands/index.rs
@@ -1,11 +1,12 @@
-use tauri::{ipc::Channel, State};
+use tauri::{ipc::Channel, AppHandle, Emitter, State};
 
 use crate::core::app_state::AppState;
 use crate::core::index_manager::{
-    DirectoryChildrenResponse, FileFilterResponse, FileTreeNode, FileTreeResponse,
-    RevealPathResponse, SearchBatchResponse, SearchOptions, SearchResponse,
+    DirectoryChildrenResponse, FileFilterResponse, FileTreeResponse, RevealPathResponse,
+    SearchBatchResponse, SearchOptions, SearchResponse,
 };
 use crate::core::local_search::{SearchOutputMode, SearchQueryMode};
+use crate::ipc::app_events;
 use crate::ipc::frontend_channels::SearchStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::persistence::repo::workspace_repo;
@@ -13,6 +14,7 @@ use std::time::Duration;
 
 #[tauri::command]
 pub async fn index_get_tree(
+    app: AppHandle,
     state: State<'_, AppState>,
     workspace_id: String,
 ) -> Result<FileTreeResponse, AppError> {
@@ -20,20 +22,34 @@ pub async fn index_get_tree(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
-    let (tree_result, overlay_result) = tokio::join!(
-        state.index_manager.get_tree(&workspace.canonical_path),
-        state
-            .git_manager
-            .get_workspace_overlay(&workspace.canonical_path)
-    );
+    let tree = state
+        .index_manager
+        .get_tree(&workspace.canonical_path)
+        .await?;
 
-    let mut tree = tree_result?;
-    let overlay = overlay_result?;
-
-    tree.apply_git_overlay(&overlay.states);
+    // Spawn async overlay fetch — pushes the result to the frontend via event
+    // so the tree can render immediately without waiting for `git status`.
+    let canonical_path = workspace.canonical_path.clone();
+    let ws_id = workspace_id.clone();
+    let git_manager = state.git_manager.clone();
+    tauri::async_runtime::spawn(async move {
+        match git_manager.get_workspace_overlay(&canonical_path).await {
+            Ok(overlay) => {
+                let payload = app_events::IndexGitOverlayReadyPayload {
+                    workspace_id: ws_id,
+                    repo_available: overlay.repo_available,
+                    states: overlay.states.clone(),
+                };
+                let _ = app.emit(app_events::INDEX_GIT_OVERLAY_READY, payload);
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "git overlay fetch failed for tree");
+            }
+        }
+    });
 
     Ok(FileTreeResponse {
-        repo_available: overlay.repo_available,
+        repo_available: false,
         tree,
     })
 }
@@ -50,39 +66,15 @@ pub async fn index_get_children(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
-    let (children_result, overlay_result) = tokio::join!(
-        state.index_manager.get_children(
+    state
+        .index_manager
+        .get_children(
             &workspace.canonical_path,
             &directory_path,
             offset,
             max_results,
-        ),
-        state
-            .git_manager
-            .get_workspace_overlay(&workspace.canonical_path)
-    );
-
-    let response = children_result?;
-    let overlay = overlay_result?;
-
-    let mut overlay_root = FileTreeNode {
-        name: workspace.name.clone(),
-        path: String::new(),
-        is_dir: true,
-        is_expandable: true,
-        children_has_more: false,
-        children_next_offset: None,
-        git_state: None,
-        children: Some(response.children),
-    };
-
-    overlay_root.apply_git_overlay(&overlay.states);
-
-    Ok(DirectoryChildrenResponse {
-        children: overlay_root.children.unwrap_or_default(),
-        has_more: response.has_more,
-        next_offset: response.next_offset,
-    })
+        )
+        .await
 }
 
 #[tauri::command]
@@ -112,44 +104,10 @@ pub async fn index_reveal_path(
         .await?
         .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
-    let (response_result, overlay_result) = tokio::join!(
-        state
-            .index_manager
-            .reveal_path(&workspace.canonical_path, &target_path),
-        state
-            .git_manager
-            .get_workspace_overlay(&workspace.canonical_path)
-    );
-
-    let mut response = response_result?;
-    let overlay = overlay_result?;
-
-    for segment in &mut response.segments {
-        let mut overlay_root = FileTreeNode {
-            name: if segment.directory_path.is_empty() {
-                workspace.name.clone()
-            } else {
-                segment
-                    .directory_path
-                    .split('/')
-                    .next_back()
-                    .unwrap_or(&workspace.name)
-                    .to_string()
-            },
-            path: segment.directory_path.clone(),
-            is_dir: true,
-            is_expandable: true,
-            children_has_more: segment.has_more,
-            children_next_offset: segment.next_offset,
-            git_state: None,
-            children: Some(segment.children.clone()),
-        };
-
-        overlay_root.apply_git_overlay(&overlay.states);
-        segment.children = overlay_root.children.unwrap_or_default();
-    }
-
-    Ok(response)
+    state
+        .index_manager
+        .reveal_path(&workspace.canonical_path, &target_path)
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/core/index_manager.rs
+++ b/src-tauri/src/core/index_manager.rs
@@ -55,6 +55,9 @@ const INITIAL_LOADED_DEPTH: usize = 0;
 /// Cache workspace file manifests briefly so repeated filter input stays fast.
 const MANIFEST_TTL: Duration = Duration::from_secs(2);
 
+/// Cache the initial tree briefly so rapid panel refreshes skip the FS scan.
+const TREE_CACHE_TTL: Duration = Duration::from_secs(2);
+
 /// Max children loaded for a directory page in TreeView.
 const DIRECTORY_PAGE_SIZE: usize = 200;
 
@@ -230,6 +233,12 @@ struct ManifestCacheEntry {
 }
 
 #[derive(Debug, Clone)]
+struct TreeCacheEntry {
+    built_at: Instant,
+    tree: FileTreeNode,
+}
+
+#[derive(Debug, Clone)]
 struct DirectoryPage {
     children: Vec<FileTreeNode>,
     has_more: bool,
@@ -246,6 +255,7 @@ struct DirectoryEntry {
 #[derive(Clone)]
 pub struct IndexManager {
     manifest_cache: Arc<RwLock<HashMap<String, ManifestCacheEntry>>>,
+    tree_cache: Arc<RwLock<HashMap<String, TreeCacheEntry>>>,
     canonical_cache: Arc<RwLock<HashMap<String, PathBuf>>>,
     stream_cancellations: Arc<Mutex<HashMap<u32, LocalSearchCancellation>>>,
 }
@@ -260,6 +270,7 @@ impl IndexManager {
     pub fn new() -> Self {
         Self {
             manifest_cache: Arc::new(RwLock::new(HashMap::new())),
+            tree_cache: Arc::new(RwLock::new(HashMap::new())),
             canonical_cache: Arc::new(RwLock::new(HashMap::new())),
             stream_cancellations: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -309,17 +320,38 @@ impl IndexManager {
     }
 
     /// Scan workspace directory and return a shallow, expandable file tree.
+    ///
+    /// Results are cached for a short TTL so rapid panel refreshes or workspace
+    /// switches do not trigger redundant filesystem scans.
     pub async fn get_tree(&self, workspace_path: &str) -> Result<FileTreeNode, AppError> {
         let root = self.cached_canonicalize(workspace_path).await?;
+        let cache_key = root.to_string_lossy().to_string();
 
-        tokio::task::spawn_blocking(move || build_initial_tree(&root))
+        if let Some(cached) = self.tree_cache.read().await.get(&cache_key) {
+            if cached.built_at.elapsed() < TREE_CACHE_TTL {
+                return Ok(cached.tree.clone());
+            }
+        }
+
+        let root_for_scan = root.clone();
+        let tree = tokio::task::spawn_blocking(move || build_initial_tree(&root_for_scan))
             .await
             .map_err(|error| {
                 AppError::internal(
                     ErrorSource::Index,
                     format!("Initial tree task failed: {error}"),
                 )
-            })?
+            })??;
+
+        self.tree_cache.write().await.insert(
+            cache_key,
+            TreeCacheEntry {
+                built_at: Instant::now(),
+                tree: tree.clone(),
+            },
+        );
+
+        Ok(tree)
     }
 
     /// Load a directory's direct children on demand.
@@ -868,27 +900,15 @@ fn scan_tree_node(
         return Ok(make_file_node(path, root));
     }
 
-    let page = if depth == 0 {
-        read_directory_entries_page(
-            root,
-            path,
-            skipped,
-            tree_lazy_only,
-            depth < preload_depth,
-            0,
-            usize::MAX,
-        )?
-    } else {
-        read_directory_entries_page(
-            root,
-            path,
-            skipped,
-            tree_lazy_only,
-            depth < preload_depth,
-            0,
-            DIRECTORY_PAGE_SIZE,
-        )?
-    };
+    let page = read_directory_entries_page(
+        root,
+        path,
+        skipped,
+        tree_lazy_only,
+        depth < preload_depth,
+        0,
+        DIRECTORY_PAGE_SIZE,
+    )?;
 
     Ok(FileTreeNode {
         name: node_name(path, root),

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -144,6 +144,18 @@ impl WorkspaceManager {
             .await?
             .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
 
+        self.validate_record(&record).await?;
+
+        // Re-fetch the updated record
+        workspace_repo::find_by_id(&self.pool, id)
+            .await?
+            .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))
+    }
+
+    /// Validate a workspace from an already-loaded record, skipping the
+    /// initial `find_by_id` lookup and the trailing re-fetch.  This is the
+    /// shared validation core used by both `validate` and `validate_all`.
+    async fn validate_record(&self, record: &WorkspaceRecord) -> Result<(), AppError> {
         let canonical = Path::new(&record.canonical_path);
         let now = Utc::now();
 
@@ -163,22 +175,24 @@ impl WorkspaceManager {
         // Update git detection as well
         let is_git = fs::metadata(canonical.join(".git")).await.is_ok();
         if is_git != record.is_git {
-            workspace_repo::update_is_git(&self.pool, id, is_git).await?;
+            workspace_repo::update_is_git(&self.pool, &record.id, is_git).await?;
         }
 
-        workspace_repo::update_status(&self.pool, id, &new_status, now).await?;
-
-        // Re-fetch the updated record
-        workspace_repo::find_by_id(&self.pool, id)
-            .await?
-            .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))
+        workspace_repo::update_status(&self.pool, &record.id, &new_status, now).await?;
+        Ok(())
     }
 
     /// Validate all workspaces — called on app startup.
+    ///
+    /// Validations run concurrently so that slow filesystem checks (e.g. on
+    /// Windows with antivirus hooks) do not accumulate sequentially.
     pub async fn validate_all(&self) -> Result<(), AppError> {
         let workspaces = self.list().await?;
-        for ws in &workspaces {
-            if let Err(e) = self.validate(&ws.id).await {
+        let results =
+            futures::future::join_all(workspaces.iter().map(|ws| self.validate_record(ws))).await;
+
+        for (ws, result) in workspaces.iter().zip(results) {
+            if let Err(e) = result {
                 tracing::warn!(
                     workspace_id = %ws.id,
                     error = %e,

--- a/src-tauri/src/ipc/app_events.rs
+++ b/src-tauri/src/ipc/app_events.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 pub const THREAD_RUN_STARTED: &str = "thread-run-started";
 pub const THREAD_RUN_FINISHED: &str = "thread-run-finished";
 pub const THREAD_TITLE_UPDATED: &str = "thread-title-updated";
+pub const INDEX_GIT_OVERLAY_READY: &str = "index-git-overlay-ready";
 
 /// Payload emitted when a thread run transitions to the `running` state.
 #[derive(Debug, Clone, Serialize)]
@@ -33,4 +34,14 @@ pub struct ThreadRunFinishedPayload {
 pub struct ThreadTitleUpdatedPayload {
     pub thread_id: String,
     pub title: String,
+}
+
+/// Payload emitted when a workspace git overlay has been computed asynchronously
+/// after the initial tree response was returned to the frontend.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IndexGitOverlayReadyPayload {
+    pub workspace_id: String,
+    pub repo_available: bool,
+    pub states: std::collections::HashMap<String, crate::model::git::GitFileState>,
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -436,26 +436,37 @@ pub fn run() {
                 }
             }
 
-            // 6. Startup recovery: validate workspaces + interrupt dangling runs
-            tauri::async_runtime::block_on(async {
-                state.workspace_manager.validate_all().await?;
-                state.thread_manager.recover_interrupted_runs().await?;
-                state.terminal_manager.recover_orphaned_sessions().await?;
-                Ok::<(), crate::model::errors::AppError>(())
-            })?;
-
             // Apply bundled catalog snapshot if it is newer than the local cache.
             // This ensures a usable catalog is available even without network access
             // (e.g. fresh install or app update in an offline environment).
             crate::core::settings_manager::apply_bundled_catalog_if_newer(app.handle());
 
+            app.manage(state);
+            app.manage(desktop_runtime);
+
+            // 6. Startup recovery: validate workspaces + interrupt dangling runs.
+            // Spawned asynchronously so the window can render without waiting for
+            // potentially slow filesystem checks (especially on Windows where NTFS
+            // metadata + antivirus hooks add significant latency per workspace).
+            let recovery_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let state = recovery_handle.state::<AppState>();
+                if let Err(e) = state.workspace_manager.validate_all().await {
+                    tracing::warn!(error = %e, "startup workspace validation failed");
+                }
+                if let Err(e) = state.thread_manager.recover_interrupted_runs().await {
+                    tracing::warn!(error = %e, "startup run recovery failed");
+                }
+                if let Err(e) = state.terminal_manager.recover_orphaned_sessions().await {
+                    tracing::warn!(error = %e, "startup terminal session recovery failed");
+                }
+                tracing::info!("startup recovery complete");
+            });
+
             tauri::async_runtime::spawn(async {
                 crate::core::settings_manager::SettingsManager::refresh_catalog_snapshot_silently()
                     .await;
             });
-
-            app.manage(state);
-            app.manage(desktop_runtime);
             build_tray(app, minimize_to_tray)?;
 
             // 7. Platform-specific window setup

--- a/src-tauri/tests/m1_8_index.rs
+++ b/src-tauri/tests/m1_8_index.rs
@@ -770,3 +770,80 @@ async fn test_file_tree_scan_performance() {
         elapsed.as_millis()
     );
 }
+
+// =========================================================================
+// T1.8.4 — Tree cache TTL hit / expiry
+// =========================================================================
+
+#[tokio::test]
+async fn test_tree_cache_hit_returns_same_result_without_rescan() {
+    use std::time::Instant;
+    use tiycode::core::index_manager::IndexManager;
+
+    let manager = IndexManager::new();
+    let tmp = tempfile::tempdir().expect("should create tempdir");
+    let base = tmp.path();
+
+    std::fs::create_dir_all(base.join("src")).unwrap();
+    std::fs::write(base.join("src/main.rs"), "fn main() {}").unwrap();
+
+    // First call — populates the cache.
+    let first = manager.get_tree(&base.to_string_lossy()).await.unwrap();
+
+    // Mutate the filesystem *before* the second call.
+    std::fs::write(base.join("src/extra.rs"), "fn extra() {}").unwrap();
+
+    // Second call within the TTL window — should return the cached (stale) tree.
+    let start = Instant::now();
+    let second = manager.get_tree(&base.to_string_lossy()).await.unwrap();
+    let elapsed = start.elapsed();
+
+    assert_eq!(
+        first.children.as_ref().map(|c| c.len()),
+        second.children.as_ref().map(|c| c.len()),
+        "cached tree should return the same children count before TTL expires"
+    );
+    assert!(
+        elapsed.as_millis() < 50,
+        "cache hit should be near-instant, took {}ms",
+        elapsed.as_millis()
+    );
+}
+
+#[tokio::test]
+async fn test_tree_cache_expires_after_ttl() {
+    use tiycode::core::index_manager::IndexManager;
+
+    let manager = IndexManager::new();
+    let tmp = tempfile::tempdir().expect("should create tempdir");
+    let base = tmp.path();
+
+    std::fs::create_dir_all(base.join("src")).unwrap();
+    std::fs::write(base.join("src/main.rs"), "fn main() {}").unwrap();
+
+    // First call — populates the cache.
+    let first = manager.get_tree(&base.to_string_lossy()).await.unwrap();
+    let first_count = first.children.as_ref().map(|c| c.len()).unwrap_or(0);
+
+    // Add a new file.
+    std::fs::write(base.join("src/extra.rs"), "fn extra() {}").unwrap();
+
+    // Wait for the cache TTL (2 s) to expire.
+    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+    // Third call — TTL expired, should rescan and pick up the new file.
+    let refreshed = manager.get_tree(&base.to_string_lossy()).await.unwrap();
+    let refreshed_count = refreshed
+        .children
+        .as_ref()
+        .map(|c| c.len())
+        .unwrap_or(0);
+
+    assert!(
+        refreshed_count > first_count
+            || refreshed.children.as_ref().is_some_and(|children| children
+                .iter()
+                .any(|child| child.path == "src")),
+        "after TTL expiry the tree should reflect filesystem changes"
+    );
+}

--- a/src-tauri/tests/m1_8_index.rs
+++ b/src-tauri/tests/m1_8_index.rs
@@ -833,17 +833,14 @@ async fn test_tree_cache_expires_after_ttl() {
 
     // Third call — TTL expired, should rescan and pick up the new file.
     let refreshed = manager.get_tree(&base.to_string_lossy()).await.unwrap();
-    let refreshed_count = refreshed
-        .children
-        .as_ref()
-        .map(|c| c.len())
-        .unwrap_or(0);
+    let refreshed_count = refreshed.children.as_ref().map(|c| c.len()).unwrap_or(0);
 
     assert!(
         refreshed_count > first_count
-            || refreshed.children.as_ref().is_some_and(|children| children
-                .iter()
-                .any(|child| child.path == "src")),
+            || refreshed
+                .children
+                .as_ref()
+                .is_some_and(|children| children.iter().any(|child| child.path == "src")),
         "after TTL expiry the tree should reflect filesystem changes"
     );
 }

--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -651,7 +651,7 @@ export function ProjectPanel({
         }
 
         // Deep-clone the tree so React detects the state change.
-        const nextTree: FileTreeNode = JSON.parse(JSON.stringify(current.data.tree));
+        const nextTree: FileTreeNode = structuredClone(current.data.tree);
         applyGitOverlayToNode(nextTree, event.payload.states);
 
         return {

--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -1,6 +1,7 @@
 import { useDeferredValue, useEffect, useRef, useState } from "react";
 import { useT } from "@/i18n";
 import { invoke, isTauri } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { Check, ChevronDown, ChevronRight, Copy, FolderOpen, LoaderCircle, RefreshCw } from "lucide-react";
 import {
   type DirectoryChildrenResponse,
@@ -12,6 +13,7 @@ import {
   type FileFilterResponse,
   type FileTreeNode,
   type FileTreeResponse,
+  type IndexGitOverlayReadyPayload,
 } from "@/services/bridge";
 import { Input } from "@/shared/ui/input";
 import { cn } from "@/shared/lib/utils";
@@ -374,6 +376,48 @@ function applyRevealSegment(
   };
 }
 
+const GIT_STATE_PRIORITY: Record<string, number> = {
+  ignored: 1,
+  tracked: 2,
+  modified: 3,
+  untracked: 4,
+};
+
+function strongestGitState(
+  a: FileTreeNode["gitState"],
+  b: FileTreeNode["gitState"],
+): FileTreeNode["gitState"] {
+  if (!a) return b;
+  if (!b) return a;
+  return (GIT_STATE_PRIORITY[a] ?? 0) >= (GIT_STATE_PRIORITY[b] ?? 0) ? a : b;
+}
+
+/**
+ * Apply a git overlay (path → state map) to a tree, mirroring the backend
+ * `annotate_git_state` logic: directories inherit the "strongest" state of
+ * their children, and direct matches take precedence.
+ */
+function applyGitOverlayToNode(
+  node: FileTreeNode,
+  states: Record<string, FileTreeNode["gitState"]>,
+): FileTreeNode["gitState"] {
+  let childAggregate: FileTreeNode["gitState"] = undefined;
+
+  const nextChildren = node.children?.map((child) => {
+    const childState = applyGitOverlayToNode(child, states);
+    childAggregate = strongestGitState(childAggregate, childState);
+    return child;
+  });
+
+  const directState = node.path ? states[node.path] : undefined;
+  const resolved = strongestGitState(directState, childAggregate) ?? undefined;
+  node.gitState = resolved;
+  if (nextChildren) {
+    node.children = nextChildren;
+  }
+  return resolved;
+}
+
 export function ProjectPanel({
   currentProject,
   workspaceId,
@@ -584,6 +628,54 @@ export function ProjectPanel({
       cancelled = true;
     };
   }, [projectPath, workspaceId, treeReloadVersion]);
+
+  // Listen for async git overlay events pushed from the backend after the
+  // initial tree response. This allows the tree to render immediately and
+  // receive git status annotations once they are ready.
+  useEffect(() => {
+    if (!isTauri() || !workspaceId) {
+      return;
+    }
+
+    let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
+
+    void listen<IndexGitOverlayReadyPayload>("index-git-overlay-ready", (event) => {
+      if (cancelled || event.payload.workspaceId !== workspaceId) {
+        return;
+      }
+
+      setTreeState((current) => {
+        if (!current.data) {
+          return current;
+        }
+
+        // Deep-clone the tree so React detects the state change.
+        const nextTree: FileTreeNode = JSON.parse(JSON.stringify(current.data.tree));
+        applyGitOverlayToNode(nextTree, event.payload.states);
+
+        return {
+          ...current,
+          data: {
+            ...current.data,
+            repoAvailable: event.payload.repoAvailable,
+            tree: nextTree,
+          },
+        };
+      });
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [workspaceId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/services/bridge/index-commands.ts
+++ b/src/services/bridge/index-commands.ts
@@ -47,6 +47,12 @@ export interface RevealPathResponse {
   segments: RevealPathSegment[];
 }
 
+export interface IndexGitOverlayReadyPayload {
+  workspaceId: string;
+  repoAvailable: boolean;
+  states: Record<string, GitFileState>;
+}
+
 export interface SearchResult {
   path: string;
   absolutePath: string;


### PR DESCRIPTION
## Summary
- Move startup recovery (`validate_all`, `recover_interrupted_runs`, `recover_orphaned_sessions`) from blocking `setup()` to `tauri::async_runtime::spawn`, allowing the window to render immediately
- Parallelize workspace validation using `futures::future::join_all` instead of sequential loop, reducing cumulative FS I/O latency
- Decouple git overlay from `index_get_tree` — tree returns instantly, git status pushed async via Tauri event
- Add 2s TTL tree cache to skip redundant filesystem scans on rapid refreshes
- Unify root directory paging with `DIRECTORY_PAGE_SIZE` (was `usize::MAX`)

## Changes
### Backend (`src-tauri/`)
- `lib.rs`: Replace `block_on` recovery block with async `spawn`; `app.manage(state)` moved before recovery
- `workspace_manager.rs`: New `validate_record()` internal method eliminates redundant DB lookups; `validate_all()` uses `join_all` for concurrent validation
- `index_manager.rs`: Root dir paging unified to `DIRECTORY_PAGE_SIZE`; added `TreeCacheEntry` with 2s TTL
- `commands/index.rs`: `index_get_tree`, `index_get_children`, `index_reveal_path` decoupled from git overlay join; overlay pushed via `app.emit()`
- `ipc/app_events.rs`: New `INDEX_GIT_OVERLAY_READY` event + `IndexGitOverlayReadyPayload`
- `Cargo.toml`: Added `futures = "0.3"`

### Frontend (`src/`)
- `project-panel.tsx`: New `applyGitOverlayToNode` recursive function + `useEffect` listener for overlay event
- `index-commands.ts`: New `IndexGitOverlayReadyPayload` TypeScript interface

## Test Plan
- [x] `cargo fmt --check` — pass
- [x] `cargo build` — no warnings
- [x] `cargo test` — 229 passed, 0 failed
- [x] `npm run typecheck` — pass
- [ ] Manual: Windows startup should render window before workspace validation completes
- [ ] Manual: TreeView renders file tree immediately, git badges appear shortly after
- [ ] Manual: Root directory with >200 entries shows paginated with Load more

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)