### PR TITLE
fix(extensions): 🐛 Fix MCP tool execution scope mismatch for workspace servers

### DIFF
--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -3207,7 +3207,7 @@ impl ExtensionsManager {
         tracing::info!(server_id, tool = %tool.name, "MCP tool execution starting");
         tracing::debug!(server_id, tool = %tool.name, %tool_input, "MCP tool execution input");
         let config = self
-            .load_mcp_configs_with_scope(Some(workspace_path), ConfigScope::Global)
+            .load_mcp_configs_with_scope(Some(workspace_path), ConfigScope::Workspace)
             .await?
             .into_iter()
             .find(|(config, _)| config.id == server_id)


### PR DESCRIPTION
## Summary
- Fix `execute_mcp_tool` using `ConfigScope::Global` instead of `ConfigScope::Workspace`, causing workspace-scoped MCP servers to fail with `MCP server 'xxx' not found` during tool execution
- `list_runtime_agent_tools` and `resolve_tool` both use `ConfigScope::Workspace` (which includes global + workspace), so tools were correctly injected into prompts but failed at execution time
- Change scope to `ConfigScope::Workspace` to make all three code paths consistent

## Test Plan
- [ ] Add a workspace-scoped MCP server and verify its tools execute successfully
- [ ] Verify global-scoped MCP server tools still work as before
- [ ] Run `cargo check` — ✅ passed

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)