### PR TITLE
feat(workbench): ✨ Per-thread agent profile bindings

### DIFF
--- a/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { resolveThreadProfileId } from "./dashboard-workbench";
 
 describe("resolveThreadProfileId", () => {
-  const profileIds = new Set(["p-1", "p-2", "p-3"]);
-  const globalActive = "p-1";
+  const profileIds = new Set(["p-1", "p-2", "p-3", "p-global"]);
+  const globalActive = "p-global";
   const firstProfile = "p-1";
 
   it("returns global active when threadId is null", () => {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { resolveThreadProfileId } from "./dashboard-workbench";
+
+describe("resolveThreadProfileId", () => {
+  const profileIds = new Set(["p-1", "p-2", "p-3"]);
+  const globalActive = "p-1";
+  const firstProfile = "p-1";
+
+  it("returns global active when threadId is null", () => {
+    expect(
+      resolveThreadProfileId(null, { "t-1": "p-2" }, profileIds, globalActive, firstProfile),
+    ).toBe(globalActive);
+  });
+
+  it("returns global active when thread has no binding", () => {
+    expect(
+      resolveThreadProfileId("t-99", {}, profileIds, globalActive, firstProfile),
+    ).toBe(globalActive);
+  });
+
+  it("returns the bound profile when it exists in profileIds", () => {
+    const bindings = { "t-1": "p-2", "t-2": "p-3" };
+    expect(
+      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, firstProfile),
+    ).toBe("p-2");
+    expect(
+      resolveThreadProfileId("t-2", bindings, profileIds, globalActive, firstProfile),
+    ).toBe("p-3");
+  });
+
+  it("falls back to firstProfileId when bound profile was deleted", () => {
+    const bindings = { "t-1": "p-deleted" };
+    expect(
+      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, firstProfile),
+    ).toBe(firstProfile);
+  });
+
+  it("falls back to globalActive when bound profile was deleted and firstProfileId is null", () => {
+    const bindings = { "t-1": "p-deleted" };
+    expect(
+      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, null),
+    ).toBe(globalActive);
+  });
+
+  it("returns global active when profileIds is empty and no binding", () => {
+    expect(
+      resolveThreadProfileId("t-1", {}, new Set(), globalActive, null),
+    ).toBe(globalActive);
+  });
+
+  it("falls back correctly when profileIds is empty but binding exists", () => {
+    const bindings = { "t-1": "p-1" };
+    expect(
+      resolveThreadProfileId("t-1", bindings, new Set(), globalActive, null),
+    ).toBe(globalActive);
+  });
+});

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -153,7 +153,7 @@ const SIDEBAR_AUTO_REFRESH_GRACE_MS = 20_000;
  *  2. Global active profile (= last actively-switched profile).
  *  3. First profile in the list (fallback when the bound profile was deleted).
  */
-function resolveThreadProfileId(
+export function resolveThreadProfileId(
   threadId: string | null,
   bindings: Record<string, string>,
   profileIds: ReadonlySet<string>,
@@ -1270,6 +1270,8 @@ export function DashboardWorkbench() {
         if (!cancelled && stored?.value) {
           const parsed = JSON.parse(String(stored.value));
           if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            // Mark to skip the persistence effect that will fire from this setState.
+            threadProfileBindingsSkipNextPersistRef.current = true;
             setThreadProfileBindings(parsed as Record<string, string>);
           }
         }
@@ -1303,9 +1305,16 @@ export function DashboardWorkbench() {
   }, [syncWorkspaceSidebar]);
 
   // Persist thread-profile bindings to backend KV whenever they change.
+  const threadProfileBindingsSkipNextPersistRef = useRef(false);
   useEffect(() => {
     if (!threadProfileBindingsLoadedRef.current) return;
     if (!isTauri()) return;
+
+    // Skip the write triggered immediately after hydration (same data).
+    if (threadProfileBindingsSkipNextPersistRef.current) {
+      threadProfileBindingsSkipNextPersistRef.current = false;
+      return;
+    }
 
     // Cap to most recent 200 entries (by insertion order, which is recent-enough for UUIDv7 keys).
     const MAX_THREAD_PROFILE_BINDINGS = 200;
@@ -1338,6 +1347,27 @@ export function DashboardWorkbench() {
       return changed ? next : current;
     });
   }, [agentProfiles, profileIdSet]);
+
+  // After hydration (or any external update) of thread-profile bindings,
+  // re-evaluate the active thread's profile so that a thread selected before
+  // hydration completed gets its correct profile restored.
+  useEffect(() => {
+    if (!threadProfileBindingsLoadedRef.current) return;
+    if (isNewThreadMode || !activeThread?.id) return;
+
+    const resolved = resolveThreadProfileId(
+      activeThread.id,
+      threadProfileBindings,
+      profileIdSet,
+      activeAgentProfileId,
+      firstProfileId,
+    );
+    if (resolved !== activeAgentProfileId) {
+      setActiveAgentProfile(resolved);
+    }
+    // Only re-run when the bindings map itself changes — not on every profile switch.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [threadProfileBindings]);
 
   useEffect(() => {
     if (!terminalResize || typeof window === "undefined") {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -52,6 +52,8 @@ import type {
   WorkspaceDto,
 } from "@/shared/types/api";
 import {
+  settingsGet,
+  settingsSet,
   threadCreate,
   threadDelete,
   threadList,
@@ -142,6 +144,29 @@ const DEFAULT_TERMINAL_COLLAPSED = true;
 const WORKSPACE_THREAD_PAGE_SIZE = 10;
 const SIDEBAR_AUTO_REFRESH_INTERVAL_MS = 2_000;
 const SIDEBAR_AUTO_REFRESH_GRACE_MS = 20_000;
+
+/**
+ * Resolve which profile a thread should use.
+ *
+ * Priority:
+ *  1. Persisted binding for this thread, if the profile still exists.
+ *  2. Global active profile (= last actively-switched profile).
+ *  3. First profile in the list (fallback when the bound profile was deleted).
+ */
+function resolveThreadProfileId(
+  threadId: string | null,
+  bindings: Record<string, string>,
+  profileIds: ReadonlySet<string>,
+  globalActiveProfileId: string,
+  firstProfileId: string | null,
+): string {
+  if (!threadId) return globalActiveProfileId;
+  const boundId = bindings[threadId];
+  if (!boundId) return globalActiveProfileId;
+  if (profileIds.has(boundId)) return boundId;
+  // Bound profile was deleted → fall back to first available profile.
+  return firstProfileId ?? globalActiveProfileId;
+}
 
 function buildInitialWorkspaceThreadDisplayCounts() {
   return Object.fromEntries(
@@ -484,6 +509,10 @@ export function DashboardWorkbench() {
   const [terminalThreadBindings, setTerminalThreadBindings] = useState<
     Record<string, string>
   >({});
+  const [threadProfileBindings, setThreadProfileBindings] = useState<
+    Record<string, string>
+  >({});
+  const threadProfileBindingsLoadedRef = useRef(false);
   const [composerValue, setComposerValue] = useState("");
   const [composerDrafts, setComposerDrafts] = useState<Record<string, string>>({});
   const [composerError, setComposerError] = useState<string | null>(null);
@@ -569,6 +598,11 @@ export function DashboardWorkbench() {
   const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
   const activeThread = getActiveThread(workspaces);
+  const profileIdSet = useMemo(
+    () => new Set(agentProfiles.map((p) => p.id)),
+    [agentProfiles],
+  );
+  const firstProfileId = agentProfiles[0]?.id ?? null;
   const selectedProjectWorkspaceId = getWorkspaceBindingId(
     terminalWorkspaceBindings,
     selectedProject?.path ?? null,
@@ -1229,6 +1263,23 @@ export function DashboardWorkbench() {
     void (async () => {
       await waitForBackendReady();
       if (cancelled) return;
+
+      // Hydrate thread-profile bindings from backend KV
+      try {
+        const stored = await settingsGet("thread_profile_bindings");
+        if (!cancelled && stored?.value) {
+          const parsed = JSON.parse(String(stored.value));
+          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+            setThreadProfileBindings(parsed as Record<string, string>);
+          }
+        }
+      } catch {
+        // Ignore corrupted JSON – fall back to empty bindings
+      }
+      if (!cancelled) {
+        threadProfileBindingsLoadedRef.current = true;
+      }
+
       await syncWorkspaceSidebar();
     })()
       .then(() => {
@@ -1250,6 +1301,43 @@ export function DashboardWorkbench() {
       cancelled = true;
     };
   }, [syncWorkspaceSidebar]);
+
+  // Persist thread-profile bindings to backend KV whenever they change.
+  useEffect(() => {
+    if (!threadProfileBindingsLoadedRef.current) return;
+    if (!isTauri()) return;
+
+    // Cap to most recent 200 entries (by insertion order, which is recent-enough for UUIDv7 keys).
+    const MAX_THREAD_PROFILE_BINDINGS = 200;
+    const entries = Object.entries(threadProfileBindings);
+    const trimmed =
+      entries.length > MAX_THREAD_PROFILE_BINDINGS
+        ? Object.fromEntries(entries.slice(-MAX_THREAD_PROFILE_BINDINGS))
+        : threadProfileBindings;
+
+    void settingsSet("thread_profile_bindings", JSON.stringify(trimmed)).catch(
+      () => {
+        // Best-effort persistence — silently ignore write failures.
+      },
+    );
+  }, [threadProfileBindings]);
+
+  // Remove thread-profile bindings that reference a deleted profile.
+  useEffect(() => {
+    if (!agentProfiles.length) return;
+    setThreadProfileBindings((current) => {
+      let changed = false;
+      const next: Record<string, string> = {};
+      for (const [tid, pid] of Object.entries(current)) {
+        if (profileIdSet.has(pid)) {
+          next[tid] = pid;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : current;
+    });
+  }, [agentProfiles, profileIdSet]);
 
   useEffect(() => {
     if (!terminalResize || typeof window === "undefined") {
@@ -1691,6 +1779,18 @@ export function DashboardWorkbench() {
     setActiveWorkspaceMenuId(null);
     setPendingDeleteThreadId(null);
     setWorkspaces((current) => activateThread(current, threadId));
+
+    // Restore the profile that was last used on this thread.
+    const resolved = resolveThreadProfileId(
+      threadId,
+      threadProfileBindings,
+      profileIdSet,
+      activeAgentProfileId,
+      firstProfileId,
+    );
+    if (resolved !== activeAgentProfileId) {
+      setActiveAgentProfile(resolved);
+    }
   };
 
   const handleProjectSelect = (project: ProjectOption) => {
@@ -1866,6 +1966,12 @@ export function DashboardWorkbench() {
                 ([, boundThreadId]) => boundThreadId !== threadId,
               ),
             );
+            return next;
+          });
+          setThreadProfileBindings((current) => {
+            if (!(threadId in current)) return current;
+            const next = { ...current };
+            delete next[threadId];
             return next;
           });
 
@@ -2103,6 +2209,14 @@ export function DashboardWorkbench() {
           }));
         }
 
+        // Bind the current profile to the newly created thread.
+        if (persistedThreadId) {
+          setThreadProfileBindings((current) => ({
+            ...current,
+            [persistedThreadId]: activeAgentProfileId,
+          }));
+        }
+
         setNewThreadMode(false);
         setNewThreadRunMode("default");
         setComposerValue("");
@@ -2136,6 +2250,21 @@ export function DashboardWorkbench() {
     setLanguage(nextLanguage);
     setOpenSettingsSection("language");
   };
+
+  // Wrapper: when user switches profile inside an active thread, also record
+  // the binding so it's restored when the user switches back to this thread.
+  const handleSelectAgentProfileForThread = useCallback(
+    (profileId: string) => {
+      setActiveAgentProfile(profileId);
+      if (!isNewThreadMode && activeThread?.id) {
+        setThreadProfileBindings((current) => ({
+          ...current,
+          [activeThread.id]: profileId,
+        }));
+      }
+    },
+    [activeThread?.id, isNewThreadMode, setActiveAgentProfile],
+  );
 
   const handleOpenSettings = (category: SettingsCategory = "general") => {
     setActiveSettingsCategory(category);
@@ -2983,7 +3112,7 @@ export function DashboardWorkbench() {
                         }}
                         onContextUsageChange={setRuntimeContextUsage}
                         onRunStateChange={handleRuntimeThreadRunStateChange}
-                        onSelectAgentProfile={setActiveAgentProfile}
+                        onSelectAgentProfile={handleSelectAgentProfileForThread}
                         onThreadTitleChange={handleRuntimeThreadTitleChange}
                         providers={providers}
                         threadId={resolvedTerminalThreadId}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2082,6 +2082,16 @@ export function RuntimeThreadSurface({
   const [selectedRunMode, setSelectedRunMode] = useState<RunMode>("default");
   const [snapshotReady, setSnapshotReady] = useState(false);
   const [snapshotThreadId, setSnapshotThreadId] = useState<string | null>(null);
+
+  // Reset run mode (plan toggle) when switching to a different thread so it
+  // doesn't leak from one thread to another.
+  const prevThreadIdRef = useRef(threadId);
+  useEffect(() => {
+    if (prevThreadIdRef.current !== threadId) {
+      prevThreadIdRef.current = threadId;
+      setSelectedRunMode("default");
+    }
+  }, [threadId]);
   const [thinkingPlaceholder, setThinkingPlaceholder] = useState<ThinkingPlaceholder | null>(null);
   const [tools, setTools] = useState<Array<SurfaceToolEntry>>([]);
   const [completedToolOpen, setCompletedToolOpen] = useState<Record<string, boolean>>({});


### PR DESCRIPTION
## Summary
- 每个 Thread 独立记录所使用的 Profile，切换 Thread 时自动恢复对应 Profile
- 缓存最近一次主动切换的 Profile，New Thread 默认使用该 Profile
- Profile 被删除时，所有引用该 Profile 的 Thread 绑定自动清理，回退到列表第一个

## Changes
- 新增 `resolveThreadProfileId` 辅助函数，按优先级解析 Thread 应使用的 Profile（绑定 > 全局 active > 列表首个）
- 新增 `threadProfileBindings` state（`Record<threadId, profileId>`），启动时从后端 KV `thread_profile_bindings` 加载，变化时写回（上限 200 条）
- `handleThreadSelect` 切换 Thread 时调用 resolve 恢复 Profile
- `handleSelectAgentProfileForThread` 包装回调：在活跃 Thread 内切换 Profile 时同时写入绑定
- New Thread 创建成功后自动绑定当前 `activeAgentProfileId`
- Profile 删除时 `useEffect` 清理所有无效绑定
- Thread 删除时同步清除对应绑定条目

## Test Plan
- [x] `npm run typecheck` 通过
- [x] `npm run test:unit` 通过（14 tests）
- [ ] 手动验证：Thread A 切 P2、Thread B 切 P3，来回切换恢复正确
- [ ] 手动验证：New Thread 使用最近切换的 Profile
- [ ] 手动验证：删除 Profile 后 Thread 自动回退
- [ ] 手动验证：重启应用后绑定持久化正确

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)