### PR TITLE
fix(workbench): 🐛 Fix cached Open In app reset on reload

### DIFF
--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -517,6 +517,9 @@ export function ProjectPanel({
   }, [isOpenMenuOpen]);
 
   useEffect(() => {
+    if (openApps.length === 0) {
+      return;
+    }
     if (!preferredOpenAppId || !openApps.some((app) => app.id === preferredOpenAppId)) {
       const fileManagerApp = openApps.find((app) => FILE_MANAGER_APP_IDS.includes(app.id));
       setPreferredOpenAppId(fileManagerApp?.id ?? openApps[0]?.id ?? null);


### PR DESCRIPTION
## Summary
- Fix the cached preferred Open In app being reset to Finder/Explorer on restart or workspace switch.
- Root cause: `openApps` initializes as `[]` during loading, the fallback useEffect fires immediately and clears the cached ID before real data arrives.
- Fix: skip the fallback logic when `openApps.length === 0` (still loading).

## Test Plan
- [ ] Select an Open In app (e.g. VS Code), restart the app → same app is pre-selected
- [ ] Switch workspace → cached app persists if available
- [ ] Uninstall a cached app, restart → correctly falls back to Finder/Explorer

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)