### PR TITLE
feat(workbench): ✨ Cache preferred Open In app in localStorage

### DIFF
--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -29,6 +29,25 @@ import { useWorkspaceOpenApps } from "@/modules/workbench-shell/model/use-worksp
 import type { ProjectOption, ProjectTreeItem, WorkspaceOpenApp } from "@/modules/workbench-shell/model/types";
 import { ProjectTreeIcon } from "@/modules/workbench-shell/ui/project-tree-icon";
 
+const PREFERRED_OPEN_APP_STORAGE_KEY = "tiy-preferred-open-app-id";
+const FILE_MANAGER_APP_IDS = ["finder", "explorer"];
+
+function readCachedPreferredOpenAppId(): string | null {
+  try {
+    return localStorage.getItem(PREFERRED_OPEN_APP_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedPreferredOpenAppId(id: string): void {
+  try {
+    localStorage.setItem(PREFERRED_OPEN_APP_STORAGE_KEY, id);
+  } catch {
+    // ignore
+  }
+}
+
 const APP_ICON_FALLBACKS: Record<
   string,
   { src?: string; label: string; className: string }
@@ -439,7 +458,7 @@ export function ProjectPanel({
   const [isRefreshingTree, setRefreshingTree] = useState(false);
   const [treeReloadVersion, setTreeReloadVersion] = useState(0);
   const [isOpenMenuOpen, setOpenMenuOpen] = useState(false);
-  const [preferredOpenAppId, setPreferredOpenAppId] = useState<string | null>(null);
+  const [preferredOpenAppId, setPreferredOpenAppId] = useState<string | null>(() => readCachedPreferredOpenAppId());
   const [activeOpenTargetId, setActiveOpenTargetId] = useState<string | null>(null);
   const [openError, setOpenError] = useState<string | null>(null);
   const [copiedPath, setCopiedPath] = useState<string | null>(null);
@@ -499,7 +518,8 @@ export function ProjectPanel({
 
   useEffect(() => {
     if (!preferredOpenAppId || !openApps.some((app) => app.id === preferredOpenAppId)) {
-      setPreferredOpenAppId(openApps[0]?.id ?? null);
+      const fileManagerApp = openApps.find((app) => FILE_MANAGER_APP_IDS.includes(app.id));
+      setPreferredOpenAppId(fileManagerApp?.id ?? openApps[0]?.id ?? null);
     }
   }, [openApps, preferredOpenAppId]);
 
@@ -785,6 +805,7 @@ export function ProjectPanel({
         appPath: app.openWith,
       });
       setPreferredOpenAppId(app.id);
+      writeCachedPreferredOpenAppId(app.id);
       setOpenMenuOpen(false);
       setOpenError(null);
     } catch (error) {


### PR DESCRIPTION
## Summary
- Cache the user's last selected **Open In** app to `localStorage` (`tiy-preferred-open-app-id`).
- On restart or workspace switch, automatically restore the cached app selection.
- If the cached app is no longer available in the list, fall back to the platform file manager (Finder / Explorer), then to the first available app.

## Test Plan
- [ ] Select an Open In app (e.g. VS Code), restart the app → the same app should be pre-selected
- [ ] Switch workspace → cached app persists if available in the new list
- [ ] Uninstall a cached app, restart → falls back to Finder/Explorer
- [ ] Verify tree-view file clicks use the cached preferred app

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)