### PR TITLE
fix(settings): 🐛 Fix duplicate Default profile after onboarding restart

### DIFF
--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -1345,11 +1345,12 @@ impl SettingsManager {
             updated_at: String::new(),
         };
 
+        // Insert the row first so that set_default can find it.
+        profile_repo::insert(&self.pool, &record).await?;
+
         if record.is_default {
             profile_repo::set_default(&self.pool, &record.id).await.ok();
         }
-
-        profile_repo::insert(&self.pool, &record).await?;
 
         profile_repo::find_by_id(&self.pool, &record.id)
             .await?

--- a/src/modules/settings-center/model/use-settings-controller.ts
+++ b/src/modules/settings-center/model/use-settings-controller.ts
@@ -1352,6 +1352,7 @@ export function useSettingsController() {
     addWorkspace,
     removeWorkspace,
     setDefaultWorkspace,
+    backendHydrated,
     addProvider,
     removeProvider,
     updateProvider,

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -427,6 +427,7 @@ export function DashboardWorkbench() {
     terminal,
     availableShells,
     policy,
+    backendHydrated: settingsHydrated,
     updateGeneralPreference,
     addWorkspace,
     removeWorkspace,
@@ -3174,7 +3175,7 @@ export function DashboardWorkbench() {
         onDismiss={appUpdater.dismiss}
       />
 
-      {showOnboarding ? (
+      {showOnboarding && settingsHydrated ? (
         <OnboardingWizard
           language={language}
           theme={theme}


### PR DESCRIPTION
## Summary
- Fix race condition where OnboardingWizard rendered before backend hydration, causing duplicate "Default" profiles on restart
- Gate onboarding wizard on `backendHydrated` so it only mounts after DB-backed profiles are ready
- Fix Rust `create_profile()` to insert row before calling `set_default()` (previously silently failed)

## Test Plan
- [ ] Clear app data / fresh profile, complete onboarding with model selections
- [ ] Restart app — verify only one "Default" profile exists with correct models
- [ ] Verify `npm run typecheck`, `cargo check`, `npm run test:unit` all pass

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)