### PR TITLE
feat(worktree): ✨ Add Git worktree support to workspaces

### DIFF
--- a/src-tauri/migrations/20260418000000_workspace_worktree_support.sql
+++ b/src-tauri/migrations/20260418000000_workspace_worktree_support.sql
@@ -1,0 +1,18 @@
+-- Tiy Agent: add Git worktree support columns to `workspaces` table.
+-- Date: 2026-04-18
+-- Description: Extends `workspaces` so that a worktree can be modeled as a
+--              workspace row with a pointer to its parent repo workspace.
+--              Historical rows keep `kind='standalone'`; they are upgraded to
+--              `kind='repo'` by WorkspaceManager when detected as a Git repo.
+
+ALTER TABLE workspaces ADD COLUMN kind TEXT NOT NULL DEFAULT 'standalone';
+ALTER TABLE workspaces ADD COLUMN parent_workspace_id TEXT NULL REFERENCES workspaces(id);
+ALTER TABLE workspaces ADD COLUMN git_common_dir TEXT NULL;
+ALTER TABLE workspaces ADD COLUMN branch TEXT NULL;
+ALTER TABLE workspaces ADD COLUMN worktree_name TEXT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_parent
+    ON workspaces(parent_workspace_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_kind
+    ON workspaces(kind);

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -44,7 +44,7 @@ pub async fn workspace_ensure_default(
 
 #[tauri::command]
 pub async fn workspace_remove(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
-    state.workspace_manager.remove(&id).await
+    state.workspace_manager.remove(&id, true).await
 }
 
 #[tauri::command]
@@ -102,12 +102,12 @@ pub async fn workspace_remove_worktree(
 ) -> Result<(), AppError> {
     // Physical removal + DB cascade are both handled inside
     // `workspace_manager.remove`: it detects the `kind=worktree` row, calls
-    // the injected `WorktreeManager::remove_physical` with force=true, and
-    // then deletes the DB rows (threads / terminals / runs cascade included).
-    // Keeping `force` in the signature for API stability even though the
-    // current implementation always forces.
-    let _ = force;
-    state.workspace_manager.remove(&id).await
+    // the injected `WorktreeManager::remove_physical`, and then deletes the
+    // DB rows (threads / terminals / runs cascade included).
+    state
+        .workspace_manager
+        .remove(&id, force.unwrap_or(true))
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -43,8 +43,15 @@ pub async fn workspace_ensure_default(
 }
 
 #[tauri::command]
-pub async fn workspace_remove(state: State<'_, AppState>, id: String) -> Result<(), AppError> {
-    state.workspace_manager.remove(&id, true).await
+pub async fn workspace_remove(
+    state: State<'_, AppState>,
+    id: String,
+    force: Option<bool>,
+) -> Result<(), AppError> {
+    state
+        .workspace_manager
+        .remove(&id, force.unwrap_or(false))
+        .await
 }
 
 #[tauri::command]
@@ -106,7 +113,7 @@ pub async fn workspace_remove_worktree(
     // DB rows (threads / terminals / runs cascade included).
     state
         .workspace_manager
-        .remove(&id, force.unwrap_or(true))
+        .remove(&id, force.unwrap_or(false))
         .await
 }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1,8 +1,10 @@
 use tauri::State;
 
 use crate::core::app_state::AppState;
-use crate::model::errors::AppError;
-use crate::model::workspace::{WorkspaceAddInput, WorkspaceDto};
+use crate::core::worktree_manager::WorktreeInfoDto;
+use crate::model::errors::{AppError, ErrorSource};
+use crate::model::workspace::{WorkspaceAddInput, WorkspaceDto, WorktreeCreateInput};
+use crate::persistence::repo::workspace_repo;
 
 #[tauri::command]
 pub async fn workspace_list(state: State<'_, AppState>) -> Result<Vec<WorkspaceDto>, AppError> {
@@ -57,4 +59,62 @@ pub async fn workspace_validate(
 ) -> Result<WorkspaceDto, AppError> {
     let record = state.workspace_manager.validate(&id).await?;
     Ok(WorkspaceDto::from(record))
+}
+
+// ---------------------------------------------------------------------------
+// Worktree commands
+// ---------------------------------------------------------------------------
+
+async fn load_workspace(
+    state: &State<'_, AppState>,
+    id: &str,
+) -> Result<crate::model::workspace::WorkspaceRecord, AppError> {
+    workspace_repo::find_by_id(&state.pool, id)
+        .await?
+        .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))
+}
+
+#[tauri::command]
+pub async fn workspace_list_worktrees(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<Vec<WorktreeInfoDto>, AppError> {
+    let parent = load_workspace(&state, &workspace_id).await?;
+    state.worktree_manager.list(&parent).await
+}
+
+#[tauri::command]
+pub async fn workspace_create_worktree(
+    state: State<'_, AppState>,
+    workspace_id: String,
+    input: WorktreeCreateInput,
+) -> Result<WorkspaceDto, AppError> {
+    let parent = load_workspace(&state, &workspace_id).await?;
+    let record = state.worktree_manager.create(&parent, input).await?;
+    Ok(WorkspaceDto::from(record))
+}
+
+#[tauri::command]
+pub async fn workspace_remove_worktree(
+    state: State<'_, AppState>,
+    id: String,
+    force: Option<bool>,
+) -> Result<(), AppError> {
+    // Physical removal + DB cascade are both handled inside
+    // `workspace_manager.remove`: it detects the `kind=worktree` row, calls
+    // the injected `WorktreeManager::remove_physical` with force=true, and
+    // then deletes the DB rows (threads / terminals / runs cascade included).
+    // Keeping `force` in the signature for API stability even though the
+    // current implementation always forces.
+    let _ = force;
+    state.workspace_manager.remove(&id).await
+}
+
+#[tauri::command]
+pub async fn workspace_prune_worktrees(
+    state: State<'_, AppState>,
+    workspace_id: String,
+) -> Result<(), AppError> {
+    let parent = load_workspace(&state, &workspace_id).await?;
+    state.worktree_manager.prune(&parent).await
 }

--- a/src-tauri/src/core/app_state.rs
+++ b/src-tauri/src/core/app_state.rs
@@ -13,6 +13,7 @@ use crate::core::terminal_manager::TerminalManager;
 use crate::core::thread_manager::ThreadManager;
 use crate::core::tool_gateway::ToolGateway;
 use crate::core::workspace_manager::WorkspaceManager;
+use crate::core::worktree_manager::WorktreeManager;
 use crate::extensions::ExtensionsManager;
 
 /// Global application state shared across all Tauri commands.
@@ -21,6 +22,7 @@ use crate::extensions::ExtensionsManager;
 pub struct AppState {
     pub pool: SqlitePool,
     pub workspace_manager: WorkspaceManager,
+    pub worktree_manager: Arc<WorktreeManager>,
     pub settings_manager: SettingsManager,
     pub prompt_command_manager: PromptCommandManager,
     pub thread_manager: ThreadManager,
@@ -37,6 +39,8 @@ pub struct AppState {
 impl AppState {
     pub fn new(pool: SqlitePool, app_handle: AppHandle) -> Self {
         let workspace_manager = WorkspaceManager::new(pool.clone());
+        let worktree_manager = Arc::new(WorktreeManager::new(pool.clone()));
+        workspace_manager.set_worktree_manager(Arc::clone(&worktree_manager));
         let settings_manager = SettingsManager::new(pool.clone());
         let prompt_command_manager = PromptCommandManager::new();
         let thread_manager = ThreadManager::new(pool.clone());
@@ -63,6 +67,7 @@ impl AppState {
         Self {
             pool,
             workspace_manager,
+            worktree_manager,
             settings_manager,
             prompt_command_manager,
             thread_manager,

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -25,6 +25,7 @@ pub mod tool_gateway;
 pub mod windows_process;
 pub mod workspace_manager;
 pub mod workspace_paths;
+pub mod worktree_manager;
 
 /// Returns the default HTTP headers that identify TiyCode in every LLM API request.
 pub fn tiycode_default_headers() -> std::collections::HashMap<String, String> {

--- a/src-tauri/src/core/plan_checkpoint.rs
+++ b/src-tauri/src/core/plan_checkpoint.rs
@@ -415,7 +415,7 @@ mod tests {
         approval_prompt_markdown, build_approval_prompt_metadata,
         build_plan_artifact_from_tool_input, build_plan_message_metadata,
         parse_approval_prompt_metadata, parse_plan_message_metadata, plan_markdown,
-        write_plan_file, write_plan_file_to, PlanApprovalAction,
+        write_plan_file_to, PlanApprovalAction,
     };
 
     #[test]

--- a/src-tauri/src/core/plan_checkpoint.rs
+++ b/src-tauri/src/core/plan_checkpoint.rs
@@ -375,7 +375,7 @@ fn read_prose_field(value: Option<&serde_json::Value>) -> String {
 // Plan file persistence — write plan markdown to ~/.tiy/plans/{thread_id}.md
 // ---------------------------------------------------------------------------
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Return the directory used for plan file persistence.
 pub fn plan_file_dir() -> Option<PathBuf> {
@@ -393,7 +393,17 @@ pub fn write_plan_file(thread_id: &str, markdown: &str) -> Result<PathBuf, std::
     let dir = plan_file_dir().ok_or_else(|| {
         std::io::Error::new(std::io::ErrorKind::NotFound, "home directory not available")
     })?;
-    std::fs::create_dir_all(&dir)?;
+    write_plan_file_to(&dir, thread_id, markdown)
+}
+
+/// Write plan markdown to an explicit directory. Creates it if needed.
+/// Returns the written path on success.
+fn write_plan_file_to(
+    dir: &Path,
+    thread_id: &str,
+    markdown: &str,
+) -> Result<PathBuf, std::io::Error> {
+    std::fs::create_dir_all(dir)?;
     let path = dir.join(format!("{thread_id}.md"));
     std::fs::write(&path, markdown)?;
     Ok(path)
@@ -405,7 +415,7 @@ mod tests {
         approval_prompt_markdown, build_approval_prompt_metadata,
         build_plan_artifact_from_tool_input, build_plan_message_metadata,
         parse_approval_prompt_metadata, parse_plan_message_metadata, plan_markdown,
-        write_plan_file, PlanApprovalAction,
+        write_plan_file, write_plan_file_to, PlanApprovalAction,
     };
 
     #[test]
@@ -507,25 +517,25 @@ mod tests {
 
     #[test]
     fn write_plan_file_creates_and_overwrites() {
-        // Use a unique thread ID to avoid collisions with parallel test runs.
+        // Use a dedicated tempdir so this test never races with parallel tests
+        // that mutate $HOME.
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let plans_dir = temp_dir.path().join("plans");
         let thread_id = format!("test-plan-file-{}", std::process::id());
 
         // First write creates the file.
-        let path = write_plan_file(&thread_id, "# Revision 1\n\nFirst draft.")
+        let path = write_plan_file_to(&plans_dir, &thread_id, "# Revision 1\n\nFirst draft.")
             .expect("first write should succeed");
         assert!(path.exists());
         let content = std::fs::read_to_string(&path).expect("read first revision");
         assert!(content.contains("# Revision 1"));
 
-        // Second write overwrites.
-        let path2 = write_plan_file(&thread_id, "# Revision 2\n\nRefined plan.")
+        // Second write overwrites the same file.
+        let path2 = write_plan_file_to(&plans_dir, &thread_id, "# Revision 2\n\nRefined plan.")
             .expect("second write should succeed");
         assert_eq!(path, path2);
-        let content = std::fs::read_to_string(&path).expect("read second revision");
+        let content = std::fs::read_to_string(&path2).expect("read second revision");
         assert!(content.contains("# Revision 2"));
         assert!(!content.contains("# Revision 1"));
-
-        // Cleanup
-        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -159,7 +159,7 @@ impl WorkspaceManager {
     ///   then cleaned via the repo-level cascade.
     /// - If the row is `kind=repo`, its child worktree rows are cleaned up the
     ///   same way before the repo row itself is deleted.
-    pub async fn remove(&self, id: &str) -> Result<(), AppError> {
+    pub async fn remove(&self, id: &str, force: bool) -> Result<(), AppError> {
         let record = workspace_repo::find_by_id(&self.pool, id)
             .await?
             .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
@@ -171,7 +171,7 @@ impl WorkspaceManager {
                     // `.git/worktrees/<name>` registration. `remove_physical`
                     // is tolerant of an already-missing directory, so any
                     // error here is worth surfacing to the caller.
-                    manager.remove_physical(&record, true).await?;
+                    manager.remove_physical(&record, force).await?;
                 }
             }
             WorkspaceKind::Repo => {

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -2,19 +2,38 @@ use chrono::Utc;
 use sqlx::SqlitePool;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::{fs, task};
 
+use crate::core::worktree_manager::WorktreeManager;
 use crate::model::errors::{AppError, ErrorSource};
-use crate::model::workspace::{WorkspaceAddInput, WorkspaceRecord, WorkspaceStatus};
+use crate::model::workspace::{WorkspaceAddInput, WorkspaceKind, WorkspaceRecord, WorkspaceStatus};
 use crate::persistence::repo::workspace_repo;
 
 pub struct WorkspaceManager {
     pool: SqlitePool,
+    worktree_manager: std::sync::OnceLock<Arc<WorktreeManager>>,
 }
 
 impl WorkspaceManager {
     pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            worktree_manager: std::sync::OnceLock::new(),
+        }
+    }
+
+    /// Inject the worktree manager so that `remove` can physically clean up
+    /// `.git/worktrees/<name>` entries when deleting a worktree row or a repo
+    /// row with child worktrees. Without this injection, `remove` falls back
+    /// to DB-only cleanup (worktree directories must then be removed with
+    /// `git worktree prune` manually).
+    pub fn set_worktree_manager(&self, manager: Arc<WorktreeManager>) {
+        let _ = self.worktree_manager.set(manager);
+    }
+
+    fn worktree_manager(&self) -> Option<&Arc<WorktreeManager>> {
+        self.worktree_manager.get()
     }
 
     /// List all workspaces, ordered by default first, then by updated_at.
@@ -80,8 +99,14 @@ impl WorkspaceManager {
             .unwrap_or_else(|| derive_name_from_path(&canonical));
         let display_path = derive_display_path(&canonical).await;
 
-        // Detect git repository
+        // Detect git repository. A worktree child's `.git` is a file, while a
+        // regular repo's is a directory; either means Git is in play.
         let is_git = fs::metadata(canonical.join(".git")).await.is_ok();
+        let kind = if is_git {
+            WorkspaceKind::Repo
+        } else {
+            WorkspaceKind::Standalone
+        };
 
         let record = WorkspaceRecord {
             id: uuid::Uuid::now_v7().to_string(),
@@ -96,6 +121,11 @@ impl WorkspaceManager {
             last_validated_at: Some(Utc::now()),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            kind,
+            parent_workspace_id: None,
+            git_common_dir: None,
+            branch: None,
+            worktree_name: None,
         };
 
         workspace_repo::insert(&self.pool, &record).await?;
@@ -122,17 +152,64 @@ impl WorkspaceManager {
     }
 
     /// Remove a workspace by ID.
+    ///
+    /// Worktree-aware semantics:
+    /// - If the row is `kind=worktree`, the underlying `git worktree remove`
+    ///   is executed first (when a worktree manager is injected); DB rows are
+    ///   then cleaned via the repo-level cascade.
+    /// - If the row is `kind=repo`, its child worktree rows are cleaned up the
+    ///   same way before the repo row itself is deleted.
     pub async fn remove(&self, id: &str) -> Result<(), AppError> {
+        let record = workspace_repo::find_by_id(&self.pool, id)
+            .await?
+            .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
+
+        match record.kind {
+            WorkspaceKind::Worktree => {
+                if let Some(manager) = self.worktree_manager() {
+                    // Physically remove the worktree directory and the
+                    // `.git/worktrees/<name>` registration. `remove_physical`
+                    // is tolerant of an already-missing directory, so any
+                    // error here is worth surfacing to the caller.
+                    manager.remove_physical(&record, true).await?;
+                }
+            }
+            WorkspaceKind::Repo => {
+                let children = workspace_repo::list_worktrees_of(&self.pool, &record.id).await?;
+                for child in children {
+                    if let Some(manager) = self.worktree_manager() {
+                        manager.remove_physical(&child, true).await?;
+                    }
+                    workspace_repo::delete(&self.pool, &child.id).await?;
+                }
+            }
+            WorkspaceKind::Standalone => {}
+        }
+
         let deleted = workspace_repo::delete(&self.pool, id).await?;
         if !deleted {
             return Err(AppError::not_found(ErrorSource::Workspace, "workspace"));
         }
-        tracing::info!(workspace_id = %id, "workspace removed");
+        tracing::info!(
+            workspace_id = %id,
+            kind = %record.kind.as_str(),
+            "workspace removed"
+        );
         Ok(())
     }
 
-    /// Set a workspace as the default.
+    /// Set a workspace as the default. Worktree rows cannot be the default.
     pub async fn set_default(&self, id: &str) -> Result<(), AppError> {
+        let record = workspace_repo::find_by_id(&self.pool, id)
+            .await?
+            .ok_or_else(|| AppError::not_found(ErrorSource::Workspace, "workspace"))?;
+        if record.kind == WorkspaceKind::Worktree {
+            return Err(AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.default.worktree_not_allowed",
+                "A worktree cannot be set as the default workspace",
+            ));
+        }
         workspace_repo::set_default(&self.pool, id).await?;
         tracing::info!(workspace_id = %id, "workspace set as default");
         Ok(())
@@ -176,6 +253,24 @@ impl WorkspaceManager {
         let is_git = fs::metadata(canonical.join(".git")).await.is_ok();
         if is_git != record.is_git {
             workspace_repo::update_is_git(&self.pool, &record.id, is_git).await?;
+        }
+
+        // Auto-upgrade standalone Git workspaces to `kind=repo` so the sidebar
+        // can offer worktree actions. Never downgrade repo or worktree rows.
+        if is_git
+            && record.kind == WorkspaceKind::Standalone
+            && record.parent_workspace_id.is_none()
+        {
+            workspace_repo::update_kind_metadata(
+                &self.pool,
+                &record.id,
+                WorkspaceKind::Repo,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?;
         }
 
         workspace_repo::update_status(&self.pool, &record.id, &new_status, now).await?;

--- a/src-tauri/src/core/workspace_manager.rs
+++ b/src-tauri/src/core/workspace_manager.rs
@@ -178,7 +178,7 @@ impl WorkspaceManager {
                 let children = workspace_repo::list_worktrees_of(&self.pool, &record.id).await?;
                 for child in children {
                     if let Some(manager) = self.worktree_manager() {
-                        manager.remove_physical(&child, true).await?;
+                        manager.remove_physical(&child, force).await?;
                     }
                     workspace_repo::delete(&self.pool, &child.id).await?;
                 }

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -1,0 +1,656 @@
+//! Git worktree management for workspace rows.
+//!
+//! Worktrees are modeled as workspace rows with `kind = 'worktree'` and a
+//! `parent_workspace_id` pointing to the repo's workspace row. This module
+//! owns the lifecycle of those rows: listing, creating, and deleting the
+//! underlying Git worktree alongside the DB record.
+//!
+//! The Git operations themselves are executed via the `git` CLI (already used
+//! by the rest of the codebase). Creating worktrees via the CLI keeps feature
+//! parity with `--track`, `-b` and remote branches, which is important for
+//! downstream UX even though the read-only enumeration below also works via
+//! `git2`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use chrono::Utc;
+use git2::Repository;
+use serde::Serialize;
+use sqlx::SqlitePool;
+use tokio::task;
+
+use crate::core::windows_process::configure_background_std_command;
+use crate::model::errors::{AppError, ErrorCategory, ErrorSource};
+use crate::model::workspace::{
+    WorkspaceKind, WorkspaceRecord, WorkspaceStatus, WorktreeCreateInput,
+};
+use crate::persistence::repo::workspace_repo;
+
+const WORKTREE_OUTPUT_LIMIT: usize = 32_000;
+
+/// Information about a git worktree, including whether it has been registered
+/// as a TiyCode workspace row.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeInfoDto {
+    /// The git worktree name (i.e. the directory name inside
+    /// `.git/worktrees/`). Used as the first-6-char tag on the frontend.
+    pub name: String,
+    pub path: String,
+    pub branch: Option<String>,
+    pub head: Option<String>,
+    pub is_valid: bool,
+    pub is_locked: bool,
+    /// Workspace id when this worktree has been registered.
+    pub workspace_id: Option<String>,
+}
+
+pub struct WorktreeManager {
+    pool: SqlitePool,
+}
+
+impl WorktreeManager {
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    /// List the worktrees discovered from the parent repo, merged with any
+    /// worktree workspaces already registered in the DB.
+    pub async fn list(&self, parent: &WorkspaceRecord) -> Result<Vec<WorktreeInfoDto>, AppError> {
+        require_repo_kind(parent)?;
+
+        let repo_root = parent.canonical_path.clone();
+        let git_infos = task::spawn_blocking(move || enumerate_git_worktrees(&repo_root))
+            .await
+            .map_err(|error| {
+                AppError::internal(
+                    ErrorSource::Git,
+                    format!("worktree enumeration task failed: {error}"),
+                )
+            })??;
+
+        let registered = workspace_repo::list_worktrees_of(&self.pool, &parent.id).await?;
+
+        let mut results = Vec::with_capacity(git_infos.len().max(registered.len()));
+        for info in git_infos {
+            let matching =
+                registered
+                    .iter()
+                    .find(|row| match (&row.worktree_name, &row.canonical_path) {
+                        (Some(name), _) if name == &info.name => true,
+                        (_, path) => path == &info.path,
+                    });
+            results.push(WorktreeInfoDto {
+                workspace_id: matching.map(|row| row.id.clone()),
+                ..info
+            });
+        }
+        Ok(results)
+    }
+
+    /// Create a new worktree for the given repo workspace, register a
+    /// `kind='worktree'` workspace row for it, and return the new record.
+    pub async fn create(
+        &self,
+        parent: &WorkspaceRecord,
+        input: WorktreeCreateInput,
+    ) -> Result<WorkspaceRecord, AppError> {
+        require_repo_kind(parent)?;
+        let branch = validate_branch_name(&input.branch)?;
+        let slug = slugify_branch(branch);
+        // The worktree name is the short logical label for this worktree. The
+        // first 6 characters (= the random hex prefix) are what the sidebar
+        // displays as a hash tag, so uniqueness across siblings is guaranteed.
+        let hex6 = random_hex6();
+        let worktree_name = format!("{hex6}-{slug}");
+        let repo_root = PathBuf::from(&parent.canonical_path);
+        let target_path = match input
+            .path
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            Some(custom) => PathBuf::from(custom),
+            None => default_worktree_path(&repo_root, &worktree_name),
+        };
+
+        if target_path.exists() {
+            return Err(worktree_error(
+                "workspace.worktree.path_exists",
+                format!(
+                    "Worktree target path '{}' already exists",
+                    target_path.display()
+                ),
+                false,
+            ));
+        }
+
+        let parent_path_string = parent.canonical_path.clone();
+        let target_path_string = target_path.to_string_lossy().to_string();
+        let worktree_name_clone = worktree_name.clone();
+        let branch_name = branch.to_string();
+        let base_ref = input
+            .base_ref
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_string);
+        let create_branch = input.create_branch;
+
+        task::spawn_blocking(move || {
+            run_git_worktree_add(
+                &parent_path_string,
+                &target_path_string,
+                &worktree_name_clone,
+                &branch_name,
+                create_branch,
+                base_ref.as_deref(),
+            )
+        })
+        .await
+        .map_err(|error| {
+            AppError::internal(
+                ErrorSource::Git,
+                format!("git worktree add task failed: {error}"),
+            )
+        })??;
+
+        // Canonicalize the freshly created worktree path so subsequent lookups match.
+        let canonical = task::spawn_blocking({
+            let target = target_path.clone();
+            move || dunce::canonicalize(&target)
+        })
+        .await
+        .map_err(|error| {
+            AppError::internal(
+                ErrorSource::Workspace,
+                format!("worktree path canonicalization task failed: {error}"),
+            )
+        })?
+        .map_err(|error| {
+            AppError::recoverable(
+                ErrorSource::Workspace,
+                "workspace.worktree.path_invalid",
+                format!(
+                    "Cannot resolve worktree path '{}': {error}",
+                    target_path.display()
+                ),
+            )
+        })?;
+        let canonical_str = canonical.to_string_lossy().to_string();
+
+        // Derive git_common_dir from the worktree (via git2), fall back to parent.git.
+        let git_common_dir = task::spawn_blocking({
+            let canonical = canonical.clone();
+            move || -> Option<String> {
+                Repository::open(&canonical)
+                    .ok()
+                    .map(|repo| repo.commondir().to_path_buf())
+                    .and_then(|p| dunce::canonicalize(&p).ok())
+                    .map(|p| p.to_string_lossy().to_string())
+            }
+        })
+        .await
+        .unwrap_or(None)
+        .unwrap_or_else(|| format!("{}/.git", parent.canonical_path));
+
+        let display_path = derive_display_path(&canonical).await;
+        let name = derive_name_from_path(&canonical);
+
+        let now = Utc::now();
+        let record = WorkspaceRecord {
+            id: uuid::Uuid::now_v7().to_string(),
+            name,
+            path: target_path.to_string_lossy().to_string(),
+            canonical_path: canonical_str,
+            display_path,
+            is_default: false,
+            is_git: true,
+            auto_work_tree: false,
+            status: WorkspaceStatus::Ready,
+            last_validated_at: Some(now),
+            created_at: now,
+            updated_at: now,
+            kind: WorkspaceKind::Worktree,
+            parent_workspace_id: Some(parent.id.clone()),
+            git_common_dir: Some(git_common_dir),
+            branch: Some(branch.to_string()),
+            worktree_name: Some(worktree_name.clone()),
+        };
+
+        workspace_repo::insert(&self.pool, &record).await?;
+
+        // Make sure the parent workspace is tagged as a repo from now on.
+        if parent.kind != WorkspaceKind::Repo {
+            workspace_repo::update_kind_metadata(
+                &self.pool,
+                &parent.id,
+                WorkspaceKind::Repo,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await?;
+        }
+
+        tracing::info!(
+            parent_workspace_id = %parent.id,
+            workspace_id = %record.id,
+            worktree_name = %worktree_name,
+            branch = %branch,
+            path = %record.canonical_path,
+            "worktree created"
+        );
+
+        Ok(record)
+    }
+
+    /// Physically remove the worktree directory and its `.git/worktrees/<name>`
+    /// registration. The caller is responsible for the DB row deletion via
+    /// `WorkspaceManager::remove`. If the worktree is already gone this is a
+    /// no-op returning `Ok(())`.
+    pub async fn remove_physical(
+        &self,
+        worktree: &WorkspaceRecord,
+        force: bool,
+    ) -> Result<(), AppError> {
+        if worktree.kind != WorkspaceKind::Worktree {
+            return Err(worktree_error(
+                "workspace.worktree.kind_mismatch",
+                "workspace_remove_worktree can only be called on a worktree row",
+                false,
+            ));
+        }
+
+        let Some(parent_id) = worktree.parent_workspace_id.as_deref() else {
+            return Ok(());
+        };
+        let parent = workspace_repo::find_by_id(&self.pool, parent_id).await?;
+        let Some(parent) = parent else {
+            return Ok(());
+        };
+
+        let parent_path = parent.canonical_path.clone();
+        let worktree_path = worktree.canonical_path.clone();
+        task::spawn_blocking(move || run_git_worktree_remove(&parent_path, &worktree_path, force))
+            .await
+            .map_err(|error| {
+                AppError::internal(
+                    ErrorSource::Git,
+                    format!("git worktree remove task failed: {error}"),
+                )
+            })??;
+
+        Ok(())
+    }
+
+    /// Run `git worktree prune` on the parent repo. Useful when a worktree
+    /// directory was deleted externally.
+    pub async fn prune(&self, parent: &WorkspaceRecord) -> Result<(), AppError> {
+        require_repo_kind(parent)?;
+        let repo_root = parent.canonical_path.clone();
+        task::spawn_blocking(move || run_git_worktree_prune(&repo_root))
+            .await
+            .map_err(|error| {
+                AppError::internal(
+                    ErrorSource::Git,
+                    format!("git worktree prune task failed: {error}"),
+                )
+            })??;
+        Ok(())
+    }
+}
+
+fn require_repo_kind(parent: &WorkspaceRecord) -> Result<(), AppError> {
+    let allowed = matches!(parent.kind, WorkspaceKind::Repo)
+        || (matches!(parent.kind, WorkspaceKind::Standalone) && parent.is_git);
+    if allowed {
+        Ok(())
+    } else {
+        Err(worktree_error(
+            "workspace.worktree.parent_not_repo",
+            "Worktrees can only be created on a Git repository workspace",
+            false,
+        ))
+    }
+}
+
+fn validate_branch_name(name: &str) -> Result<&str, AppError> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Err(worktree_error(
+            "workspace.worktree.branch_empty",
+            "Branch name cannot be empty",
+            false,
+        ));
+    }
+
+    let full_ref = format!("refs/heads/{trimmed}");
+    if !git2::Reference::is_valid_name(&full_ref) {
+        return Err(worktree_error(
+            "workspace.worktree.branch_invalid",
+            format!("'{trimmed}' is not a valid branch name"),
+            false,
+        ));
+    }
+    Ok(trimmed)
+}
+
+fn slugify_branch(branch: &str) -> String {
+    let lower = branch.to_ascii_lowercase();
+    let mut out = String::with_capacity(lower.len());
+    let mut last_dash = false;
+    for ch in lower.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if ch == '-' || ch == '_' || ch == '.' {
+            if !last_dash {
+                out.push('-');
+                last_dash = true;
+            }
+        } else {
+            if !last_dash {
+                out.push('-');
+                last_dash = true;
+            }
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "worktree".to_string()
+    } else if trimmed.len() > 40 {
+        trimmed[..40].trim_matches('-').to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn random_hex6() -> String {
+    let raw = uuid::Uuid::new_v4().simple().to_string();
+    raw[..6].to_string()
+}
+
+fn default_worktree_path(repo_root: &Path, worktree_name: &str) -> PathBuf {
+    let repo_name = repo_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("repo");
+    let parent = repo_root.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(format!("{repo_name}-{worktree_name}"))
+}
+
+fn derive_name_from_path(path: &Path) -> String {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("Worktree")
+        .to_string()
+}
+
+async fn derive_display_path(path: &Path) -> String {
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(relative) = path.strip_prefix(&home) {
+            return format!("~/{}", relative.display());
+        }
+        if let Ok(canonical_home) = dunce::canonicalize(&home) {
+            if let Ok(relative) = path.strip_prefix(&canonical_home) {
+                return format!("~/{}", relative.display());
+            }
+        }
+    }
+    path.display().to_string()
+}
+
+fn enumerate_git_worktrees(repo_root: &str) -> Result<Vec<WorktreeInfoDto>, AppError> {
+    let repo = Repository::open(repo_root).map_err(|error| {
+        worktree_error(
+            "workspace.worktree.repo_open_failed",
+            format!("Unable to open Git repository: {error}"),
+            false,
+        )
+    })?;
+
+    let names = repo.worktrees().map_err(|error| {
+        worktree_error(
+            "workspace.worktree.enumerate_failed",
+            format!("Unable to list Git worktrees: {error}"),
+            false,
+        )
+    })?;
+
+    let mut out = Vec::new();
+    for idx in 0..names.len() {
+        let Some(name) = names.get(idx) else { continue };
+        let worktree = match repo.find_worktree(name) {
+            Ok(wt) => wt,
+            Err(_) => continue,
+        };
+
+        let path = dunce::canonicalize(worktree.path())
+            .unwrap_or_else(|_| worktree.path().to_path_buf())
+            .to_string_lossy()
+            .to_string();
+        let is_valid = worktree.validate().is_ok();
+        let is_locked = matches!(
+            worktree.is_locked(),
+            Ok(git2::WorktreeLockStatus::Locked(_))
+        );
+
+        let (branch, head) = if is_valid {
+            match Repository::open(worktree.path()) {
+                Ok(wt_repo) => {
+                    let head = wt_repo.head().ok();
+                    let branch = head
+                        .as_ref()
+                        .and_then(|h| h.shorthand().map(|s| s.to_string()));
+                    let oid = head
+                        .as_ref()
+                        .and_then(|h| h.target())
+                        .map(|oid| oid.to_string());
+                    (branch, oid)
+                }
+                Err(_) => (None, None),
+            }
+        } else {
+            (None, None)
+        };
+
+        out.push(WorktreeInfoDto {
+            name: name.to_string(),
+            path,
+            branch,
+            head,
+            is_valid,
+            is_locked,
+            workspace_id: None,
+        });
+    }
+
+    Ok(out)
+}
+
+fn run_git_worktree_add(
+    repo_root: &str,
+    target_path: &str,
+    worktree_name: &str,
+    branch: &str,
+    create_branch: bool,
+    base_ref: Option<&str>,
+) -> Result<(), AppError> {
+    // `git worktree add` uses the final path component as the worktree
+    // registration name. We don't force it explicitly; the caller is expected
+    // to produce a target_path whose basename already matches worktree_name
+    // when that identity matters.
+    let _ = worktree_name;
+
+    let mut args: Vec<String> = vec!["worktree".to_string(), "add".to_string()];
+
+    if create_branch {
+        args.push("-b".to_string());
+        args.push(branch.to_string());
+        args.push(target_path.to_string());
+        if let Some(base) = base_ref {
+            args.push(base.to_string());
+        }
+    } else {
+        args.push(target_path.to_string());
+        args.push(branch.to_string());
+    }
+
+    run_git_cli(repo_root, &args).map(|_| ())
+}
+
+fn run_git_worktree_remove(
+    repo_root: &str,
+    worktree_path: &str,
+    force: bool,
+) -> Result<(), AppError> {
+    let mut args: Vec<String> = vec!["worktree".to_string(), "remove".to_string()];
+    if force {
+        args.push("--force".to_string());
+    }
+    args.push(worktree_path.to_string());
+    match run_git_cli(repo_root, &args) {
+        Ok(_) => Ok(()),
+        Err(error) => {
+            // Non-existing worktree (already removed) → tolerate.
+            let detail = error.detail.clone().unwrap_or_default().to_lowercase();
+            let message = error.user_message.to_lowercase();
+            if detail.contains("not a working tree")
+                || detail.contains("no such")
+                || message.contains("not a working tree")
+                || message.contains("no such")
+            {
+                // Also run prune so the admin store is cleaned.
+                let _ = run_git_worktree_prune(repo_root);
+                Ok(())
+            } else {
+                Err(error)
+            }
+        }
+    }
+}
+
+fn run_git_worktree_prune(repo_root: &str) -> Result<(), AppError> {
+    let args = vec!["worktree".to_string(), "prune".to_string()];
+    run_git_cli(repo_root, &args).map(|_| ())
+}
+
+fn run_git_cli(repo_root: &str, args: &[String]) -> Result<String, AppError> {
+    ensure_git_cli_available()?;
+
+    let mut command = Command::new("git");
+    configure_background_std_command(&mut command);
+
+    let output = command
+        .args(args)
+        .current_dir(repo_root)
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_PAGER", "cat")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|error| {
+            worktree_error(
+                "workspace.worktree.cli_spawn_failed",
+                format!("Failed to launch Git CLI: {error}"),
+                true,
+            )
+        })?;
+
+    let stdout = trim_output(&String::from_utf8_lossy(&output.stdout));
+    let stderr = trim_output(&String::from_utf8_lossy(&output.stderr));
+
+    if !output.status.success() {
+        let action = args
+            .iter()
+            .skip(1)
+            .next()
+            .map(|s| s.as_str())
+            .unwrap_or("command");
+        return Err(AppError {
+            error_code: format!("workspace.worktree.{action}_failed"),
+            category: ErrorCategory::Recoverable,
+            source: ErrorSource::Git,
+            user_message: first_line(if !stderr.is_empty() { &stderr } else { &stdout })
+                .to_string(),
+            detail: Some(format!("stdout: {stdout}\nstderr: {stderr}")),
+            retryable: false,
+        });
+    }
+
+    Ok(stdout)
+}
+
+fn ensure_git_cli_available() -> Result<(), AppError> {
+    let mut command = Command::new("git");
+    configure_background_std_command(&mut command);
+    let available = command
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if available {
+        Ok(())
+    } else {
+        Err(worktree_error(
+            "workspace.worktree.cli_unavailable",
+            "Git CLI is not installed or is not available on PATH",
+            false,
+        ))
+    }
+}
+
+fn trim_output(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.len() > WORKTREE_OUTPUT_LIMIT {
+        trimmed[..WORKTREE_OUTPUT_LIMIT].to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn first_line(text: &str) -> &str {
+    text.lines().next().unwrap_or(text)
+}
+
+fn worktree_error(code: &str, message: impl Into<String>, retryable: bool) -> AppError {
+    AppError {
+        error_code: code.to_string(),
+        category: ErrorCategory::Recoverable,
+        source: ErrorSource::Workspace,
+        user_message: message.into(),
+        detail: None,
+        retryable,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slugify_handles_common_branch_names() {
+        assert_eq!(slugify_branch("feature/foo-bar"), "feature-foo-bar");
+        assert_eq!(slugify_branch("fix/auth_bug"), "fix-auth-bug");
+        assert_eq!(slugify_branch("Main"), "main");
+        assert_eq!(slugify_branch("   "), "worktree");
+    }
+
+    #[test]
+    fn random_hex6_is_six_chars() {
+        let value = random_hex6();
+        assert_eq!(value.len(), 6);
+        assert!(value.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn default_worktree_path_uses_sibling_directory() {
+        let path = default_worktree_path(Path::new("/tmp/my-repo"), "feature-foo");
+        assert_eq!(path, PathBuf::from("/tmp/my-repo-feature-foo"));
+    }
+}

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -110,7 +110,34 @@ impl WorktreeManager {
             .map(str::trim)
             .filter(|s| !s.is_empty())
         {
-            Some(custom) => PathBuf::from(custom),
+            Some(custom) => {
+                let p = PathBuf::from(custom);
+                // Resolve relative paths against the parent repo directory so
+                // the user can pass e.g. `../my-worktree` in the dialog.
+                let resolved = if p.is_relative() {
+                    PathBuf::from(&parent.canonical_path).join(&p)
+                } else {
+                    p
+                };
+
+                // Reject target paths that fall inside the parent repo working
+                // tree. Creating a worktree inside its own repo causes Git
+                // conflicts and confusing file-system state.
+                let parent_dir = PathBuf::from(&parent.canonical_path);
+                if resolved.starts_with(&parent_dir) {
+                    return Err(worktree_error(
+                        "workspace.worktree.path_inside_repo",
+                        format!(
+                            "Worktree path '{}' must not be inside the parent repository '{}'",
+                            resolved.display(),
+                            parent_dir.display(),
+                        ),
+                        false,
+                    ));
+                }
+
+                resolved
+            }
             None => default_worktree_path(&parent.name, &hex6)?,
         };
 

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -104,7 +104,6 @@ impl WorktreeManager {
         // displays as a hash tag, so uniqueness across siblings is guaranteed.
         let hex6 = random_hex6();
         let worktree_name = format!("{hex6}-{slug}");
-        let repo_root = PathBuf::from(&parent.canonical_path);
         let target_path = match input
             .path
             .as_deref()
@@ -112,7 +111,7 @@ impl WorktreeManager {
             .filter(|s| !s.is_empty())
         {
             Some(custom) => PathBuf::from(custom),
-            None => default_worktree_path(&repo_root, &worktree_name),
+            None => default_worktree_path(&parent.name, &hex6)?,
         };
 
         if target_path.exists() {
@@ -373,13 +372,47 @@ fn random_hex6() -> String {
     raw[..6].to_string()
 }
 
-fn default_worktree_path(repo_root: &Path, worktree_name: &str) -> PathBuf {
-    let repo_name = repo_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or("repo");
-    let parent = repo_root.parent().unwrap_or_else(|| Path::new("."));
-    parent.join(format!("{repo_name}-{worktree_name}"))
+/// Compute the default worktree directory under the TiyCode data root:
+/// `~/.tiy/workspace/<hex6>/<safe-repo-name>`. Ensures the parent directory
+/// exists so `git worktree add` will succeed even on a fresh install where
+/// `~/.tiy/workspace/` has never been created.
+fn default_worktree_path(repo_name: &str, hex6: &str) -> Result<PathBuf, AppError> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        AppError::internal(ErrorSource::Workspace, "cannot resolve HOME directory")
+    })?;
+    let safe_name = sanitize_repo_name_for_path(repo_name);
+    let parent_dir = home.join(".tiy").join("workspace").join(hex6);
+
+    if let Err(error) = std::fs::create_dir_all(&parent_dir) {
+        return Err(worktree_error(
+            "workspace.worktree.prepare_default_path_failed",
+            format!(
+                "Failed to create default worktree parent directory '{}': {error}",
+                parent_dir.display()
+            ),
+            false,
+        ));
+    }
+
+    Ok(parent_dir.join(safe_name))
+}
+
+fn sanitize_repo_name_for_path(name: &str) -> String {
+    let trimmed = name.trim();
+    let mut out = String::with_capacity(trimmed.len());
+    for ch in trimmed.chars() {
+        if ch.is_alphanumeric() || ch == '-' || ch == '_' || ch == '.' {
+            out.push(ch);
+        } else if ch.is_whitespace() || ch == '/' || ch == '\\' {
+            out.push('-');
+        }
+    }
+    let cleaned = out.trim_matches(|c: char| c == '-' || c == '.').to_string();
+    if cleaned.is_empty() {
+        "workspace".to_string()
+    } else {
+        cleaned
+    }
 }
 
 fn derive_name_from_path(path: &Path) -> String {
@@ -649,8 +682,24 @@ mod tests {
     }
 
     #[test]
-    fn default_worktree_path_uses_sibling_directory() {
-        let path = default_worktree_path(Path::new("/tmp/my-repo"), "feature-foo");
-        assert_eq!(path, PathBuf::from("/tmp/my-repo-feature-foo"));
+    fn default_worktree_path_uses_tiy_workspace_root() {
+        let path = default_worktree_path("my-repo", "abcdef").expect("should compute path");
+        let home = dirs::home_dir().expect("home available");
+        let expected = home
+            .join(".tiy")
+            .join("workspace")
+            .join("abcdef")
+            .join("my-repo");
+        assert_eq!(path, expected);
+        // The parent directory should exist on disk after the call.
+        assert!(expected.parent().unwrap().is_dir());
+    }
+
+    #[test]
+    fn sanitize_repo_name_replaces_path_and_whitespace_characters() {
+        assert_eq!(sanitize_repo_name_for_path("my repo"), "my-repo");
+        assert_eq!(sanitize_repo_name_for_path("a/b\\c"), "a-b-c");
+        assert_eq!(sanitize_repo_name_for_path("  -repo.-"), "repo");
+        assert_eq!(sanitize_repo_name_for_path("***"), "workspace");
     }
 }

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -388,7 +388,12 @@ fn slugify_branch(branch: &str) -> String {
     if trimmed.is_empty() {
         "worktree".to_string()
     } else if trimmed.len() > 40 {
-        trimmed[..40].trim_matches('-').to_string()
+        trimmed
+            .chars()
+            .take(40)
+            .collect::<String>()
+            .trim_matches('-')
+            .to_string()
     } else {
         trimmed
     }
@@ -668,7 +673,13 @@ fn ensure_git_cli_available() -> Result<(), AppError> {
 fn trim_output(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.len() > WORKTREE_OUTPUT_LIMIT {
-        trimmed[..WORKTREE_OUTPUT_LIMIT].to_string()
+        // Find a valid UTF-8 char boundary at or before the limit to avoid
+        // panicking on multi-byte characters.
+        let mut end = WORKTREE_OUTPUT_LIMIT;
+        while !trimmed.is_char_boundary(end) && end > 0 {
+            end -= 1;
+        }
+        trimmed[..end].to_string()
     } else {
         trimmed.to_string()
     }

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -614,6 +614,7 @@ fn run_git_cli(repo_root: &str, args: &[String]) -> Result<String, AppError> {
         .current_dir(repo_root)
         .env("GIT_TERMINAL_PROMPT", "0")
         .env("GIT_PAGER", "cat")
+        .env("LC_ALL", "C")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()

--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -388,12 +388,17 @@ fn slugify_branch(branch: &str) -> String {
     if trimmed.is_empty() {
         "worktree".to_string()
     } else if trimmed.len() > 40 {
-        trimmed
+        let truncated = trimmed
             .chars()
             .take(40)
             .collect::<String>()
             .trim_matches('-')
-            .to_string()
+            .to_string();
+        if truncated.is_empty() {
+            "worktree".to_string()
+        } else {
+            truncated
+        }
     } else {
         trimmed
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -233,6 +233,10 @@ pub fn run() {
             commands::workspace::workspace_remove,
             commands::workspace::workspace_set_default,
             commands::workspace::workspace_validate,
+            commands::workspace::workspace_list_worktrees,
+            commands::workspace::workspace_create_worktree,
+            commands::workspace::workspace_remove_worktree,
+            commands::workspace::workspace_prune_worktrees,
             // Settings & Policies
             commands::settings::settings_get,
             commands::settings::settings_get_all,

--- a/src-tauri/src/model/workspace.rs
+++ b/src-tauri/src/model/workspace.rs
@@ -31,6 +31,37 @@ impl WorkspaceStatus {
     }
 }
 
+/// Classification of a workspace row, enabling worktree semantics alongside
+/// standalone folders and Git repositories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceKind {
+    /// A regular folder workspace with no Git worktree relationship.
+    Standalone,
+    /// A Git repository root that may have child worktrees.
+    Repo,
+    /// A Git worktree pointing to a parent repo workspace.
+    Worktree,
+}
+
+impl WorkspaceKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Standalone => "standalone",
+            Self::Repo => "repo",
+            Self::Worktree => "worktree",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "repo" => Self::Repo,
+            "worktree" => Self::Worktree,
+            _ => Self::Standalone,
+        }
+    }
+}
+
 /// Database row representation for the `workspaces` table.
 #[derive(Debug, Clone)]
 pub struct WorkspaceRecord {
@@ -46,6 +77,18 @@ pub struct WorkspaceRecord {
     pub last_validated_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    pub kind: WorkspaceKind,
+    pub parent_workspace_id: Option<String>,
+    pub git_common_dir: Option<String>,
+    pub branch: Option<String>,
+    /// Short logical worktree identifier for this TiyCode workspace.
+    /// Format: `<6-hex>-<branch-slug>`. The leading 6 hex characters are a
+    /// random uniqueness prefix and are what the sidebar renders as the hash
+    /// tag (`worktree_name[..6]`). Note: this is NOT the `git worktree`
+    /// registration name (git derives that from the worktree directory
+    /// basename); we store this label separately so the UI tag stays stable
+    /// even when the user picks a custom path.
+    pub worktree_name: Option<String>,
 }
 
 /// DTO sent to the frontend via Tauri invoke.
@@ -64,6 +107,11 @@ pub struct WorkspaceDto {
     pub last_validated_at: Option<String>,
     pub created_at: String,
     pub updated_at: String,
+    pub kind: WorkspaceKind,
+    pub parent_workspace_id: Option<String>,
+    pub git_common_dir: Option<String>,
+    pub branch: Option<String>,
+    pub worktree_name: Option<String>,
 }
 
 impl From<WorkspaceRecord> for WorkspaceDto {
@@ -81,6 +129,11 @@ impl From<WorkspaceRecord> for WorkspaceDto {
             last_validated_at: r.last_validated_at.map(|t| t.to_rfc3339()),
             created_at: r.created_at.to_rfc3339(),
             updated_at: r.updated_at.to_rfc3339(),
+            kind: r.kind,
+            parent_workspace_id: r.parent_workspace_id,
+            git_common_dir: r.git_common_dir,
+            branch: r.branch,
+            worktree_name: r.worktree_name,
         }
     }
 }
@@ -91,4 +144,24 @@ impl From<WorkspaceRecord> for WorkspaceDto {
 pub struct WorkspaceAddInput {
     pub path: String,
     pub name: Option<String>,
+}
+
+/// Input from the frontend when creating a worktree for a repo workspace.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorktreeCreateInput {
+    /// The branch name to check out inside the new worktree.
+    /// When `create_branch` is true this is the name of a new branch.
+    pub branch: String,
+    /// Optional starting point (commit / branch / remote ref) used when creating
+    /// a brand-new branch. Ignored when `create_branch` is false.
+    #[serde(default)]
+    pub base_ref: Option<String>,
+    /// When true, a new local branch is created and checked out in the worktree.
+    #[serde(default)]
+    pub create_branch: bool,
+    /// Optional custom path for the new worktree directory. When None the
+    /// manager derives `<repo parent>/<repo name>-<branch-slug>`.
+    #[serde(default)]
+    pub path: Option<String>,
 }

--- a/src-tauri/src/persistence/repo/workspace_repo.rs
+++ b/src-tauri/src/persistence/repo/workspace_repo.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use sqlx::SqlitePool;
 
 use crate::model::errors::{AppError, ErrorSource};
-use crate::model::workspace::{WorkspaceRecord, WorkspaceStatus};
+use crate::model::workspace::{WorkspaceKind, WorkspaceRecord, WorkspaceStatus};
 
 /// Row returned by sqlx queries (intermediate mapping).
 #[derive(sqlx::FromRow)]
@@ -19,6 +19,11 @@ struct WorkspaceRow {
     last_validated_at: Option<String>,
     created_at: String,
     updated_at: String,
+    kind: String,
+    parent_workspace_id: Option<String>,
+    git_common_dir: Option<String>,
+    branch: Option<String>,
+    worktree_name: Option<String>,
 }
 
 impl WorkspaceRow {
@@ -43,17 +48,23 @@ impl WorkspaceRow {
             updated_at: DateTime::parse_from_rfc3339(&self.updated_at)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now()),
+            kind: WorkspaceKind::from_str(&self.kind),
+            parent_workspace_id: self.parent_workspace_id,
+            git_common_dir: self.git_common_dir,
+            branch: self.branch,
+            worktree_name: self.worktree_name,
         }
     }
 }
 
+const SELECT_COLUMNS: &str = "id, name, path, canonical_path, display_path, is_default, is_git,\n                auto_work_tree, status, last_validated_at, created_at, updated_at,\n                kind, parent_workspace_id, git_common_dir, branch, worktree_name";
+
 pub async fn list_all(pool: &SqlitePool) -> Result<Vec<WorkspaceRecord>, AppError> {
-    let rows = sqlx::query_as::<_, WorkspaceRow>(
-        "SELECT id, name, path, canonical_path, display_path, is_default, is_git,
-                auto_work_tree, status, last_validated_at, created_at, updated_at
+    let rows = sqlx::query_as::<_, WorkspaceRow>(&format!(
+        "SELECT {SELECT_COLUMNS}
          FROM workspaces
-         ORDER BY is_default DESC, updated_at DESC",
-    )
+         ORDER BY is_default DESC, updated_at DESC"
+    ))
     .fetch_all(pool)
     .await?;
 
@@ -61,11 +72,9 @@ pub async fn list_all(pool: &SqlitePool) -> Result<Vec<WorkspaceRecord>, AppErro
 }
 
 pub async fn find_by_id(pool: &SqlitePool, id: &str) -> Result<Option<WorkspaceRecord>, AppError> {
-    let row = sqlx::query_as::<_, WorkspaceRow>(
-        "SELECT id, name, path, canonical_path, display_path, is_default, is_git,
-                auto_work_tree, status, last_validated_at, created_at, updated_at
-         FROM workspaces WHERE id = ?",
-    )
+    let row = sqlx::query_as::<_, WorkspaceRow>(&format!(
+        "SELECT {SELECT_COLUMNS} FROM workspaces WHERE id = ?"
+    ))
     .bind(id)
     .fetch_optional(pool)
     .await?;
@@ -77,11 +86,9 @@ pub async fn find_by_canonical_path(
     pool: &SqlitePool,
     canonical_path: &str,
 ) -> Result<Option<WorkspaceRecord>, AppError> {
-    let row = sqlx::query_as::<_, WorkspaceRow>(
-        "SELECT id, name, path, canonical_path, display_path, is_default, is_git,
-                auto_work_tree, status, last_validated_at, created_at, updated_at
-         FROM workspaces WHERE canonical_path = ?",
-    )
+    let row = sqlx::query_as::<_, WorkspaceRow>(&format!(
+        "SELECT {SELECT_COLUMNS} FROM workspaces WHERE canonical_path = ?"
+    ))
     .bind(canonical_path)
     .fetch_optional(pool)
     .await?;
@@ -89,13 +96,32 @@ pub async fn find_by_canonical_path(
     Ok(row.map(|r| r.into_record()))
 }
 
+/// List worktree workspaces attached to the given parent repo workspace.
+pub async fn list_worktrees_of(
+    pool: &SqlitePool,
+    parent_id: &str,
+) -> Result<Vec<WorkspaceRecord>, AppError> {
+    let rows = sqlx::query_as::<_, WorkspaceRow>(&format!(
+        "SELECT {SELECT_COLUMNS}
+         FROM workspaces
+         WHERE parent_workspace_id = ? AND kind = 'worktree'
+         ORDER BY created_at ASC"
+    ))
+    .bind(parent_id)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|r| r.into_record()).collect())
+}
+
 pub async fn insert(pool: &SqlitePool, record: &WorkspaceRecord) -> Result<(), AppError> {
     let now = Utc::now().to_rfc3339();
     sqlx::query(
         "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
                 is_default, is_git, auto_work_tree, status, last_validated_at,
-                created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                created_at, updated_at,
+                kind, parent_workspace_id, git_common_dir, branch, worktree_name)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&record.id)
     .bind(&record.name)
@@ -109,6 +135,11 @@ pub async fn insert(pool: &SqlitePool, record: &WorkspaceRecord) -> Result<(), A
     .bind(record.last_validated_at.map(|t| t.to_rfc3339()))
     .bind(&now)
     .bind(&now)
+    .bind(record.kind.as_str())
+    .bind(record.parent_workspace_id.as_deref())
+    .bind(record.git_common_dir.as_deref())
+    .bind(record.branch.as_deref())
+    .bind(record.worktree_name.as_deref())
     .execute(pool)
     .await?;
 
@@ -248,6 +279,38 @@ pub async fn update_is_git(pool: &SqlitePool, id: &str, is_git: bool) -> Result<
         .bind(id)
         .execute(pool)
         .await?;
+
+    Ok(())
+}
+
+/// Update the workspace `kind` (and optional related fields). Used when
+/// upgrading an existing `standalone` workspace to `repo` after Git detection,
+/// or when re-synchronizing worktree metadata after a git operation.
+pub async fn update_kind_metadata(
+    pool: &SqlitePool,
+    id: &str,
+    kind: WorkspaceKind,
+    parent_workspace_id: Option<&str>,
+    worktree_name: Option<&str>,
+    branch: Option<&str>,
+    git_common_dir: Option<&str>,
+) -> Result<(), AppError> {
+    let now = Utc::now().to_rfc3339();
+    sqlx::query(
+        "UPDATE workspaces
+         SET kind = ?, parent_workspace_id = ?, worktree_name = ?,
+             branch = ?, git_common_dir = ?, updated_at = ?
+         WHERE id = ?",
+    )
+    .bind(kind.as_str())
+    .bind(parent_workspace_id)
+    .bind(worktree_name)
+    .bind(branch)
+    .bind(git_common_dir)
+    .bind(&now)
+    .bind(id)
+    .execute(pool)
+    .await?;
 
     Ok(())
 }

--- a/src-tauri/tests/m1_2_workspace.rs
+++ b/src-tauri/tests/m1_2_workspace.rs
@@ -300,7 +300,7 @@ async fn test_workspace_repo_delete_removes_messages_before_runs() {
     .await
     .unwrap();
 
-    manager.remove("ws-del-repo").await.unwrap();
+    manager.remove("ws-del-repo", false).await.unwrap();
 
     let workspace = sqlx::query("SELECT id FROM workspaces WHERE id = ?")
         .bind("ws-del-repo")

--- a/src-tauri/tests/m1_7_frontend_integration.rs
+++ b/src-tauri/tests/m1_7_frontend_integration.rs
@@ -533,6 +533,11 @@ fn test_workspace_dto_camel_case() {
         last_validated_at: Some("2026-03-16T00:00:00Z".into()),
         created_at: "2026-03-16T00:00:00Z".into(),
         updated_at: "2026-03-16T00:00:00Z".into(),
+        kind: tiycode::model::workspace::WorkspaceKind::Repo,
+        parent_workspace_id: None,
+        git_common_dir: None,
+        branch: None,
+        worktree_name: None,
     };
 
     let json = serde_json::to_value(&dto).unwrap();

--- a/src-tauri/tests/m2_4_worktree.rs
+++ b/src-tauri/tests/m2_4_worktree.rs
@@ -1,0 +1,382 @@
+//! M2.4 — Workspace worktree management tests
+//!
+//! Covers:
+//! - `WorktreeManager::create` produces a sibling worktree directory,
+//!   inserts a `kind='worktree'` workspace row, and records the parent link.
+//! - Creating a worktree against a non-repo workspace is rejected.
+//! - `WorkspaceManager::remove` on a worktree removes the `.git/worktrees/<name>`
+//!   registration and the DB row.
+//! - `WorkspaceManager::remove` on the parent repo also removes all child
+//!   worktree rows and their `.git/worktrees/<name>` registrations.
+//! - `WorkspaceManager::set_default` refuses worktree rows.
+//! - `WorkspaceManager::validate` upgrades a standalone Git workspace to
+//!   `kind='repo'` so the UI can surface worktree actions.
+
+mod test_helpers;
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use git2::{Repository, Signature};
+use sqlx::Row;
+use tiycode::core::workspace_manager::WorkspaceManager;
+use tiycode::core::worktree_manager::WorktreeManager;
+use tiycode::model::workspace::{
+    WorkspaceAddInput, WorkspaceKind, WorkspaceStatus, WorktreeCreateInput,
+};
+
+fn git_cli_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn init_repo_with_commit(repo_root: &Path) {
+    std::fs::create_dir_all(repo_root).expect("should create repo root");
+    let repo = Repository::init(repo_root).expect("should init repo");
+    std::fs::write(repo_root.join("README.md"), "# test\n").expect("should write README");
+    let mut index = repo.index().expect("should get index");
+    index
+        .add_path(Path::new("README.md"))
+        .expect("should stage README");
+    index.write().expect("should write index");
+    let tree_id = index.write_tree().expect("should write tree");
+    let tree = repo.find_tree(tree_id).expect("should find tree");
+    let sig = Signature::now("TiyCode", "tests@tiy.local").expect("should build signature");
+    repo.commit(Some("HEAD"), &sig, &sig, "initial", &tree, &[])
+        .expect("should commit");
+}
+
+fn canonical(path: &Path) -> String {
+    dunce::canonicalize(path)
+        .unwrap_or_else(|_| path.to_path_buf())
+        .to_string_lossy()
+        .to_string()
+}
+
+async fn setup_repo_workspace(
+    pool: &sqlx::SqlitePool,
+    repo_root: &Path,
+) -> tiycode::model::workspace::WorkspaceRecord {
+    let manager = WorkspaceManager::new(pool.clone());
+    manager
+        .add(WorkspaceAddInput {
+            path: repo_root.to_string_lossy().to_string(),
+            name: Some("Test Repo".to_string()),
+        })
+        .await
+        .expect("should add repo workspace")
+}
+
+fn worktree_admin_path(repo_root: &Path, name: &str) -> PathBuf {
+    repo_root.join(".git").join("worktrees").join(name)
+}
+
+#[tokio::test]
+async fn worktree_create_registers_workspace_and_updates_parent_kind() {
+    if !git_cli_available() {
+        eprintln!("skipping worktree test: git CLI not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let repo_root = tmp.path().join("repo-main");
+    init_repo_with_commit(&repo_root);
+
+    let pool = test_helpers::setup_test_pool().await;
+    let parent = setup_repo_workspace(&pool, &repo_root).await;
+
+    assert_eq!(
+        parent.kind,
+        WorkspaceKind::Repo,
+        "Git repo should be kind=repo"
+    );
+    assert!(parent.is_git);
+
+    let worktree_manager = WorktreeManager::new(pool.clone());
+    let created = worktree_manager
+        .create(
+            &parent,
+            WorktreeCreateInput {
+                branch: "feature/worktree-alpha".to_string(),
+                base_ref: None,
+                create_branch: true,
+                path: None,
+            },
+        )
+        .await
+        .expect("worktree creation should succeed");
+
+    assert_eq!(created.kind, WorkspaceKind::Worktree);
+    assert_eq!(
+        created.parent_workspace_id.as_deref(),
+        Some(parent.id.as_str())
+    );
+    assert_eq!(created.branch.as_deref(), Some("feature/worktree-alpha"));
+    let worktree_name = created.worktree_name.clone().expect("worktree_name set");
+    assert!(
+        worktree_name.len() > 6,
+        "worktree_name should include hex + slug"
+    );
+    assert!(created.canonical_path != canonical(&repo_root));
+
+    // Worktree directory and admin dir both exist on disk.
+    assert!(Path::new(&created.canonical_path).is_dir());
+    // Git enumerates this worktree.
+    let enumerated = worktree_manager
+        .list(&parent)
+        .await
+        .expect("list should succeed");
+    assert_eq!(enumerated.len(), 1);
+    assert_eq!(
+        enumerated[0].workspace_id.as_deref(),
+        Some(created.id.as_str())
+    );
+    assert!(enumerated[0].is_valid);
+}
+
+#[tokio::test]
+async fn worktree_create_rejects_non_repo_parent() {
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let folder = tmp.path().join("plain-folder");
+    std::fs::create_dir_all(&folder).unwrap();
+
+    let pool = test_helpers::setup_test_pool().await;
+    let ws_manager = WorkspaceManager::new(pool.clone());
+    let parent = ws_manager
+        .add(WorkspaceAddInput {
+            path: folder.to_string_lossy().to_string(),
+            name: None,
+        })
+        .await
+        .expect("should add standalone workspace");
+
+    assert_eq!(parent.kind, WorkspaceKind::Standalone);
+
+    let worktree_manager = WorktreeManager::new(pool.clone());
+    let err = worktree_manager
+        .create(
+            &parent,
+            WorktreeCreateInput {
+                branch: "feature/foo".to_string(),
+                base_ref: None,
+                create_branch: true,
+                path: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.error_code, "workspace.worktree.parent_not_repo");
+}
+
+#[tokio::test]
+async fn worktree_remove_cleans_up_admin_dir_and_db_row() {
+    if !git_cli_available() {
+        eprintln!("skipping worktree test: git CLI not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let repo_root = tmp.path().join("repo-remove");
+    init_repo_with_commit(&repo_root);
+
+    let pool = test_helpers::setup_test_pool().await;
+    let ws_manager = WorkspaceManager::new(pool.clone());
+    let worktree_manager = std::sync::Arc::new(WorktreeManager::new(pool.clone()));
+    ws_manager.set_worktree_manager(std::sync::Arc::clone(&worktree_manager));
+
+    let parent = ws_manager
+        .add(WorkspaceAddInput {
+            path: repo_root.to_string_lossy().to_string(),
+            name: None,
+        })
+        .await
+        .unwrap();
+
+    let created = worktree_manager
+        .create(
+            &parent,
+            WorktreeCreateInput {
+                branch: "feature/remove-me".to_string(),
+                base_ref: None,
+                create_branch: true,
+                path: None,
+            },
+        )
+        .await
+        .expect("create should succeed");
+
+    // Confirm admin directory exists before removal.
+    let basename = Path::new(&created.canonical_path)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap()
+        .to_string();
+    let admin = worktree_admin_path(&repo_root, &basename);
+    assert!(admin.is_dir(), "admin dir should exist pre-remove");
+
+    ws_manager
+        .remove(&created.id)
+        .await
+        .expect("remove should succeed");
+
+    // DB row gone.
+    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM workspaces WHERE id = ?")
+        .bind(&created.id)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+    assert!(exists.is_none());
+
+    // Worktree directory gone.
+    assert!(!Path::new(&created.canonical_path).exists());
+    // Admin entry gone.
+    assert!(!admin.exists());
+}
+
+#[tokio::test]
+async fn worktree_parent_remove_cascades_children() {
+    if !git_cli_available() {
+        eprintln!("skipping worktree test: git CLI not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let repo_root = tmp.path().join("repo-parent-remove");
+    init_repo_with_commit(&repo_root);
+
+    let pool = test_helpers::setup_test_pool().await;
+    let ws_manager = WorkspaceManager::new(pool.clone());
+    let worktree_manager = std::sync::Arc::new(WorktreeManager::new(pool.clone()));
+    ws_manager.set_worktree_manager(std::sync::Arc::clone(&worktree_manager));
+
+    let parent = ws_manager
+        .add(WorkspaceAddInput {
+            path: repo_root.to_string_lossy().to_string(),
+            name: None,
+        })
+        .await
+        .unwrap();
+
+    let child = worktree_manager
+        .create(
+            &parent,
+            WorktreeCreateInput {
+                branch: "feature/child".to_string(),
+                base_ref: None,
+                create_branch: true,
+                path: None,
+            },
+        )
+        .await
+        .expect("create child should succeed");
+
+    // Seed a thread for the child worktree to prove cascade cleanup.
+    test_helpers::seed_thread(&pool, "t-child", &child.id).await;
+
+    ws_manager
+        .remove(&parent.id)
+        .await
+        .expect("remove parent should succeed");
+
+    let parent_count: i64 = sqlx::query("SELECT COUNT(*) AS c FROM workspaces WHERE id = ?")
+        .bind(&parent.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("c");
+    let child_count: i64 = sqlx::query("SELECT COUNT(*) AS c FROM workspaces WHERE id = ?")
+        .bind(&child.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("c");
+    let thread_count: i64 = sqlx::query("SELECT COUNT(*) AS c FROM threads WHERE id = 't-child'")
+        .fetch_one(&pool)
+        .await
+        .unwrap()
+        .get("c");
+
+    assert_eq!(parent_count, 0);
+    assert_eq!(child_count, 0);
+    assert_eq!(thread_count, 0);
+    assert!(!Path::new(&child.canonical_path).exists());
+}
+
+#[tokio::test]
+async fn set_default_rejects_worktree_row() {
+    if !git_cli_available() {
+        eprintln!("skipping worktree test: git CLI not available");
+        return;
+    }
+
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let repo_root = tmp.path().join("repo-default");
+    init_repo_with_commit(&repo_root);
+
+    let pool = test_helpers::setup_test_pool().await;
+    let ws_manager = WorkspaceManager::new(pool.clone());
+    let worktree_manager = std::sync::Arc::new(WorktreeManager::new(pool.clone()));
+    ws_manager.set_worktree_manager(std::sync::Arc::clone(&worktree_manager));
+
+    let parent = ws_manager
+        .add(WorkspaceAddInput {
+            path: repo_root.to_string_lossy().to_string(),
+            name: None,
+        })
+        .await
+        .unwrap();
+
+    let child = worktree_manager
+        .create(
+            &parent,
+            WorktreeCreateInput {
+                branch: "feature/no-default".to_string(),
+                base_ref: None,
+                create_branch: true,
+                path: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let err = ws_manager.set_default(&child.id).await.unwrap_err();
+    assert_eq!(err.error_code, "workspace.default.worktree_not_allowed");
+}
+
+#[tokio::test]
+async fn validate_upgrades_standalone_git_workspace_to_repo() {
+    let tmp = tempfile::tempdir().expect("should create temp root");
+    let repo_root = tmp.path().join("repo-upgrade");
+    init_repo_with_commit(&repo_root);
+
+    let pool = test_helpers::setup_test_pool().await;
+    // Insert a raw row with kind='standalone' but is_git=1 to simulate pre-migration data.
+    let canonical_path = canonical(&repo_root);
+    sqlx::query(
+        "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
+                is_default, is_git, auto_work_tree, status,
+                created_at, updated_at, kind)
+         VALUES (?, ?, ?, ?, ?, 0, 1, 0, 'ready',
+                 strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+                 strftime('%Y-%m-%dT%H:%M:%fZ','now'),
+                 'standalone')",
+    )
+    .bind("ws-upgrade")
+    .bind("Upgrade Me")
+    .bind(&canonical_path)
+    .bind(&canonical_path)
+    .bind(&canonical_path)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let ws_manager = WorkspaceManager::new(pool.clone());
+    let validated = ws_manager.validate("ws-upgrade").await.unwrap();
+
+    assert_eq!(validated.kind, WorkspaceKind::Repo);
+    assert_eq!(validated.status, WorkspaceStatus::Ready);
+}

--- a/src-tauri/tests/m2_4_worktree.rs
+++ b/src-tauri/tests/m2_4_worktree.rs
@@ -219,7 +219,7 @@ async fn worktree_remove_cleans_up_admin_dir_and_db_row() {
     assert!(admin.is_dir(), "admin dir should exist pre-remove");
 
     ws_manager
-        .remove(&created.id)
+        .remove(&created.id, false)
         .await
         .expect("remove should succeed");
 
@@ -278,7 +278,7 @@ async fn worktree_parent_remove_cascades_children() {
     test_helpers::seed_thread(&pool, "t-child", &child.id).await;
 
     ws_manager
-        .remove(&parent.id)
+        .remove(&parent.id, false)
         .await
         .expect("remove parent should succeed");
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -759,7 +759,7 @@ const en: Record<TranslationKey, string> = {
   "worktree.field.path": "Worktree directory",
   "worktree.field.pathPlaceholder": "Auto-generated path",
   "worktree.field.pathBrowse": "Browse…",
-  "worktree.field.pathHint": "Defaults to a sibling directory next to the main repo. You can override it.",
+  "worktree.field.pathHint": "Leave empty to auto-generate under ~/.tiy/workspace/<hash>/<repo>.",
   "worktree.submit": "Create worktree",
   "worktree.submitting": "Creating…",
   "worktree.cancel": "Cancel",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -746,6 +746,29 @@ const en: Record<TranslationKey, string> = {
   "onboarding.complete.title": "All set!",
   "onboarding.complete.desc": "Configuration complete. You can adjust these settings anytime.",
   "onboarding.complete.tip": "Tip: Use the top menu bar to quickly switch theme and language.",
+
+  // ── Worktree ───────────────────────────────────────────
+  "worktree.createTitle": "New worktree",
+  "worktree.createDescription": "Create a new worktree for this Git repository. Choose an existing branch or create a new one.",
+  "worktree.field.branch": "Branch",
+  "worktree.field.branchPlaceholder": "Pick or type a branch name",
+  "worktree.tab.existingBranch": "Existing branch",
+  "worktree.tab.newBranch": "New branch",
+  "worktree.field.baseRef": "Base ref",
+  "worktree.field.baseRefPlaceholder": "Default: current HEAD",
+  "worktree.field.path": "Worktree directory",
+  "worktree.field.pathPlaceholder": "Auto-generated path",
+  "worktree.field.pathBrowse": "Browse…",
+  "worktree.field.pathHint": "Defaults to a sibling directory next to the main repo. You can override it.",
+  "worktree.submit": "Create worktree",
+  "worktree.submitting": "Creating…",
+  "worktree.cancel": "Cancel",
+  "worktree.menu.newWorktree": "New worktree…",
+  "worktree.removeConfirm": "Removing this worktree will delete the directory on disk and all related threads. Continue?",
+  "worktree.error.branchRequired": "Branch name is required",
+  "worktree.error.selectRepo": "Worktrees can only be created on a Git repository workspace",
+  "worktree.empty.branches": "No branches yet",
+  "worktree.tag.label": "Worktree",
 };
 
 export default en;

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -749,13 +749,11 @@ const en: Record<TranslationKey, string> = {
 
   // ── Worktree ───────────────────────────────────────────
   "worktree.createTitle": "New worktree",
-  "worktree.createDescription": "Create a new worktree for this Git repository. Choose an existing branch or create a new one.",
-  "worktree.field.branch": "Branch",
-  "worktree.field.branchPlaceholder": "Pick or type a branch name",
-  "worktree.tab.existingBranch": "Existing branch",
-  "worktree.tab.newBranch": "New branch",
-  "worktree.field.baseRef": "Base ref",
-  "worktree.field.baseRefPlaceholder": "Default: current HEAD",
+  "worktree.createDescription": "Create a new worktree with a new branch for this Git repository.",
+  "worktree.field.branch": "New branch name",
+  "worktree.field.branchPlaceholder": "Type a new branch name",
+  "worktree.field.baseBranch": "Base branch",
+  "worktree.field.baseBranchHint": "New branch will be created from {{branch}}",
   "worktree.field.path": "Worktree directory",
   "worktree.field.pathPlaceholder": "Auto-generated path",
   "worktree.field.pathBrowse": "Browse…",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -766,6 +766,7 @@ const en: Record<TranslationKey, string> = {
   "worktree.error.branchRequired": "Branch name is required",
   "worktree.error.selectRepo": "Worktrees can only be created on a Git repository workspace",
   "worktree.empty.branches": "No branches yet",
+"worktree.loading.branches": "Loading…",
   "worktree.tag.label": "Worktree",
 };
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -766,7 +766,7 @@ const en: Record<TranslationKey, string> = {
   "worktree.error.branchRequired": "Branch name is required",
   "worktree.error.selectRepo": "Worktrees can only be created on a Git repository workspace",
   "worktree.empty.branches": "No branches yet",
-"worktree.loading.branches": "Loading…",
+  "worktree.loading.branches": "Loading…",
   "worktree.tag.label": "Worktree",
 };
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -784,6 +784,29 @@ const zhCN = {
   "onboarding.complete.title": "一切就绪！",
   "onboarding.complete.desc": "配置已完成。你可以随时在设置中调整这些选项。",
   "onboarding.complete.tip": "提示：使用顶部菜单栏快速切换主题和语言。",
+
+  // ── Worktree ───────────────────────────────────────────
+  "worktree.createTitle": "新建 Worktree",
+  "worktree.createDescription": "为当前 Git 仓库创建一个新的 worktree，可基于现有分支或新建分支。",
+  "worktree.field.branch": "分支",
+  "worktree.field.branchPlaceholder": "选择或输入分支名",
+  "worktree.tab.existingBranch": "已有分支",
+  "worktree.tab.newBranch": "新建分支",
+  "worktree.field.baseRef": "起点（Base）",
+  "worktree.field.baseRefPlaceholder": "默认：当前 HEAD",
+  "worktree.field.path": "worktree 目录",
+  "worktree.field.pathPlaceholder": "自动生成路径",
+  "worktree.field.pathBrowse": "选择...",
+  "worktree.field.pathHint": "默认创建在主仓库同级目录，可修改",
+  "worktree.submit": "创建 Worktree",
+  "worktree.submitting": "创建中...",
+  "worktree.cancel": "取消",
+  "worktree.menu.newWorktree": "新建 Worktree…",
+  "worktree.removeConfirm": "删除此 worktree 将同时删除磁盘目录与相关对话记录，确定继续？",
+  "worktree.error.branchRequired": "请填写分支名",
+  "worktree.error.selectRepo": "仅 Git 仓库 workspace 支持创建 worktree",
+  "worktree.empty.branches": "暂无分支",
+  "worktree.tag.label": "Worktree",
 } as const;
 
 export type TranslationKey = keyof typeof zhCN;

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -797,7 +797,7 @@ const zhCN = {
   "worktree.field.path": "worktree 目录",
   "worktree.field.pathPlaceholder": "自动生成路径",
   "worktree.field.pathBrowse": "选择...",
-  "worktree.field.pathHint": "默认创建在主仓库同级目录，可修改",
+  "worktree.field.pathHint": "留空将自动生成在 ~/.tiy/workspace/<hash>/<repo>",
   "worktree.submit": "创建 Worktree",
   "worktree.submitting": "创建中...",
   "worktree.cancel": "取消",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -787,13 +787,11 @@ const zhCN = {
 
   // ── Worktree ───────────────────────────────────────────
   "worktree.createTitle": "新建 Worktree",
-  "worktree.createDescription": "为当前 Git 仓库创建一个新的 worktree，可基于现有分支或新建分支。",
-  "worktree.field.branch": "分支",
-  "worktree.field.branchPlaceholder": "选择或输入分支名",
-  "worktree.tab.existingBranch": "已有分支",
-  "worktree.tab.newBranch": "新建分支",
-  "worktree.field.baseRef": "起点（Base）",
-  "worktree.field.baseRefPlaceholder": "默认：当前 HEAD",
+  "worktree.createDescription": "为当前 Git 仓库创建一个新的 worktree，基于现有分支新建分支。",
+  "worktree.field.branch": "新分支名",
+  "worktree.field.branchPlaceholder": "输入新分支名称",
+  "worktree.field.baseBranch": "基于分支",
+  "worktree.field.baseBranchHint": "新分支将基于 {{branch}} 创建",
   "worktree.field.path": "worktree 目录",
   "worktree.field.pathPlaceholder": "自动生成路径",
   "worktree.field.pathBrowse": "选择...",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -804,7 +804,7 @@ const zhCN = {
   "worktree.error.branchRequired": "请填写分支名",
   "worktree.error.selectRepo": "仅 Git 仓库 workspace 支持创建 worktree",
   "worktree.empty.branches": "暂无分支",
-"worktree.loading.branches": "加载中…",
+  "worktree.loading.branches": "加载中…",
   "worktree.tag.label": "Worktree",
 } as const;
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -804,6 +804,7 @@ const zhCN = {
   "worktree.error.branchRequired": "请填写分支名",
   "worktree.error.selectRepo": "仅 Git 仓库 workspace 支持创建 worktree",
   "worktree.empty.branches": "暂无分支",
+"worktree.loading.branches": "加载中…",
   "worktree.tag.label": "Worktree",
 } as const;
 

--- a/src/modules/workbench-shell/model/helpers.test.ts
+++ b/src/modules/workbench-shell/model/helpers.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceDto } from "@/shared/types/api";
+import {
+  buildProjectOptionFromWorkspace,
+  sortWorkspacesWithWorktrees,
+} from "@/modules/workbench-shell/model/helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWorkspace(overrides: Partial<WorkspaceDto> = {}): WorkspaceDto {
+  return {
+    id: "ws-1",
+    name: "Repo",
+    path: "/home/user/repo",
+    canonicalPath: "/home/user/repo",
+    displayPath: "~/repo",
+    isDefault: false,
+    isGit: true,
+    autoWorkTree: false,
+    status: "ready",
+    lastValidatedAt: null,
+    createdAt: "2026-04-12T00:00:00Z",
+    updatedAt: "2026-04-12T00:00:00Z",
+    kind: "repo",
+    parentWorkspaceId: null,
+    gitCommonDir: null,
+    branch: "main",
+    worktreeName: null,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// buildProjectOptionFromWorkspace
+// ---------------------------------------------------------------------------
+
+describe("buildProjectOptionFromWorkspace", () => {
+  it("maps basic workspace fields", () => {
+    const ws = createWorkspace();
+    const opt = buildProjectOptionFromWorkspace(ws);
+    expect(opt.id).toBe(ws.id);
+    expect(opt.name).toBe(ws.name);
+    expect(opt.path).toBe(ws.canonicalPath);
+    expect(opt.kind).toBe(ws.kind);
+    expect(opt.parentWorkspaceId).toBe(ws.parentWorkspaceId);
+    expect(opt.branch).toBe(ws.branch);
+  });
+
+  it("falls back to path when canonicalPath is empty", () => {
+    const ws = createWorkspace({ canonicalPath: "", path: "/fallback/path" });
+    const opt = buildProjectOptionFromWorkspace(ws);
+    expect(opt.path).toBe("/fallback/path");
+  });
+
+  it("slices worktreeName to first 6 chars as worktreeHash", () => {
+    const ws = createWorkspace({
+      kind: "worktree",
+      worktreeName: "abc123-feat-login",
+    });
+    const opt = buildProjectOptionFromWorkspace(ws);
+    expect(opt.worktreeHash).toBe("abc123");
+  });
+
+  it("returns null worktreeHash when worktreeName is null", () => {
+    const ws = createWorkspace({ worktreeName: null });
+    const opt = buildProjectOptionFromWorkspace(ws);
+    expect(opt.worktreeHash).toBeNull();
+  });
+
+  it("uses provided lastOpenedLabel", () => {
+    const ws = createWorkspace();
+    const opt = buildProjectOptionFromWorkspace(ws, "2 hours ago");
+    expect(opt.lastOpenedLabel).toBe("2 hours ago");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sortWorkspacesWithWorktrees
+// ---------------------------------------------------------------------------
+
+describe("sortWorkspacesWithWorktrees", () => {
+  it("keeps standalone items in original order", () => {
+    const items = [
+      { id: "a", kind: "standalone" as const, parentWorkspaceId: null },
+      { id: "b", kind: "standalone" as const, parentWorkspaceId: null },
+      { id: "c", kind: "standalone" as const, parentWorkspaceId: null },
+    ];
+    const sorted = sortWorkspacesWithWorktrees(items);
+    expect(sorted.map((i) => i.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("places worktree children immediately after their parent repo", () => {
+    const items = [
+      { id: "repo-1", kind: "repo" as const, parentWorkspaceId: null },
+      { id: "standalone-1", kind: "standalone" as const, parentWorkspaceId: null },
+      { id: "wt-1", kind: "worktree" as const, parentWorkspaceId: "repo-1" },
+      { id: "wt-2", kind: "worktree" as const, parentWorkspaceId: "repo-1" },
+    ];
+    const sorted = sortWorkspacesWithWorktrees(items);
+    expect(sorted.map((i) => i.id)).toEqual([
+      "repo-1",
+      "wt-1",
+      "wt-2",
+      "standalone-1",
+    ]);
+  });
+
+  it("handles orphan worktrees (parent missing) gracefully", () => {
+    const items = [
+      { id: "standalone-1", kind: "standalone" as const, parentWorkspaceId: null },
+      { id: "wt-orphan", kind: "worktree" as const, parentWorkspaceId: "missing-repo" },
+    ];
+    const sorted = sortWorkspacesWithWorktrees(items);
+    // Orphans should still appear — not be lost
+    expect(sorted.map((i) => i.id)).toContain("wt-orphan");
+    expect(sorted).toHaveLength(2);
+  });
+
+  it("handles multiple repos each with worktrees", () => {
+    const items = [
+      { id: "repo-a", kind: "repo" as const, parentWorkspaceId: null },
+      { id: "repo-b", kind: "repo" as const, parentWorkspaceId: null },
+      { id: "wt-b1", kind: "worktree" as const, parentWorkspaceId: "repo-b" },
+      { id: "wt-a1", kind: "worktree" as const, parentWorkspaceId: "repo-a" },
+    ];
+    const sorted = sortWorkspacesWithWorktrees(items);
+    const ids = sorted.map((i) => i.id);
+    // Each worktree must come after its parent
+    expect(ids.indexOf("wt-a1")).toBeGreaterThan(ids.indexOf("repo-a"));
+    expect(ids.indexOf("wt-b1")).toBeGreaterThan(ids.indexOf("repo-b"));
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(sortWorkspacesWithWorktrees([])).toEqual([]);
+  });
+
+  it("preserves items without kind field", () => {
+    const items = [
+      { id: "x", parentWorkspaceId: null },
+      { id: "y", parentWorkspaceId: null },
+    ];
+    const sorted = sortWorkspacesWithWorktrees(items);
+    expect(sorted.map((i) => i.id)).toEqual(["x", "y"]);
+  });
+});

--- a/src/modules/workbench-shell/model/helpers.ts
+++ b/src/modules/workbench-shell/model/helpers.ts
@@ -345,7 +345,7 @@ function mapThreadStatus(status: ApiThreadStatus): WorkbenchThreadStatus {
   }
 }
 
-export function formatThreadTimeLabel(value: string | null | undefined, language: LanguagePreference = "zh-CN", now = Date.now()) {
+export function formatThreadTimeLabel(value: string | null | undefined, language: LanguagePreference = "en", now = Date.now()) {
   if (!value) {
     return "";
   }
@@ -382,7 +382,7 @@ export function formatThreadTimeLabel(value: string | null | undefined, language
 export function buildWorkspaceThreadItem(
   thread: ThreadSummaryDto,
   activeThreadId: string | null,
-  language: LanguagePreference = "zh-CN",
+  language: LanguagePreference = "en",
 ): WorkspaceThreadItem {
   const trimmedTitle = thread.title.trim();
   const displayTitle = trimmedTitle || translate(language, "dashboard.newThread");
@@ -400,7 +400,7 @@ export function buildWorkspaceItemsFromDtos(
   workspaces: ReadonlyArray<WorkspaceDto>,
   threadsByWorkspaceId: Record<string, ReadonlyArray<ThreadSummaryDto>>,
   activeThreadId: string | null,
-  language: LanguagePreference = "zh-CN",
+  language: LanguagePreference = "en",
 ): Array<WorkspaceItem> {
   return workspaces.map((workspace) => ({
     id: workspace.id,
@@ -497,7 +497,7 @@ export function mergeRecentProjects(
   ].slice(0, 6);
 }
 
-export function buildProjectOptionFromPath(path: string | null): ProjectOption | null {
+export function buildProjectOptionFromPath(path: string | null, language: LanguagePreference = "en"): ProjectOption | null {
   if (!path) {
     return null;
   }
@@ -514,19 +514,20 @@ export function buildProjectOptionFromPath(path: string | null): ProjectOption |
     id: normalizedId || `project-${Date.now()}`,
     name: folderName,
     path: normalizedPath,
-    lastOpenedLabel: translate("zh-CN", "time.justNow"),
+    lastOpenedLabel: translate(language, "time.justNow"),
   };
 }
 
 export function buildProjectOptionFromWorkspace(
   workspace: WorkspaceDto,
   lastOpenedLabel?: string,
+  language: LanguagePreference = "en",
 ): ProjectOption {
   return {
     id: workspace.id,
     name: workspace.name,
     path: workspace.canonicalPath || workspace.path,
-    lastOpenedLabel: lastOpenedLabel ?? translate("zh-CN", "time.justNow"),
+    lastOpenedLabel: lastOpenedLabel ?? translate(language, "time.justNow"),
     kind: workspace.kind,
     parentWorkspaceId: workspace.parentWorkspaceId,
     worktreeHash: workspace.worktreeName

--- a/src/modules/workbench-shell/model/helpers.ts
+++ b/src/modules/workbench-shell/model/helpers.ts
@@ -407,6 +407,10 @@ export function buildWorkspaceItemsFromDtos(
     name: workspace.name,
     defaultOpen: workspace.isDefault,
     path: workspace.canonicalPath || workspace.path,
+    kind: workspace.kind,
+    parentWorkspaceId: workspace.parentWorkspaceId,
+    worktreeHash: workspace.worktreeName ? workspace.worktreeName.slice(0, 6) : null,
+    branch: workspace.branch,
     threads: (threadsByWorkspaceId[workspace.id] ?? []).map((thread) =>
       buildWorkspaceThreadItem(thread, activeThreadId, language),
     ),
@@ -512,6 +516,76 @@ export function buildProjectOptionFromPath(path: string | null): ProjectOption |
     path: normalizedPath,
     lastOpenedLabel: translate("zh-CN", "time.justNow"),
   };
+}
+
+export function buildProjectOptionFromWorkspace(
+  workspace: WorkspaceDto,
+  lastOpenedLabel?: string,
+): ProjectOption {
+  return {
+    id: workspace.id,
+    name: workspace.name,
+    path: workspace.canonicalPath || workspace.path,
+    lastOpenedLabel: lastOpenedLabel ?? translate("zh-CN", "time.justNow"),
+    kind: workspace.kind,
+    parentWorkspaceId: workspace.parentWorkspaceId,
+    worktreeHash: workspace.worktreeName
+      ? workspace.worktreeName.slice(0, 6)
+      : null,
+    branch: workspace.branch,
+  };
+}
+
+/**
+ * Order workspaces so each worktree row immediately follows its parent repo.
+ * Non-worktree rows keep their incoming ordering. Orphan worktrees (missing
+ * parent) fall back to their own ordering position.
+ */
+export function sortWorkspacesWithWorktrees<
+  T extends {
+    id: string;
+    kind?: "standalone" | "repo" | "worktree";
+    parentWorkspaceId?: string | null;
+  },
+>(items: ReadonlyArray<T>): Array<T> {
+  const byId = new Map(items.map((item) => [item.id, item] as const));
+  const placed = new Set<string>();
+  const result: Array<T> = [];
+
+  for (const item of items) {
+    if (placed.has(item.id)) continue;
+    if (item.kind === "worktree") {
+      const parentId = item.parentWorkspaceId ?? "";
+      if (parentId && byId.has(parentId) && !placed.has(parentId)) {
+        // Defer until parent is emitted first; skip now and pick up later.
+        continue;
+      }
+    }
+    result.push(item);
+    placed.add(item.id);
+
+    // Emit this item's worktrees right after it, preserving order.
+    for (const child of items) {
+      if (placed.has(child.id)) continue;
+      if (
+        child.kind === "worktree"
+        && (child.parentWorkspaceId ?? "") === item.id
+      ) {
+        result.push(child);
+        placed.add(child.id);
+      }
+    }
+  }
+
+  // Orphan worktrees whose parent never appeared.
+  for (const item of items) {
+    if (!placed.has(item.id)) {
+      result.push(item);
+      placed.add(item.id);
+    }
+  }
+
+  return result;
 }
 
 export function formatProjectPathLabel(path: string) {

--- a/src/modules/workbench-shell/model/types.ts
+++ b/src/modules/workbench-shell/model/types.ts
@@ -17,6 +17,10 @@ export type WorkspaceItem = {
   defaultOpen: boolean;
   threads: Array<WorkspaceThreadItem>;
   path?: string;
+  kind?: "standalone" | "repo" | "worktree";
+  parentWorkspaceId?: string | null;
+  worktreeHash?: string | null;
+  branch?: string | null;
 };
 
 export type ProjectOption = {
@@ -24,6 +28,10 @@ export type ProjectOption = {
   name: string;
   path: string;
   lastOpenedLabel: string;
+  kind?: "standalone" | "repo" | "worktree";
+  parentWorkspaceId?: string | null;
+  worktreeHash?: string | null;
+  branch?: string | null;
 };
 
 export type WorkspaceOpenApp = {

--- a/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
+++ b/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
@@ -122,4 +122,39 @@ describe("workspace path bindings", () => {
     expect(project?.name).toBe("docs");
     expect(project?.id).toContain("docs");
   });
+
+  it("prefers id/path match over name match for worktree workspaces", () => {
+    // The parent repo and worktree can share the same name (the default
+    // worktree path is `~/.tiy/workspace/<hex>/<repo-name>`).  The resolver
+    // must not short-circuit on the parent's name match when the worktree
+    // project exists with a matching id.
+    const project = resolveProjectForWorkspace(
+      createWorkspaceItem({
+        id: "worktree-1",
+        name: "my-repo",
+        path: "/Users/buddy/.tiy/workspace/abc123/my-repo",
+        kind: "worktree",
+        parentWorkspaceId: "parent-1",
+      }),
+      [
+        {
+          id: "parent-1",
+          name: "my-repo",
+          path: "/Users/buddy/projects/my-repo",
+          lastOpenedLabel: "Today",
+        },
+        {
+          id: "worktree-1",
+          name: "my-repo",
+          path: "/Users/buddy/.tiy/workspace/abc123/my-repo",
+          lastOpenedLabel: "Today",
+          kind: "worktree",
+          parentWorkspaceId: "parent-1",
+        },
+      ],
+    );
+
+    expect(project?.id).toBe("worktree-1");
+    expect(project?.path).toBe("/Users/buddy/.tiy/workspace/abc123/my-repo");
+  });
 });

--- a/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
+++ b/src/modules/workbench-shell/model/workspace-path-bindings.test.ts
@@ -25,6 +25,11 @@ function createWorkspace(overrides: Partial<WorkspaceDto> = {}): WorkspaceDto {
     lastValidatedAt: null,
     createdAt: "2026-04-12T00:00:00Z",
     updatedAt: "2026-04-12T00:00:00Z",
+    kind: "repo",
+    parentWorkspaceId: null,
+    gitCommonDir: null,
+    branch: null,
+    worktreeName: null,
     ...overrides,
   };
 }

--- a/src/modules/workbench-shell/model/workspace-path-bindings.ts
+++ b/src/modules/workbench-shell/model/workspace-path-bindings.ts
@@ -103,15 +103,28 @@ export function resolveProjectForWorkspace(
     return null;
   }
 
-  const matchedProject = recentProjects.find(
+  // Two-pass matching: prefer id/path exact matches first, then fall back to
+  // a weaker name-only match.  Without this separation, a worktree whose
+  // default directory basename equals the parent repo name (e.g.
+  // `~/.tiy/workspace/<hex>/<repo-name>`) would match the parent project by
+  // name before the worktree project is found, causing the right-side panels
+  // (tree view, git panel) to stay on the parent workspace.
+  const exactMatch = recentProjects.find(
     (project) =>
-      isSameWorkspacePath(project.path, workspace.path)
-      || project.id === workspace.id
-      || project.name === workspace.name,
+      project.id === workspace.id
+      || isSameWorkspacePath(project.path, workspace.path),
   );
 
-  if (matchedProject) {
-    return matchedProject;
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const nameMatch = recentProjects.find(
+    (project) => project.name === workspace.name,
+  );
+
+  if (nameMatch) {
+    return nameMatch;
   }
 
   if (!workspace.path) {

--- a/src/modules/workbench-shell/ui/branch-selector.tsx
+++ b/src/modules/workbench-shell/ui/branch-selector.tsx
@@ -45,10 +45,12 @@ export function BranchSelector({
   workspaceId,
   snapshot,
   modelPlan,
+  readOnly,
 }: {
   workspaceId: string | null;
   snapshot: Pick<GitSnapshotDto, "headRef" | "isDetached" | "stagedFiles" | "unstagedFiles" | "untrackedFiles"> | null;
   modelPlan: RunModelPlanDto | null;
+  readOnly?: boolean;
 }) {
   const t = useT();
   const [isOpen, setOpen] = useState(false);
@@ -340,6 +342,15 @@ export function BranchSelector({
       <span className="inline-flex items-center gap-1.5 text-xs text-app-subtle">
         <GitBranch className="size-3.5" />
         <span>{t("sourceControl.noBranch")}</span>
+      </span>
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs text-app-subtle">
+        <GitBranch className="size-3.5 shrink-0" />
+        <span className="max-w-[120px] truncate">{branchLabel}</span>
       </span>
     );
   }

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2475,10 +2475,12 @@ export function DashboardWorkbench() {
       }
 
       if (workspace.kind === "worktree") {
-        const confirmed =
-          typeof window === "undefined" ||
-          window.confirm(t("worktree.removeConfirm"));
-        if (!confirmed) return;
+        if (
+          typeof window !== "undefined" &&
+          !window.confirm(t("worktree.removeConfirm"))
+        ) {
+          return;
+        }
       }
 
       void (async () => {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -88,6 +88,7 @@ import {
   buildInitialWorkspaces,
   buildWorkspaceItemsFromDtos,
   buildThreadTitle,
+  sortWorkspacesWithWorktrees,
   clearActiveThreads,
   getActiveThread,
   isEditableSelectionTarget,
@@ -116,6 +117,10 @@ import type {
 } from "@/modules/workbench-shell/model/types";
 import type { ExtensionDetail, SkillPreview } from "@/shared/types/extensions";
 import { NewThreadEmptyState } from "@/modules/workbench-shell/ui/new-thread-empty-state";
+import {
+  NewWorktreeDialog,
+  type NewWorktreeDialogContext,
+} from "@/modules/workbench-shell/ui/new-worktree-dialog";
 import { ProjectPanel } from "@/modules/workbench-shell/ui/project-panel";
 import { BranchSelector } from "@/modules/workbench-shell/ui/branch-selector";
 import {
@@ -190,7 +195,7 @@ function getNewThreadTerminalBindingKey(workspaceId: string) {
   return `${workspaceId}:${NEW_THREAD_TERMINAL_KEY_SUFFIX}`;
 }
 
-function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
+function buildProjectOptionFromWorkspace(workspace: WorkspaceDto): ProjectOption | null {
   const project = buildProjectOptionFromPath(
     workspace.canonicalPath || workspace.path,
   );
@@ -202,6 +207,12 @@ function buildProjectOptionFromWorkspace(workspace: WorkspaceDto) {
     ...project,
     id: workspace.id,
     name: workspace.name,
+    kind: workspace.kind,
+    parentWorkspaceId: workspace.parentWorkspaceId ?? null,
+    worktreeHash: workspace.worktreeName
+      ? workspace.worktreeName.slice(0, 6)
+      : null,
+    branch: workspace.branch ?? null,
   };
 }
 
@@ -541,6 +552,8 @@ export function DashboardWorkbench() {
     workspaceId: string;
     kind: "open" | "remove";
   } | null>(null);
+  const [worktreeDialogContext, setWorktreeDialogContext] =
+    useState<NewWorktreeDialogContext | null>(null);
   const [pendingThreadRuns, setPendingThreadRuns] = useState<
     Record<string, PendingThreadRun>
   >({});
@@ -2407,6 +2420,13 @@ export function DashboardWorkbench() {
         return;
       }
 
+      if (workspace.kind === "worktree") {
+        const confirmed =
+          typeof window === "undefined" ||
+          window.confirm(t("worktree.removeConfirm"));
+        if (!confirmed) return;
+      }
+
       void (async () => {
         const workspaceThreadIds = new Set(
           workspace.threads.map((thread) => thread.id),
@@ -2538,6 +2558,7 @@ export function DashboardWorkbench() {
       selectedProject?.id,
       selectedProject?.path,
       syncWorkspaceSidebar,
+      t,
       workspaceAction,
     ],
   );
@@ -2724,10 +2745,20 @@ export function DashboardWorkbench() {
                     </div>
                   </div>
                 ) : (
-                workspaces.map((workspace) => {
+                sortWorkspacesWithWorktrees(workspaces).map((workspace) => {
+                  const isWorktreeRow = workspace.kind === "worktree";
+                  const isRepoRow = workspace.kind === "repo";
+                  const worktreeTag =
+                    workspace.worktreeHash && workspace.worktreeHash.length > 0
+                      ? workspace.worktreeHash
+                      : null;
                   const isOpen =
                     openWorkspaces[workspace.id] ?? workspace.defaultOpen;
-                  const FolderIcon = isOpen ? FolderOpen : Folder;
+                  const FolderIcon = isWorktreeRow
+                    ? GitBranch
+                    : isOpen
+                      ? FolderOpen
+                      : Folder;
                   const isWorkspaceMenuOpen =
                     activeWorkspaceMenuId === workspace.id;
                   const isOpeningWorkspace =
@@ -2767,9 +2798,17 @@ export function DashboardWorkbench() {
                             onClick={() => handleWorkspaceToggle(workspace.id)}
                           >
                             <FolderIcon className="size-4 shrink-0 text-app-muted" />
-                            <span className={DRAWER_LIST_LABEL_CLASS}>
+                            <span className={cn(DRAWER_LIST_LABEL_CLASS, "flex-1")}>
                               {workspace.name}
                             </span>
+                            {worktreeTag ? (
+                              <span
+                                title={t("worktree.tag.label")}
+                                className="rounded bg-app-surface-hover px-1.5 py-0.5 font-mono text-[10px] text-app-subtle"
+                              >
+                                {worktreeTag}
+                              </span>
+                            ) : null}
                           </button>
                           <button
                             type="button"
@@ -2809,6 +2848,30 @@ export function DashboardWorkbench() {
                                 <MessageSquarePlus className="size-4 shrink-0" />
                                 <span>{t("sidebar.newThreadForWorkspace")}</span>
                               </button>
+                              {isRepoRow ? (
+                                <button
+                                  type="button"
+                                  role="menuitem"
+                                  className="flex w-full items-center gap-2 rounded-lg px-2.5 py-2 text-left text-sm text-app-foreground transition-colors hover:bg-app-surface-hover disabled:cursor-not-allowed disabled:text-app-subtle"
+                                  onClick={(event) => {
+                                    event.stopPropagation();
+                                    setActiveWorkspaceMenuId(null);
+                                    if (workspace.path) {
+                                      setWorktreeDialogContext({
+                                        repo: {
+                                          id: workspace.id,
+                                          name: workspace.name,
+                                          canonicalPath: workspace.path,
+                                        },
+                                      });
+                                    }
+                                  }}
+                                  disabled={!workspace.path}
+                                >
+                                  <GitBranch className="size-4 shrink-0" />
+                                  <span>{t("worktree.menu.newWorktree")}</span>
+                                </button>
+                              ) : null}
                               <button
                                 type="button"
                                 role="menuitem"
@@ -2983,6 +3046,15 @@ export function DashboardWorkbench() {
                             isOverlayOpen={isOverlayOpen}
                             isLoading={!isSidebarReady}
                             onSelectProject={handleProjectSelect}
+                            onRequestNewWorktree={(project) => {
+                              setWorktreeDialogContext({
+                                repo: {
+                                  id: project.id,
+                                  name: project.name,
+                                  canonicalPath: project.path,
+                                },
+                              });
+                            }}
                             branchSlot={
                               resolvedWorkspaceId &&
                               topBarGitSnapshot?.capabilities.repoAvailable &&
@@ -3390,6 +3462,14 @@ export function DashboardWorkbench() {
           onDismiss={() => setShowOnboarding(false)}
         />
       ) : null}
+
+      <NewWorktreeDialog
+        context={worktreeDialogContext}
+        onClose={() => setWorktreeDialogContext(null)}
+        onCreated={() => {
+          void syncWorkspaceSidebar().catch(() => {});
+        }}
+      />
     </main>
   );
 }

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -196,9 +196,10 @@ function getNewThreadTerminalBindingKey(workspaceId: string) {
   return `${workspaceId}:${NEW_THREAD_TERMINAL_KEY_SUFFIX}`;
 }
 
-function buildProjectOptionFromWorkspace(workspace: WorkspaceDto): ProjectOption | null {
+function buildProjectOptionFromWorkspace(workspace: WorkspaceDto, language: LanguagePreference = "en"): ProjectOption | null {
   const project = buildProjectOptionFromPath(
     workspace.canonicalPath || workspace.path,
+    language,
   );
   if (!project) {
     return null;
@@ -1003,7 +1004,7 @@ export function DashboardWorkbench() {
         ]),
       );
       const nextProjects = workspaceEntries
-        .map((workspace) => buildProjectOptionFromWorkspace(workspace))
+        .map((workspace) => buildProjectOptionFromWorkspace(workspace, language))
         .filter((project): project is ProjectOption => project !== null);
       const nextBindings = buildWorkspaceBindings(workspaceEntries);
       const defaultWorkspace =
@@ -1887,7 +1888,7 @@ export function DashboardWorkbench() {
 
     clearNewThreadBindingForWorkspace(workspace.id);
 
-    const projectFromPath = buildProjectOptionFromPath(workspace.path);
+    const projectFromPath = buildProjectOptionFromPath(workspace.path, language);
     const nextProject: ProjectOption = {
       ...(projectFromPath ?? {
         id: workspace.id,
@@ -2129,7 +2130,7 @@ export function DashboardWorkbench() {
                 })
               : await workspaceEnsureDefault();
             const ensuredProject =
-              buildProjectOptionFromWorkspace(ensuredWorkspace) ?? {
+              buildProjectOptionFromWorkspace(ensuredWorkspace, language) ?? {
                 id: ensuredWorkspace.id,
                 name: ensuredWorkspace.name,
                 path: ensuredWorkspace.canonicalPath || ensuredWorkspace.path,
@@ -2395,7 +2396,7 @@ export function DashboardWorkbench() {
           return;
         }
 
-        const nextProject = buildProjectOptionFromPath(selectedPath);
+        const nextProject = buildProjectOptionFromPath(selectedPath, language);
 
         if (!nextProject) {
           return;

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2519,7 +2519,7 @@ export function DashboardWorkbench() {
           if (workspace.path) {
             addRemovedWorkspacePath(removedWorkspacePathsRef.current, workspace.path);
           }
-          await workspaceRemove(workspace.id);
+          await workspaceRemove(workspace.id, true);
 
           if (isRemovingActiveWorkspace) {
             setNewThreadMode(true);

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2172,14 +2172,20 @@ export function DashboardWorkbench() {
           ...nextProject,
           lastOpenedLabel: t("time.justNow"),
         };
+        // Two-pass lookup: prefer an exact ID match so a worktree is never
+        // shadowed by its parent repo when they share the same name.
         const existingWorkspace =
           workspaces.find(
             (workspace) =>
               workspace.id === nextWorkspaceId
-              || workspace.id === project.id
-              || workspace.name === project.name
+              || workspace.id === project.id,
+          )
+          ?? workspaces.find(
+            (workspace) =>
+              workspace.name === project.name
               || isSameWorkspacePath(workspace.path, project.path),
-          ) ?? null;
+          )
+          ?? null;
         const nextPendingRunId =
           typeof crypto !== "undefined" && "randomUUID" in crypto
             ? crypto.randomUUID()
@@ -2238,6 +2244,10 @@ export function DashboardWorkbench() {
               name: project.name,
               defaultOpen: true,
               path: project.path,
+              kind: project.kind,
+              parentWorkspaceId: project.parentWorkspaceId,
+              worktreeHash: project.worktreeHash ?? null,
+              branch: project.branch ?? null,
               threads: [nextThread],
             },
             ...cleared,

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -1633,6 +1633,10 @@ export function DashboardWorkbench() {
       return;
     }
 
+    // Clear stale snapshot immediately so the UI doesn't flash the previous
+    // workspace's branch while the new subscription/fetch is in flight.
+    setTopBarGitSnapshot(null);
+
     let cancelled = false;
     let unsubscribe: (() => Promise<void>) | null = null;
 
@@ -1656,7 +1660,7 @@ export function DashboardWorkbench() {
     void gitGetSnapshot(resolvedWorkspaceId)
       .then((snapshot) => {
         if (!cancelled && snapshot) {
-          setTopBarGitSnapshot((current) => current ?? snapshot);
+          setTopBarGitSnapshot(snapshot);
         }
       })
       .catch(() => {});

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -18,6 +18,7 @@ import {
   LoaderCircle,
   MessageSquarePlus,
   MoreHorizontal,
+  Shuffle,
   Trash2,
 } from "lucide-react";
 import {
@@ -1498,6 +1499,13 @@ export function DashboardWorkbench() {
       return;
     }
 
+    // Worktree rows cannot be the default workspace — only the owning repo
+    // can. Skip the auto-promotion in that case to avoid a recoverable
+    // backend error and a stale bootstrap banner.
+    if (selectedProject.kind === "worktree") {
+      return;
+    }
+
     let cancelled = false;
 
     void workspaceSetDefault(selectedProjectWorkspaceId)
@@ -1821,7 +1829,28 @@ export function DashboardWorkbench() {
     setNewThreadMode(false);
     setActiveWorkspaceMenuId(null);
     setPendingDeleteThreadId(null);
+    setTerminalBootstrapError(null);
     setWorkspaces((current) => activateThread(current, threadId));
+
+    // Align the selected project with the workspace that owns this thread so
+    // the new-thread empty state and path bindings stay consistent when the
+    // user toggles back to New Thread mode. Without this, selectedProject can
+    // drift (e.g. it stays on a worktree after the user jumped back to a
+    // thread belonging to the parent repo).
+    const nextWorkspace = workspaces.find((workspace) =>
+      workspace.threads.some((thread) => thread.id === threadId),
+    );
+    if (nextWorkspace && nextWorkspace.id !== selectedProject?.id) {
+      const projectForWorkspace = recentProjects.find(
+        (project) => project.id === nextWorkspace.id,
+      );
+      if (projectForWorkspace) {
+        setSelectedProject({
+          ...projectForWorkspace,
+          lastOpenedLabel: t("time.justNow"),
+        });
+      }
+    }
 
     // Restore the profile that was last used on this thread.
     const resolved = resolveThreadProfileId(
@@ -1855,7 +1884,7 @@ export function DashboardWorkbench() {
     clearNewThreadBindingForWorkspace(workspace.id);
 
     const projectFromPath = buildProjectOptionFromPath(workspace.path);
-    const nextProject = {
+    const nextProject: ProjectOption = {
       ...(projectFromPath ?? {
         id: workspace.id,
         name: workspace.name,
@@ -1866,6 +1895,16 @@ export function DashboardWorkbench() {
       name: workspace.name,
       path: workspace.path,
       lastOpenedLabel: t("time.justNow"),
+      // Preserve worktree-aware metadata so downstream effects (e.g. the
+      // "set this workspace as default" auto-promotion) can correctly skip
+      // worktree rows. Without this, selecting a worktree to start a new
+      // thread would surface the backend error
+      // "A worktree cannot be set as the default workspace" in the project
+      // and git panels.
+      kind: workspace.kind,
+      parentWorkspaceId: workspace.parentWorkspaceId,
+      worktreeHash: workspace.worktreeHash,
+      branch: workspace.branch,
     };
 
     deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
@@ -2755,7 +2794,7 @@ export function DashboardWorkbench() {
                   const isOpen =
                     openWorkspaces[workspace.id] ?? workspace.defaultOpen;
                   const FolderIcon = isWorktreeRow
-                    ? GitBranch
+                    ? Shuffle
                     : isOpen
                       ? FolderOpen
                       : Folder;
@@ -2798,17 +2837,19 @@ export function DashboardWorkbench() {
                             onClick={() => handleWorkspaceToggle(workspace.id)}
                           >
                             <FolderIcon className="size-4 shrink-0 text-app-muted" />
-                            <span className={cn(DRAWER_LIST_LABEL_CLASS, "flex-1")}>
-                              {workspace.name}
-                            </span>
-                            {worktreeTag ? (
-                              <span
-                                title={t("worktree.tag.label")}
-                                className="rounded bg-app-surface-hover px-1.5 py-0.5 font-mono text-[10px] text-app-subtle"
-                              >
-                                {worktreeTag}
+                            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                              <span className="truncate text-[13px] leading-5">
+                                {workspace.name}
                               </span>
-                            ) : null}
+                              {worktreeTag ? (
+                                <span
+                                  title={t("worktree.tag.label")}
+                                  className="shrink-0 rounded bg-app-surface-hover px-1.5 py-0.5 font-mono text-[10px] text-app-subtle"
+                                >
+                                  {worktreeTag}
+                                </span>
+                              ) : null}
+                            </div>
                           </button>
                           <button
                             type="button"
@@ -2868,7 +2909,7 @@ export function DashboardWorkbench() {
                                   }}
                                   disabled={!workspace.path}
                                 >
-                                  <GitBranch className="size-4 shrink-0" />
+                                  <Shuffle className="size-4 shrink-0" />
                                   <span>{t("worktree.menu.newWorktree")}</span>
                                 </button>
                               ) : null}
@@ -3063,6 +3104,7 @@ export function DashboardWorkbench() {
                                   workspaceId={resolvedWorkspaceId}
                                   snapshot={branchSnapshot}
                                   modelPlan={commitMessageModelPlan}
+                                  readOnly={currentProject?.kind === "worktree"}
                                 />
                               ) : null
                             }
@@ -3175,6 +3217,7 @@ export function DashboardWorkbench() {
                             workspaceId={resolvedWorkspaceId}
                             snapshot={branchSnapshot}
                             modelPlan={commitMessageModelPlan}
+                            readOnly={currentProject?.kind === "worktree"}
                           />
                         </div>
                       </div>

--- a/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
+++ b/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown, Folder, FolderPlus } from "lucide-react";
+import { Check, ChevronDown, Folder, FolderPlus, GitBranch } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useT } from "@/i18n";
 import { cn } from "@/shared/lib/utils";
@@ -13,6 +13,7 @@ export function NewThreadEmptyState({
   isLoading,
   onSelectProject,
   branchSlot,
+  onRequestNewWorktree,
 }: {
   recentProjects: ReadonlyArray<ProjectOption>;
   selectedProject: ProjectOption | null;
@@ -20,6 +21,7 @@ export function NewThreadEmptyState({
   isLoading?: boolean;
   onSelectProject: (project: ProjectOption) => void;
   branchSlot?: ReactNode;
+  onRequestNewWorktree?: (project: ProjectOption) => void;
 }) {
   const t = useT();
   const [isMenuOpen, setMenuOpen] = useState(false);
@@ -74,6 +76,15 @@ export function NewThreadEmptyState({
     setMenuOpen(false);
   };
 
+  const newWorktreeRepo =
+    onRequestNewWorktree && activeProject?.kind === "repo"
+      ? activeProject
+      : onRequestNewWorktree && activeProject?.kind === "worktree" && activeProject.parentWorkspaceId
+        ? (recentProjects.find(
+            (project) => project.id === activeProject.parentWorkspaceId,
+          ) ?? null)
+        : null;
+
   return (
     <div
       className={cn(
@@ -116,13 +127,25 @@ export function NewThreadEmptyState({
             onClick={() => setMenuOpen((current) => !current)}
           >
             <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border border-app-border bg-app-surface-muted text-app-subtle">
-              <Folder className="size-4 shrink-0" />
+              {activeProject?.kind === "worktree" ? (
+                <GitBranch className="size-4 shrink-0" />
+              ) : (
+                <Folder className="size-4 shrink-0" />
+              )}
             </div>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 <span className="min-w-0 flex-1 truncate text-[1rem] font-medium tracking-[-0.02em] text-app-foreground">
                   {activeProject?.name ?? t("newThread.chooseProject")}
                 </span>
+                {activeProject?.worktreeHash ? (
+                  <span
+                    title={t("worktree.tag.label")}
+                    className="shrink-0 rounded bg-app-surface-muted px-1.5 py-0.5 font-mono text-[10px] text-app-subtle"
+                  >
+                    {activeProject.worktreeHash}
+                  </span>
+                ) : null}
                 {activeProject ? (
                   <span className="shrink-0 rounded-full bg-app-surface-muted px-2 py-0.5 text-[10px] font-medium text-app-subtle">
                     {activeProject.lastOpenedLabel}
@@ -157,6 +180,7 @@ export function NewThreadEmptyState({
                   <div className="space-y-0.5">
                     {recentProjects.map((project) => {
                       const isSelected = activeProject?.id === project.id;
+                      const isWorktree = project.kind === "worktree";
 
                       return (
                         <button
@@ -174,11 +198,23 @@ export function NewThreadEmptyState({
                           }}
                         >
                           <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg border border-app-border bg-app-surface-muted text-app-subtle">
-                            <Folder className="size-4 shrink-0" />
+                            {isWorktree ? (
+                              <GitBranch className="size-4 shrink-0" />
+                            ) : (
+                              <Folder className="size-4 shrink-0" />
+                            )}
                           </div>
                           <div className="min-w-0 flex-1">
                             <div className="flex items-center gap-2">
                               <span className="min-w-0 flex-1 truncate text-sm font-medium">{project.name}</span>
+                              {project.worktreeHash ? (
+                                <span
+                                  title={t("worktree.tag.label")}
+                                  className="shrink-0 rounded bg-app-surface-muted px-1.5 py-0.5 font-mono text-[10px] text-app-subtle"
+                                >
+                                  {project.worktreeHash}
+                                </span>
+                              ) : null}
                               <span className="shrink-0 text-[10px] font-medium text-app-subtle">{project.lastOpenedLabel}</span>
                             </div>
                             <p className="mt-0.5 truncate text-[11px] leading-5 text-app-subtle" title={project.path}>
@@ -207,6 +243,27 @@ export function NewThreadEmptyState({
                     <p className="mt-0.5 text-[11px] leading-5 text-app-subtle">{t("newThread.browseHint")}</p>
                   </div>
                 </button>
+
+                {newWorktreeRepo && onRequestNewWorktree ? (
+                  <button
+                    type="button"
+                    className="flex w-full shrink-0 items-start gap-2.5 rounded-xl px-2.5 py-2 text-left text-app-foreground transition-colors hover:bg-app-surface-hover/70"
+                    onClick={() => {
+                      setMenuOpen(false);
+                      onRequestNewWorktree(newWorktreeRepo);
+                    }}
+                  >
+                    <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg border border-app-border bg-app-surface-muted text-app-subtle">
+                      <GitBranch className="size-4 shrink-0" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="text-sm font-medium">{t("worktree.menu.newWorktree")}</div>
+                      <p className="mt-0.5 truncate text-[11px] leading-5 text-app-subtle">
+                        {newWorktreeRepo.name}
+                      </p>
+                    </div>
+                  </button>
+                ) : null}
               </div>
             </div>
           ) : null}

--- a/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
+++ b/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode } from "react";
-import { Check, ChevronDown, Folder, FolderPlus, GitBranch } from "lucide-react";
+import { Check, ChevronDown, Folder, FolderPlus, Shuffle } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useT } from "@/i18n";
 import { cn } from "@/shared/lib/utils";
@@ -128,7 +128,7 @@ export function NewThreadEmptyState({
           >
             <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border border-app-border bg-app-surface-muted text-app-subtle">
               {activeProject?.kind === "worktree" ? (
-                <GitBranch className="size-4 shrink-0" />
+                <Shuffle className="size-4 shrink-0" />
               ) : (
                 <Folder className="size-4 shrink-0" />
               )}
@@ -199,7 +199,7 @@ export function NewThreadEmptyState({
                         >
                           <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg border border-app-border bg-app-surface-muted text-app-subtle">
                             {isWorktree ? (
-                              <GitBranch className="size-4 shrink-0" />
+                              <Shuffle className="size-4 shrink-0" />
                             ) : (
                               <Folder className="size-4 shrink-0" />
                             )}
@@ -254,7 +254,7 @@ export function NewThreadEmptyState({
                     }}
                   >
                     <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg border border-app-border bg-app-surface-muted text-app-subtle">
-                      <GitBranch className="size-4 shrink-0" />
+                      <Shuffle className="size-4 shrink-0" />
                     </div>
                     <div className="min-w-0 flex-1">
                       <div className="text-sm font-medium">{t("worktree.menu.newWorktree")}</div>

--- a/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
+++ b/src/modules/workbench-shell/ui/new-thread-empty-state.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Check, ChevronDown, Folder, FolderPlus, Shuffle } from "lucide-react";
 import { open } from "@tauri-apps/plugin-dialog";
 import { useT } from "@/i18n";
+import { useLanguage } from "@/app/providers/language-provider";
 import { cn } from "@/shared/lib/utils";
 import { buildProjectOptionFromPath, formatProjectPathLabel } from "@/modules/workbench-shell/model/helpers";
 import type { ProjectOption } from "@/modules/workbench-shell/model/types";
@@ -24,6 +25,7 @@ export function NewThreadEmptyState({
   onRequestNewWorktree?: (project: ProjectOption) => void;
 }) {
   const t = useT();
+  const { language } = useLanguage();
   const [isMenuOpen, setMenuOpen] = useState(false);
   const projectMenuRef = useRef<HTMLDivElement | null>(null);
   const activeProject = selectedProject ?? recentProjects[0] ?? null;
@@ -66,7 +68,7 @@ export function NewThreadEmptyState({
       return;
     }
 
-    const nextProject = buildProjectOptionFromPath(selectedPath);
+    const nextProject = buildProjectOptionFromPath(selectedPath, language);
 
     if (!nextProject) {
       return;

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -1,0 +1,327 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { GitBranch, LoaderCircle, Plus } from "lucide-react";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+
+import { useT } from "@/i18n";
+import { cn } from "@/shared/lib/utils";
+import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
+import { Button } from "@/shared/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/shared/ui/dialog";
+import { Input } from "@/shared/ui/input";
+import {
+  gitListBranches,
+  workspaceCreateWorktree,
+} from "@/services/bridge";
+import type {
+  GitBranchDto,
+  WorkspaceDto,
+  WorktreeCreateInput,
+} from "@/shared/types/api";
+
+export type NewWorktreeDialogContext = {
+  /** The repo workspace this worktree will belong to. */
+  repo: Pick<WorkspaceDto, "id" | "name" | "canonicalPath">;
+};
+
+type Tab = "existing" | "new";
+
+function slugifyBranch(branch: string): string {
+  const lower = branch.toLowerCase();
+  let out = "";
+  let lastDash = false;
+  for (const ch of lower) {
+    if (/[a-z0-9]/.test(ch)) {
+      out += ch;
+      lastDash = false;
+    } else {
+      if (!lastDash) {
+        out += "-";
+        lastDash = true;
+      }
+    }
+  }
+  out = out.replace(/^-+|-+$/g, "");
+  return out || "worktree";
+}
+
+function repoParentPath(canonicalPath: string): string {
+  const normalized = canonicalPath.replace(/\\/g, "/").replace(/\/+$/g, "");
+  const slash = normalized.lastIndexOf("/");
+  if (slash <= 0) return normalized;
+  return normalized.slice(0, slash);
+}
+
+function repoBaseName(canonicalPath: string): string {
+  const normalized = canonicalPath.replace(/\\/g, "/").replace(/\/+$/g, "");
+  const slash = normalized.lastIndexOf("/");
+  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
+}
+
+export function NewWorktreeDialog({
+  context,
+  onClose,
+  onCreated,
+}: {
+  context: NewWorktreeDialogContext | null;
+  onClose: () => void;
+  onCreated?: (workspace: WorkspaceDto) => void;
+}) {
+  const t = useT();
+  const isOpen = context !== null;
+
+  const [tab, setTab] = useState<Tab>("new");
+  const [branch, setBranch] = useState("");
+  const [baseRef, setBaseRef] = useState("");
+  const [path, setPath] = useState("");
+  const [pathTouched, setPathTouched] = useState(false);
+  const [branches, setBranches] = useState<GitBranchDto[]>([]);
+  const [branchesLoading, setBranchesLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset state whenever the dialog opens for a new repo.
+  useEffect(() => {
+    if (!isOpen) return;
+    setTab("new");
+    setBranch("");
+    setBaseRef("");
+    setPath("");
+    setPathTouched(false);
+    setError(null);
+  }, [isOpen, context?.repo.id]);
+
+  // Fetch branches lazily when the dialog opens.
+  useEffect(() => {
+    if (!isOpen || !context) return;
+    let cancelled = false;
+    setBranchesLoading(true);
+    gitListBranches(context.repo.id)
+      .then((list) => {
+        if (!cancelled) setBranches(list);
+      })
+      .catch(() => {
+        if (!cancelled) setBranches([]);
+      })
+      .finally(() => {
+        if (!cancelled) setBranchesLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, context]);
+
+  // Auto-fill the default path based on the current branch input.
+  const defaultPath = useMemo(() => {
+    if (!context) return "";
+    const parent = repoParentPath(context.repo.canonicalPath);
+    const repoName = repoBaseName(context.repo.canonicalPath);
+    const slug = slugifyBranch(branch || "worktree");
+    return `${parent}/${repoName}-${slug}`;
+  }, [context, branch]);
+
+  useEffect(() => {
+    if (!pathTouched) {
+      setPath(defaultPath);
+    }
+  }, [defaultPath, pathTouched]);
+
+  const canSubmit = Boolean(context && branch.trim() && !submitting);
+
+  const handleSubmit = useCallback(async () => {
+    if (!context) return;
+    const trimmed = branch.trim();
+    if (!trimmed) {
+      setError(t("worktree.error.branchRequired"));
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      const input: WorktreeCreateInput = {
+        branch: trimmed,
+        createBranch: tab === "new",
+        baseRef: tab === "new" && baseRef.trim() ? baseRef.trim() : undefined,
+        path: path.trim() || undefined,
+      };
+      const created = await workspaceCreateWorktree(context.repo.id, input);
+      onCreated?.(created);
+      onClose();
+    } catch (e) {
+      setError(getInvokeErrorMessage(e, "Failed to create worktree"));
+    } finally {
+      setSubmitting(false);
+    }
+  }, [context, branch, baseRef, path, tab, t, onCreated, onClose]);
+
+  const handleBrowsePath = useCallback(async () => {
+    const selected = await openDialog({
+      directory: true,
+      multiple: false,
+      defaultPath: path || undefined,
+    });
+    if (typeof selected === "string" && selected) {
+      setPath(selected);
+      setPathTouched(true);
+    }
+  }, [path]);
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <GitBranch className="h-4 w-4" />
+            {t("worktree.createTitle")}
+          </DialogTitle>
+          <DialogDescription>{t("worktree.createDescription")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex gap-1 rounded-md bg-muted p-1 text-sm">
+            <button
+              type="button"
+              onClick={() => setTab("new")}
+              className={cn(
+                "flex-1 rounded px-3 py-1.5 transition-colors",
+                tab === "new"
+                  ? "bg-background shadow-sm font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <Plus className="mr-1 inline h-3.5 w-3.5" />
+              {t("worktree.tab.newBranch")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setTab("existing")}
+              className={cn(
+                "flex-1 rounded px-3 py-1.5 transition-colors",
+                tab === "existing"
+                  ? "bg-background shadow-sm font-medium"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              <GitBranch className="mr-1 inline h-3.5 w-3.5" />
+              {t("worktree.tab.existingBranch")}
+            </button>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">{t("worktree.field.branch")}</label>
+            {tab === "existing" ? (
+              <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
+                {branchesLoading ? (
+                  <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                    Loading…
+                  </div>
+                ) : branches.length === 0 ? (
+                  <div className="px-2 py-4 text-sm text-muted-foreground">
+                    {t("worktree.empty.branches")}
+                  </div>
+                ) : (
+                  branches.map((b) => {
+                    const isActive = branch === b.name;
+                    const label = b.isRemote ? "remote" : "local";
+                    return (
+                      <button
+                        key={`${label}:${b.name}`}
+                        type="button"
+                        onClick={() => setBranch(b.name)}
+                        className={cn(
+                          "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                          isActive && "bg-background font-medium",
+                        )}
+                      >
+                        <span className="truncate">{b.name}</span>
+                        <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                          {label}
+                        </span>
+                      </button>
+                    );
+                  })
+                )}
+              </div>
+            ) : (
+              <Input
+                value={branch}
+                onChange={(e) => setBranch(e.target.value)}
+                placeholder={t("worktree.field.branchPlaceholder")}
+                autoFocus
+              />
+            )}
+            {tab === "existing" && branch && (
+              <div className="text-xs text-muted-foreground">{branch}</div>
+            )}
+          </div>
+
+          {tab === "new" ? (
+            <div className="flex flex-col gap-1.5">
+              <label className="text-sm font-medium">{t("worktree.field.baseRef")}</label>
+              <Input
+                value={baseRef}
+                onChange={(e) => setBaseRef(e.target.value)}
+                placeholder={t("worktree.field.baseRefPlaceholder")}
+              />
+            </div>
+          ) : null}
+
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">{t("worktree.field.path")}</label>
+            <div className="flex gap-2">
+              <Input
+                value={path}
+                onChange={(e) => {
+                  setPath(e.target.value);
+                  setPathTouched(true);
+                }}
+                placeholder={t("worktree.field.pathPlaceholder")}
+                className="flex-1 font-mono text-xs"
+              />
+              <Button type="button" variant="outline" onClick={handleBrowsePath}>
+                {t("worktree.field.pathBrowse")}
+              </Button>
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {t("worktree.field.pathHint")}
+            </div>
+          </div>
+
+          {error ? (
+            <div className="rounded border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+              {error}
+            </div>
+          ) : null}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            {t("worktree.cancel")}
+          </Button>
+          <Button onClick={handleSubmit} disabled={!canSubmit}>
+            {submitting ? (
+              <>
+                <LoaderCircle className="mr-2 h-3.5 w-3.5 animate-spin" />
+                {t("worktree.submitting")}
+              </>
+            ) : (
+              t("worktree.submit")
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { GitBranch, LoaderCircle, Plus } from "lucide-react";
+import { GitBranch, LoaderCircle } from "lucide-react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 
 import { useT } from "@/i18n";
@@ -30,8 +30,6 @@ export type NewWorktreeDialogContext = {
   repo: Pick<WorkspaceDto, "id" | "name" | "canonicalPath">;
 };
 
-type Tab = "existing" | "new";
-
 export function NewWorktreeDialog({
   context,
   onClose,
@@ -44,9 +42,8 @@ export function NewWorktreeDialog({
   const t = useT();
   const isOpen = context !== null;
 
-  const [tab, setTab] = useState<Tab>("new");
   const [branch, setBranch] = useState("");
-  const [baseRef, setBaseRef] = useState("");
+  const [baseBranch, setBaseBranch] = useState("");
   const [path, setPath] = useState("");
   const [pathTouched, setPathTouched] = useState(false);
   const [branches, setBranches] = useState<GitBranchDto[]>([]);
@@ -57,9 +54,8 @@ export function NewWorktreeDialog({
   // Reset state whenever the dialog opens for a new repo.
   useEffect(() => {
     if (!isOpen) return;
-    setTab("new");
     setBranch("");
-    setBaseRef("");
+    setBaseBranch("");
     setPath("");
     setPathTouched(false);
     setError(null);
@@ -116,8 +112,8 @@ export function NewWorktreeDialog({
     try {
       const input: WorktreeCreateInput = {
         branch: trimmed,
-        createBranch: tab === "new",
-        baseRef: tab === "new" && baseRef.trim() ? baseRef.trim() : undefined,
+        createBranch: true,
+        baseRef: baseBranch || undefined,
         path: path.trim() || undefined,
       };
       const created = await workspaceCreateWorktree(context.repo.id, input);
@@ -128,7 +124,7 @@ export function NewWorktreeDialog({
     } finally {
       setSubmitting(false);
     }
-  }, [context, branch, baseRef, path, tab, t, onCreated, onClose]);
+  }, [context, branch, baseBranch, path, t, onCreated, onClose]);
 
   const handleBrowsePath = useCallback(async () => {
     const selected = await openDialog({
@@ -159,95 +155,61 @@ export function NewWorktreeDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
-          <div className="flex gap-1 rounded-md bg-muted p-1 text-sm">
-            <button
-              type="button"
-              onClick={() => setTab("new")}
-              className={cn(
-                "flex-1 rounded px-3 py-1.5 transition-colors",
-                tab === "new"
-                  ? "bg-background shadow-sm font-medium"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <Plus className="mr-1 inline h-3.5 w-3.5" />
-              {t("worktree.tab.newBranch")}
-            </button>
-            <button
-              type="button"
-              onClick={() => setTab("existing")}
-              className={cn(
-                "flex-1 rounded px-3 py-1.5 transition-colors",
-                tab === "existing"
-                  ? "bg-background shadow-sm font-medium"
-                  : "text-muted-foreground hover:text-foreground",
-              )}
-            >
-              <GitBranch className="mr-1 inline h-3.5 w-3.5" />
-              {t("worktree.tab.existingBranch")}
-            </button>
-          </div>
-
+          {/* New branch name */}
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium">{t("worktree.field.branch")}</label>
-            {tab === "existing" ? (
-              <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
-                {branchesLoading ? (
-                  <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
-                    <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                    Loading…
-                  </div>
-                ) : branches.length === 0 ? (
-                  <div className="px-2 py-4 text-sm text-muted-foreground">
-                    {t("worktree.empty.branches")}
-                  </div>
-                ) : (
-                  branches.map((b) => {
-                    const isActive = branch === b.name;
-                    const label = b.isRemote ? "remote" : "local";
-                    return (
-                      <button
-                        key={`${label}:${b.name}`}
-                        type="button"
-                        onClick={() => setBranch(b.name)}
-                        className={cn(
-                          "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
-                          isActive && "bg-background font-medium",
-                        )}
-                      >
-                        <span className="truncate">{b.name}</span>
-                        <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                          {label}
-                        </span>
-                      </button>
-                    );
-                  })
-                )}
+            <Input
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              placeholder={t("worktree.field.branchPlaceholder")}
+              autoFocus
+            />
+          </div>
+
+          {/* Base branch selector */}
+          <div className="flex flex-col gap-1.5">
+            <label className="text-sm font-medium">{t("worktree.field.baseBranch")}</label>
+            <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
+              {branchesLoading ? (
+                <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+                  <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                  Loading…
+                </div>
+              ) : branches.length === 0 ? (
+                <div className="px-2 py-4 text-sm text-muted-foreground">
+                  {t("worktree.empty.branches")}
+                </div>
+              ) : (
+                branches.map((b) => {
+                  const isActive = baseBranch === b.name;
+                  const label = b.isRemote ? "remote" : "local";
+                  return (
+                    <button
+                      key={`${label}:${b.name}`}
+                      type="button"
+                      onClick={() => setBaseBranch(b.name)}
+                      className={cn(
+                        "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                        isActive && "bg-background font-medium",
+                      )}
+                    >
+                      <span className="truncate">{b.name}</span>
+                      <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                        {label}
+                      </span>
+                    </button>
+                  );
+                })
+              )}
+            </div>
+            {baseBranch && (
+              <div className="text-xs text-muted-foreground">
+                {t("worktree.field.baseBranchHint", { branch: baseBranch })}
               </div>
-            ) : (
-              <Input
-                value={branch}
-                onChange={(e) => setBranch(e.target.value)}
-                placeholder={t("worktree.field.branchPlaceholder")}
-                autoFocus
-              />
-            )}
-            {tab === "existing" && branch && (
-              <div className="text-xs text-muted-foreground">{branch}</div>
             )}
           </div>
 
-          {tab === "new" ? (
-            <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium">{t("worktree.field.baseRef")}</label>
-              <Input
-                value={baseRef}
-                onChange={(e) => setBaseRef(e.target.value)}
-                placeholder={t("worktree.field.baseRefPlaceholder")}
-              />
-            </div>
-          ) : null}
-
+          {/* Path */}
           <div className="flex flex-col gap-1.5">
             <label className="text-sm font-medium">{t("worktree.field.path")}</label>
             <div className="flex gap-2">

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -1,3 +1,5 @@
+// TODO: Add component-level tests once a React testing infrastructure
+// (e.g. @testing-library/react) is set up in this project.
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { GitBranch, LoaderCircle } from "lucide-react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -173,7 +175,7 @@ export function NewWorktreeDialog({
               {branchesLoading ? (
                 <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
                   <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                  Loading…
+                  {t("worktree.loading.branches")}
                 </div>
               ) : branches.length === 0 ? (
                 <div className="px-2 py-4 text-sm text-muted-foreground">

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -32,38 +32,6 @@ export type NewWorktreeDialogContext = {
 
 type Tab = "existing" | "new";
 
-function slugifyBranch(branch: string): string {
-  const lower = branch.toLowerCase();
-  let out = "";
-  let lastDash = false;
-  for (const ch of lower) {
-    if (/[a-z0-9]/.test(ch)) {
-      out += ch;
-      lastDash = false;
-    } else {
-      if (!lastDash) {
-        out += "-";
-        lastDash = true;
-      }
-    }
-  }
-  out = out.replace(/^-+|-+$/g, "");
-  return out || "worktree";
-}
-
-function repoParentPath(canonicalPath: string): string {
-  const normalized = canonicalPath.replace(/\\/g, "/").replace(/\/+$/g, "");
-  const slash = normalized.lastIndexOf("/");
-  if (slash <= 0) return normalized;
-  return normalized.slice(0, slash);
-}
-
-function repoBaseName(canonicalPath: string): string {
-  const normalized = canonicalPath.replace(/\\/g, "/").replace(/\/+$/g, "");
-  const slash = normalized.lastIndexOf("/");
-  return slash >= 0 ? normalized.slice(slash + 1) : normalized;
-}
-
 export function NewWorktreeDialog({
   context,
   onClose,
@@ -117,20 +85,22 @@ export function NewWorktreeDialog({
     };
   }, [isOpen, context]);
 
-  // Auto-fill the default path based on the current branch input.
-  const defaultPath = useMemo(() => {
+  // When left empty, the backend auto-generates the path under
+  // `~/.tiy/workspace/<hash>/<repo-name>`. We intentionally do NOT auto-fill
+  // the input so users see the placeholder and trust the default.
+  const defaultPathHint = useMemo(() => {
     if (!context) return "";
-    const parent = repoParentPath(context.repo.canonicalPath);
-    const repoName = repoBaseName(context.repo.canonicalPath);
-    const slug = slugifyBranch(branch || "worktree");
-    return `${parent}/${repoName}-${slug}`;
-  }, [context, branch]);
+    return `~/.tiy/workspace/<hash>/${context.repo.name}`;
+  }, [context]);
 
   useEffect(() => {
+    if (!isOpen) return;
+    // Reset path back to empty whenever the dialog opens for a new repo;
+    // backend will auto-generate on submit.
     if (!pathTouched) {
-      setPath(defaultPath);
+      setPath("");
     }
-  }, [defaultPath, pathTouched]);
+  }, [isOpen, pathTouched]);
 
   const canSubmit = Boolean(context && branch.trim() && !submitting);
 
@@ -287,7 +257,7 @@ export function NewWorktreeDialog({
                   setPath(e.target.value);
                   setPathTouched(true);
                 }}
-                placeholder={t("worktree.field.pathPlaceholder")}
+                placeholder={defaultPathHint}
                 className="flex-1 font-mono text-xs"
               />
               <Button type="button" variant="outline" onClick={handleBrowsePath}>

--- a/src/services/bridge/workspace-commands.ts
+++ b/src/services/bridge/workspace-commands.ts
@@ -25,9 +25,9 @@ export async function workspaceEnsureDefault(): Promise<WorkspaceDto> {
   return invoke<WorkspaceDto>("workspace_ensure_default");
 }
 
-export async function workspaceRemove(id: string): Promise<void> {
+export async function workspaceRemove(id: string, force?: boolean): Promise<void> {
   if (!isTauri()) throw new Error("workspace_remove requires Tauri runtime");
-  return invoke("workspace_remove", { id });
+  return invoke("workspace_remove", { id, force: force ?? false });
 }
 
 export async function workspaceSetDefault(id: string): Promise<void> {
@@ -78,7 +78,7 @@ export async function workspaceRemoveWorktree(
   }
   return invoke("workspace_remove_worktree", {
     id,
-    force: force ?? true,
+    force: force ?? false,
   });
 }
 

--- a/src/services/bridge/workspace-commands.ts
+++ b/src/services/bridge/workspace-commands.ts
@@ -64,6 +64,11 @@ export async function workspaceCreateWorktree(
   });
 }
 
+/**
+ * @internal Reserved for future direct worktree removal UI.
+ * Currently unused — workspace deletion goes through `workspaceRemove` which
+ * handles worktree cleanup internally on the Rust side.
+ */
 export async function workspaceRemoveWorktree(
   id: string,
   force?: boolean,
@@ -77,6 +82,10 @@ export async function workspaceRemoveWorktree(
   });
 }
 
+/**
+ * @internal Reserved for future worktree maintenance UI.
+ * Currently unused — may be exposed as a manual cleanup action later.
+ */
 export async function workspacePruneWorktrees(
   workspaceId: string,
 ): Promise<void> {

--- a/src/services/bridge/workspace-commands.ts
+++ b/src/services/bridge/workspace-commands.ts
@@ -1,5 +1,9 @@
 import { invoke, isTauri } from "@tauri-apps/api/core";
-import type { WorkspaceDto } from "@/shared/types/api";
+import type {
+  WorkspaceDto,
+  WorktreeCreateInput,
+  WorktreeInfoDto,
+} from "@/shared/types/api";
 
 export async function workspaceList(): Promise<WorkspaceDto[]> {
   if (!isTauri()) return [];
@@ -34,4 +38,50 @@ export async function workspaceSetDefault(id: string): Promise<void> {
 export async function workspaceValidate(id: string): Promise<WorkspaceDto> {
   if (!isTauri()) throw new Error("workspace_validate requires Tauri runtime");
   return invoke<WorkspaceDto>("workspace_validate", { id });
+}
+
+// ---------------------------------------------------------------------------
+// Worktree bridge
+// ---------------------------------------------------------------------------
+
+export async function workspaceListWorktrees(
+  workspaceId: string,
+): Promise<WorktreeInfoDto[]> {
+  if (!isTauri()) return [];
+  return invoke<WorktreeInfoDto[]>("workspace_list_worktrees", { workspaceId });
+}
+
+export async function workspaceCreateWorktree(
+  workspaceId: string,
+  input: WorktreeCreateInput,
+): Promise<WorkspaceDto> {
+  if (!isTauri()) {
+    throw new Error("workspace_create_worktree requires Tauri runtime");
+  }
+  return invoke<WorkspaceDto>("workspace_create_worktree", {
+    workspaceId,
+    input,
+  });
+}
+
+export async function workspaceRemoveWorktree(
+  id: string,
+  force?: boolean,
+): Promise<void> {
+  if (!isTauri()) {
+    throw new Error("workspace_remove_worktree requires Tauri runtime");
+  }
+  return invoke("workspace_remove_worktree", {
+    id,
+    force: force ?? true,
+  });
+}
+
+export async function workspacePruneWorktrees(
+  workspaceId: string,
+): Promise<void> {
+  if (!isTauri()) {
+    throw new Error("workspace_prune_worktrees requires Tauri runtime");
+  }
+  return invoke("workspace_prune_worktrees", { workspaceId });
 }

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -11,6 +11,8 @@
 
 export type WorkspaceStatus = "ready" | "missing" | "inaccessible" | "invalid";
 
+export type WorkspaceKind = "standalone" | "repo" | "worktree";
+
 export interface WorkspaceDto {
   id: string;
   name: string;
@@ -24,6 +26,28 @@ export interface WorkspaceDto {
   lastValidatedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  kind: WorkspaceKind;
+  parentWorkspaceId: string | null;
+  gitCommonDir: string | null;
+  branch: string | null;
+  worktreeName: string | null;
+}
+
+export interface WorktreeInfoDto {
+  name: string;
+  path: string;
+  branch: string | null;
+  head: string | null;
+  isValid: boolean;
+  isLocked: boolean;
+  workspaceId: string | null;
+}
+
+export interface WorktreeCreateInput {
+  branch: string;
+  baseRef?: string | null;
+  createBranch?: boolean;
+  path?: string | null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add full Git worktree lifecycle support (create, list, remove, prune) with a new `WorktreeManager` in the Rust backend and corresponding Tauri commands.
- Introduce a new `NewWorktreeDialog` UI for creating worktrees from repo workspaces, with branch selection, auto-generated paths under `~/.tiy/workspace/`, and i18n support (en + zh-CN).
- Extend workspace model with `kind` (standalone/repo/worktree), parent–child relationships, and cascade deletion so removing a parent repo cleans up all child worktrees and their threads.

## Test Plan
- [ ] Create a worktree from a repo workspace via the sidebar menu and the new-thread empty state
- [ ] Verify worktree rows appear with the shuffle icon and hash tag in the sidebar
- [ ] Remove a worktree and confirm disk directory + DB rows are cleaned up
- [ ] Remove a parent repo and confirm child worktrees cascade-delete
- [ ] Run `cargo test --manifest-path src-tauri/Cargo.toml` — new `m2_4_worktree.rs` tests pass
- [ ] Run `npm run typecheck` — no TypeScript errors
- [ ] Run `npm run test:unit` — existing + new frontend tests pass

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)