### PR TITLE
feat(extensions-center): ✨ Force user-level storage for extensions & add MCP env editing

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -617,6 +617,8 @@ const en: Record<TranslationKey, string> = {
   "extensions.commandPlaceholder": "command",
   "extensions.argsPlaceholder": "args separated by spaces",
   "extensions.headersHelper": "Use one `Header: value` per line. Masked values are kept unless you replace or remove them.",
+"extensions.envLabel": "Environment Variables",
+"extensions.envHelper": "One `KEY: value` per line. Variables are passed to the server process.",
   "extensions.enableOnSave": "Enable on save",
   "extensions.disabledEntryHint": "Disabled entries stay registered but won't start.",
   "extensions.cancelButton": "Cancel",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -648,6 +648,8 @@ const zhCN = {
   "extensions.argsPlaceholder": "以空格分隔的参数",
   "extensions.headersHelper":
     "每行一个 `Header: value`。掩码值会保留，除非你替换或删除它们。",
+  "extensions.envLabel": "环境变量",
+  "extensions.envHelper": "每行一个 `KEY: value`。变量会传递给服务器进程。",
   "extensions.enableOnSave": "保存时启用",
   "extensions.disabledEntryHint": "禁用的条目保持注册但不会启动。",
   "extensions.cancelButton": "取消",

--- a/src/modules/extensions-center/ui/extensions-center-overlay.tsx
+++ b/src/modules/extensions-center/ui/extensions-center-overlay.tsx
@@ -1849,6 +1849,18 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
                   }
                   placeholder={t("extensions.argsPlaceholder")}
                 />
+                <div className="space-y-2">
+                  <div className="text-sm font-medium text-app-foreground">{t("extensions.envLabel")}</div>
+                  <Textarea
+                    value={mcpEnvText}
+                    onChange={(event) => setMcpEnvText(event.target.value)}
+                    placeholder={"PATH: /usr/local/bin\nNODE_ENV: production"}
+                    className="min-h-28"
+                  />
+                  <div className="text-xs text-app-muted">
+                    {t("extensions.envHelper")}
+                  </div>
+                </div>
               </>
             ) : (
               <>
@@ -1868,19 +1880,6 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
                 </div>
               </>
             )}
-
-            <div className="space-y-2">
-              <div className="text-sm font-medium text-app-foreground">{t("extensions.envLabel")}</div>
-              <Textarea
-                value={mcpEnvText}
-                onChange={(event) => setMcpEnvText(event.target.value)}
-                placeholder={"PATH: /usr/local/bin\nNODE_ENV: production"}
-                className="min-h-28"
-              />
-              <div className="text-xs text-app-muted">
-                {t("extensions.envHelper")}
-              </div>
-            </div>
 
             <div className="flex items-center justify-between rounded-xl border border-app-border bg-app-surface p-3">
               <div>

--- a/src/modules/extensions-center/ui/extensions-center-overlay.tsx
+++ b/src/modules/extensions-center/ui/extensions-center-overlay.tsx
@@ -489,6 +489,7 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
   const [mcpDialogMode, setMcpDialogMode] = useState<"create" | "edit">("create");
   const [mcpForm, setMcpForm] = useState<McpFormState>(createDefaultMcpFormState);
   const [mcpHeadersText, setMcpHeadersText] = useState("");
+  const [mcpEnvText, setMcpEnvText] = useState("");
   const [marketSourceDialogOpen, setMarketSourceDialogOpen] = useState(false);
   const [marketSourceForm, setMarketSourceForm] = useState<MarketplaceSourceInput>({ name: "", url: "" });
   const [marketSourceError, setMarketSourceError] = useState<string | null>(null);
@@ -752,6 +753,7 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
     setMcpDialogMode("create");
     setMcpForm(createDefaultMcpFormState());
     setMcpHeadersText("");
+    setMcpEnvText("");
     setMcpDialogOpen(true);
   };
 
@@ -772,11 +774,13 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
       timeoutMs: server.config.timeoutMs ?? 30_000,
     });
     setMcpHeadersText(formatHeaderMap(server.config.headers));
+    setMcpEnvText(formatHeaderMap(server.config.env));
     setMcpDialogOpen(true);
   };
 
   const handleSubmitMcp = async () => {
     const headers = parseHeaderMapInput(mcpHeadersText);
+    const envMap = parseHeaderMapInput(mcpEnvText);
     const payload: McpServerConfigInput = {
       ...mcpForm,
       command: mcpForm.command?.trim() || undefined,
@@ -784,6 +788,7 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
       url: mcpForm.url?.trim() || undefined,
       args: (mcpForm.args ?? []).filter(Boolean),
       headers: Object.keys(headers).length > 0 ? headers : undefined,
+      env: Object.keys(envMap).length > 0 ? envMap : undefined,
     };
     await runAction(() =>
       mcpDialogMode === "create"
@@ -1863,6 +1868,19 @@ export function ExtensionsCenterOverlay(props: ExtensionsCenterOverlayProps) {
                 </div>
               </>
             )}
+
+            <div className="space-y-2">
+              <div className="text-sm font-medium text-app-foreground">{t("extensions.envLabel")}</div>
+              <Textarea
+                value={mcpEnvText}
+                onChange={(event) => setMcpEnvText(event.target.value)}
+                placeholder={"PATH: /usr/local/bin\nNODE_ENV: production"}
+                className="min-h-28"
+              />
+              <div className="text-xs text-app-muted">
+                {t("extensions.envHelper")}
+              </div>
+            </div>
 
             <div className="flex items-center justify-between rounded-xl border border-app-border bg-app-surface p-3">
               <div>

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -3195,7 +3195,7 @@ export function DashboardWorkbench() {
           onUpdateMcpServer={(id, input) => updateMcpServer(id, input, resolveItemScope(id))}
           onRemoveMcpServer={(id) => removeMcpServer(id, resolveItemScope(id))}
           onRestartMcpServer={(id) => restartMcpServer(id, resolveItemScope(id))}
-          onRescanSkills={() => rescanSkills("global")}
+          onRescanSkills={() => rescanSkills(currentExtensionScope)}
           onEnableSkill={(id) => enableSkill(id, resolveItemScope(id))}
           onDisableSkill={(id) => disableSkill(id, resolveItemScope(id))}
           skillPreviewById={skillPreviewById}

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -3191,11 +3191,11 @@ export function DashboardWorkbench() {
           onRemoveMarketplaceSource={removeMarketplaceSource}
           onRefreshMarketplaceSource={refreshMarketplaceSource}
           onInstallMarketplaceItem={installMarketplaceItem}
-          onAddMcpServer={(input) => addMcpServer(input, currentExtensionScope)}
+          onAddMcpServer={(input) => addMcpServer(input, "global")}
           onUpdateMcpServer={(id, input) => updateMcpServer(id, input, resolveItemScope(id))}
           onRemoveMcpServer={(id) => removeMcpServer(id, resolveItemScope(id))}
           onRestartMcpServer={(id) => restartMcpServer(id, resolveItemScope(id))}
-          onRescanSkills={() => rescanSkills(currentExtensionScope)}
+          onRescanSkills={() => rescanSkills("global")}
           onEnableSkill={(id) => enableSkill(id, resolveItemScope(id))}
           onDisableSkill={(id) => disableSkill(id, resolveItemScope(id))}
           skillPreviewById={skillPreviewById}


### PR DESCRIPTION
## Summary
- Force plugin, MCP, and skill additions to always use global (`~/.tiy`) scope instead of workspace scope, ensuring user-level storage regardless of active workspace.
- Add environment variables editing UI to MCP server add/edit dialog, using the same `KEY: value` per-line format as headers.
- Add i18n keys (en + zh-CN) for the new env label and helper text.

## Test Plan
- [ ] Open a workspace, add a new MCP server → verify it writes to `~/.tiy/mcp.json`, not `<workspace>/.tiy/mcp.json`
- [ ] Edit existing MCP server → verify env values are correctly loaded and saved
- [ ] Create MCP server with env vars (e.g. `PATH: /usr/local/bin`) → verify env persists after re-opening edit dialog
- [ ] Verify rescan skills targets global scope
- [ ] `npm run typecheck` passes
- [ ] `npm run test:unit` passes (14/14)

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)