### PR TITLE
fix(windows): 🐛 Fix MCP server launch and plugin source display on Windows

### DIFF
--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -363,6 +363,57 @@ mod tests {
         assert_eq!(bare, None);
     }
 
+    #[test]
+    fn executable_candidates_returns_bare_name_only_on_unix() {
+        // On non-Windows the function always returns only the bare command name.
+        #[cfg(not(target_os = "windows"))]
+        {
+            let candidates = executable_candidates("npx");
+            assert_eq!(candidates, vec![OsString::from("npx")]);
+        }
+    }
+
+    #[test]
+    fn executable_candidates_prioritises_extensions_over_bare_name() {
+        // Regardless of platform, verify the ordering contract: when a bare
+        // command name is provided, PATHEXT-derived candidates must appear
+        // before the bare name so that `.cmd`/`.exe` variants win over Unix
+        // shell shims (the root cause of OS error 193 on Windows).
+        #[cfg(target_os = "windows")]
+        {
+            let candidates = executable_candidates("npx");
+            // Last element must be the bare name.
+            assert_eq!(candidates.last(), Some(&OsString::from("npx")));
+            // First element must be an extension-bearing candidate (e.g. npx.COM).
+            let first = candidates[0].to_string_lossy().to_string();
+            assert!(
+                first.contains('.'),
+                "first candidate should have an extension, got: {first}"
+            );
+            // Bare name must not appear before any extension-bearing candidate.
+            let bare_pos = candidates
+                .iter()
+                .position(|c| c == &OsString::from("npx"))
+                .expect("bare name must be present");
+            assert_eq!(
+                bare_pos,
+                candidates.len() - 1,
+                "bare name should be the last candidate"
+            );
+        }
+    }
+
+    #[test]
+    fn executable_candidates_returns_as_is_when_extension_present() {
+        // When the command already contains an extension, return it as-is
+        // without appending PATHEXT variants.
+        #[cfg(target_os = "windows")]
+        {
+            let candidates = executable_candidates("npx.cmd");
+            assert_eq!(candidates, vec![OsString::from("npx.cmd")]);
+        }
+    }
+
     #[cfg(not(target_os = "windows"))]
     #[tokio::test]
     async fn resolve_command_path_returns_explicit_existing_path_without_path_lookup() {

--- a/src-tauri/src/core/shell_runtime.rs
+++ b/src-tauri/src/core/shell_runtime.rs
@@ -262,7 +262,12 @@ fn executable_candidates(command: &str) -> Vec<OsString> {
 
         let pathext =
             std::env::var_os("PATHEXT").unwrap_or_else(|| OsString::from(".COM;.EXE;.BAT;.CMD"));
-        let mut candidates = vec![OsString::from(command)];
+        // On Windows, prioritise extension-bearing candidates (.exe, .cmd, …)
+        // over the bare name.  Tools like nvm-for-windows place a Unix shell
+        // script shim (`npx`) alongside the real `npx.cmd` in the same
+        // directory; matching the bare name first would resolve to the shell
+        // script, which is not a valid Win32 executable (OS error 193).
+        let mut candidates = Vec::new();
 
         for ext in pathext.to_string_lossy().split(';') {
             let trimmed = ext.trim();
@@ -271,6 +276,9 @@ fn executable_candidates(command: &str) -> Vec<OsString> {
             }
             candidates.push(OsString::from(format!("{command}{trimmed}")));
         }
+
+        // Bare name as last-resort fallback.
+        candidates.push(OsString::from(command));
 
         candidates
     }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -1505,7 +1505,7 @@ impl ExtensionsManager {
         dir: &Path,
         discovered: bool,
     ) -> Result<InstalledPluginRuntime, AppError> {
-        let plugin_dir = fs::canonicalize(dir).map_err(|error| {
+        let plugin_dir = dunce::canonicalize(dir).map_err(|error| {
             AppError::recoverable(
                 ErrorSource::Settings,
                 "extensions.plugin.invalid_path",
@@ -6399,7 +6399,7 @@ Provide a code review for the given pull request."#,
         assert_eq!(runtime.manifest.name, "Marketplace Plugin");
         assert_eq!(
             runtime.path,
-            fs::canonicalize(plugin_dir.path()).expect("canonical plugin path")
+            dunce::canonicalize(plugin_dir.path()).expect("canonical plugin path")
         );
     }
 

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -5090,6 +5090,7 @@ async fn spawn_stdio_mcp_process(
         "spawn_stdio_mcp_process: resolved command path"
     );
     let mut command = Command::new(&program);
+    configure_background_tokio_command(&mut command);
     command.args(config.args.clone().unwrap_or_default());
     if let Some(cwd) = config.cwd.as_deref().filter(|cwd| !cwd.trim().is_empty()) {
         command.current_dir(cwd);


### PR DESCRIPTION
## Summary
- Fix OS error 193 when launching MCP servers via `npx` on Windows (nvm-for-windows). Prioritize PATHEXT candidates (`.cmd`, `.exe`) over bare command names in `executable_candidates`, so `npx.cmd` is resolved instead of the Unix shell shim `npx`.
- Fix installed marketplace plugins showing local absolute paths instead of their marketplace source. Replace `fs::canonicalize` with `dunce::canonicalize` in `load_plugin_from_dir` to avoid Windows UNC path prefix (`\\\\?\\C:\\...`) that broke path-based matching.
- Add missing `configure_background_tokio_command` call in `spawn_stdio_mcp_process` to suppress console window flash on Windows.

## Test Plan
- [ ] Verify MCP server (e.g. context7 via npx) starts successfully on Windows with nvm4w
- [ ] Verify installed marketplace plugins display correct source repository name
- [ ] Verify no console window flash when MCP server spawns on Windows
- [ ] Verify no regression on macOS / Linux

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)