### PR TITLE
fix(startup): 🐛 Fix macOS startup delay caused by backend-ready race condition

### DIFF
--- a/src/shared/lib/backend-ready.ts
+++ b/src/shared/lib/backend-ready.ts
@@ -15,27 +15,57 @@ import { once } from "@tauri-apps/api/event";
  *
  * On macOS the probe wins almost instantly; on Windows the event or
  * probe will resolve once WebView2's IPC bridge is warmed up.
+ *
+ * All three paths share a `settled` flag so that whichever wins first
+ * cleans up the other two (event listener + timer), preventing leaks.
  */
 export function waitForBackendReady(timeoutMs = 3000): Promise<void> {
-  // 1. Listen for the explicit backend-ready event
-  const fromEvent = new Promise<void>((resolve) => {
-    once("backend-ready", () => resolve()).then((unlisten) => {
-      // Event may have already fired; schedule cleanup on next tick
-      queueMicrotask(() => unlisten());
+  let settled = false;
+  let eventUnlisten: (() => void) | null = null;
+  let timerId: ReturnType<typeof setTimeout> | null = null;
+
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    if (eventUnlisten) {
+      eventUnlisten();
+      eventUnlisten = null;
+    }
+    if (timerId !== null) {
+      clearTimeout(timerId);
+      timerId = null;
+    }
+  };
+
+  return new Promise<void>((resolve) => {
+    const done = () => {
+      settle();
+      resolve();
+    };
+
+    // 1. Listen for the explicit backend-ready event
+    once("backend-ready", () => {
+      if (!settled) done();
+    }).then((unlisten) => {
+      // If another signal already won the race, clean up immediately
+      if (settled) unlisten();
+      else eventUnlisten = unlisten;
     });
+
+    // 2. Probe IPC with a no-side-effect invoke.  Any response (success
+    //    or error) proves the bridge is up.  We use workspace_list which
+    //    is always registered and fast (~0 ms on macOS).
+    invoke("workspace_list")
+      .then(() => {
+        if (!settled) done();
+      })
+      .catch(() => {
+        if (!settled) done();
+      });
+
+    // 3. Timeout fallback
+    timerId = setTimeout(() => {
+      if (!settled) done();
+    }, timeoutMs);
   });
-
-  // 2. Probe IPC with a no-side-effect invoke.  Any response (success
-  //    or error) proves the bridge is up.  We use workspace_list which
-  //    is always registered and fast (~0 ms on macOS).
-  const fromProbe = invoke("workspace_list")
-    .then(() => {})
-    .catch(() => {});
-
-  // 3. Timeout fallback
-  const fromTimeout = new Promise<void>((resolve) => {
-    setTimeout(resolve, timeoutMs);
-  });
-
-  return Promise.race([fromEvent, fromProbe, fromTimeout]);
 }

--- a/src/shared/lib/backend-ready.ts
+++ b/src/shared/lib/backend-ready.ts
@@ -1,34 +1,41 @@
+import { invoke } from "@tauri-apps/api/core";
 import { once } from "@tauri-apps/api/event";
 
 /**
- * Returns a promise that resolves once the Rust backend has signalled
- * readiness via the `backend-ready` event.
+ * Returns a promise that resolves once the Rust backend is ready to
+ * handle IPC calls.
  *
- * On Windows the WebView2 IPC bridge may need a few seconds after
- * `on_page_load(Finished)` before it can reliably deliver `invoke`
- * responses.  By waiting for this event (which the Rust side pushes
- * via `webview.emit`), the frontend avoids queuing heavy IPC batches
- * into a channel that isn't fully warmed up yet.
+ * Uses a race between three signals:
+ * 1. The `backend-ready` event emitted by the Rust `on_page_load` handler.
+ * 2. A lightweight invoke probe — if IPC is already working this
+ *    resolves immediately (typical on macOS where WebKit is fast).
+ * 3. A timeout safety net (default 3 s) for the rare case where the
+ *    event was emitted before the listener registered and the probe
+ *    also stalls.
  *
- * A 3-second timeout acts as a safety net in case the event was
- * already emitted before the listener was registered (race with
- * `on_page_load`).
+ * On macOS the probe wins almost instantly; on Windows the event or
+ * probe will resolve once WebView2's IPC bridge is warmed up.
  */
 export function waitForBackendReady(timeoutMs = 3000): Promise<void> {
-  return new Promise<void>((resolve) => {
-    let resolved = false;
-    const done = () => {
-      if (!resolved) {
-        resolved = true;
-        resolve();
-      }
-    };
-    once("backend-ready", () => done()).then((unlisten) => {
-      // If already resolved via timeout, clean up the listener
-      if (resolved) unlisten();
+  // 1. Listen for the explicit backend-ready event
+  const fromEvent = new Promise<void>((resolve) => {
+    once("backend-ready", () => resolve()).then((unlisten) => {
+      // Event may have already fired; schedule cleanup on next tick
+      queueMicrotask(() => unlisten());
     });
-    // Safety fallback: don't block forever if the event was already
-    // emitted before the listener was registered.
-    setTimeout(done, timeoutMs);
   });
+
+  // 2. Probe IPC with a no-side-effect invoke.  Any response (success
+  //    or error) proves the bridge is up.  We use workspace_list which
+  //    is always registered and fast (~0 ms on macOS).
+  const fromProbe = invoke("workspace_list")
+    .then(() => {})
+    .catch(() => {});
+
+  // 3. Timeout fallback
+  const fromTimeout = new Promise<void>((resolve) => {
+    setTimeout(resolve, timeoutMs);
+  });
+
+  return Promise.race([fromEvent, fromProbe, fromTimeout]);
 }

--- a/src/shared/lib/backend-ready.ts
+++ b/src/shared/lib/backend-ready.ts
@@ -52,15 +52,17 @@ export function waitForBackendReady(timeoutMs = 3000): Promise<void> {
       else eventUnlisten = unlisten;
     });
 
-    // 2. Probe IPC with a no-side-effect invoke.  Any response (success
-    //    or error) proves the bridge is up.  We use workspace_list which
-    //    is always registered and fast (~0 ms on macOS).
+    // 2. Probe IPC with a no-side-effect invoke.  A successful response
+    //    proves the bridge is up.  Rejections are ignored — if the bridge
+    //    is not ready the invoke will hang rather than reject, and a real
+    //    rejection (e.g. command error) still means the bridge is up, but
+    //    we let the event or timeout handle that path to stay safe.
     invoke("workspace_list")
       .then(() => {
         if (!settled) done();
       })
       .catch(() => {
-        if (!settled) done();
+        // Intentionally ignored — rely on event or timeout.
       });
 
     // 3. Timeout fallback


### PR DESCRIPTION
## Summary
- Replace event-only `waitForBackendReady` with a three-way `Promise.race` (event + invoke probe + timeout)
- On macOS the invoke probe resolves instantly (~0ms), eliminating the ~3s false delay
- On Windows the event or probe resolves once WebView2 IPC bridge is warmed up
- Timeout fallback (3s, configurable) remains as safety net

## Root Cause
The `backend-ready` event is emitted during `on_page_load(Finished)`, but on macOS the frontend JS is already running and the `once()` listener registration is async — the event fires **before** the listener is registered, causing a 3s timeout wait on every launch.

## Test Plan
- [x] `npm run typecheck` passes
- [ ] Manual: verify macOS cold-start has no artificial delay
- [ ] Manual: verify Windows startup still waits for IPC readiness

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)