### PR TITLE
feat(workbench-shell): ✨ Add inline thread title editing with AI regeneration

### DIFF
--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -275,3 +275,131 @@ Rules:\n\
 Conversation:\n{conversation}"
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::agent_session::{RuntimeModelPlan, RuntimeModelRole};
+    use crate::model::thread::MessageRecord;
+
+    fn dummy_model_role(model: &str) -> RuntimeModelRole {
+        RuntimeModelRole {
+            provider_id: "p1".into(),
+            model_record_id: "mr1".into(),
+            provider: None,
+            provider_key: None,
+            provider_type: "openai".into(),
+            provider_name: None,
+            model: model.into(),
+            model_id: model.into(),
+            model_display_name: None,
+            base_url: "https://api.example.com".into(),
+            context_window: None,
+            max_output_tokens: None,
+            supports_image_input: None,
+            custom_headers: None,
+            provider_options: None,
+        }
+    }
+
+    fn dummy_message(role: &str, content: &str) -> MessageRecord {
+        MessageRecord {
+            id: "msg1".into(),
+            thread_id: "t1".into(),
+            run_id: None,
+            role: role.into(),
+            content_markdown: content.into(),
+            message_type: "message".into(),
+            status: "completed".into(),
+            metadata_json: None,
+            attachments_json: None,
+            created_at: "2026-01-01T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn select_title_model_role_prefers_lightweight() {
+        let plan = RuntimeModelPlan {
+            lightweight: Some(dummy_model_role("lite")),
+            auxiliary: Some(dummy_model_role("aux")),
+            primary: Some(dummy_model_role("primary")),
+            ..Default::default()
+        };
+        let role = select_title_model_role(&plan).unwrap();
+        assert_eq!(role.model, "lite");
+    }
+
+    #[test]
+    fn select_title_model_role_falls_back_to_auxiliary() {
+        let plan = RuntimeModelPlan {
+            lightweight: None,
+            auxiliary: Some(dummy_model_role("aux")),
+            primary: Some(dummy_model_role("primary")),
+            ..Default::default()
+        };
+        let role = select_title_model_role(&plan).unwrap();
+        assert_eq!(role.model, "aux");
+    }
+
+    #[test]
+    fn select_title_model_role_falls_back_to_primary() {
+        let plan = RuntimeModelPlan {
+            lightweight: None,
+            auxiliary: None,
+            primary: Some(dummy_model_role("primary")),
+            ..Default::default()
+        };
+        let role = select_title_model_role(&plan).unwrap();
+        assert_eq!(role.model, "primary");
+    }
+
+    #[test]
+    fn select_title_model_role_errors_when_all_missing() {
+        let plan = RuntimeModelPlan::default();
+        let result = select_title_model_role(&plan);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn prompt_contains_language_rule_when_specified() {
+        let msg = dummy_message("user", "Hello world");
+        let refs: Vec<&MessageRecord> = vec![&msg];
+        let prompt =
+            build_regenerate_title_prompt(&refs, Some("Chinese"), ProfileResponseStyle::Balanced);
+        assert!(prompt.contains("Write the title in Chinese"));
+    }
+
+    #[test]
+    fn prompt_matches_conversation_language_when_none() {
+        let msg = dummy_message("user", "Hello world");
+        let refs: Vec<&MessageRecord> = vec![&msg];
+        let prompt = build_regenerate_title_prompt(&refs, None, ProfileResponseStyle::Balanced);
+        assert!(prompt.contains("Match the conversation language"));
+    }
+
+    #[test]
+    fn prompt_includes_concise_style_rule() {
+        let msg = dummy_message("user", "Hello");
+        let refs: Vec<&MessageRecord> = vec![&msg];
+        let prompt = build_regenerate_title_prompt(&refs, None, ProfileResponseStyle::Concise);
+        assert!(prompt.contains("terse"));
+    }
+
+    #[test]
+    fn prompt_includes_guide_style_rule() {
+        let msg = dummy_message("user", "Hello");
+        let refs: Vec<&MessageRecord> = vec![&msg];
+        let prompt = build_regenerate_title_prompt(&refs, None, ProfileResponseStyle::Guide);
+        assert!(prompt.contains("decision focus"));
+    }
+
+    #[test]
+    fn prompt_includes_conversation_content() {
+        let m1 = dummy_message("user", "How do I parse JSON?");
+        let m2 = dummy_message("assistant", "Use serde_json.");
+        let refs: Vec<&MessageRecord> = vec![&m1, &m2];
+        let prompt = build_regenerate_title_prompt(&refs, None, ProfileResponseStyle::Balanced);
+        assert!(prompt.contains("User:\nHow do I parse JSON?"));
+        assert!(prompt.contains("Assistant:\nUse serde_json."));
+    }
+}

--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -100,7 +100,13 @@ pub async fn thread_regenerate_title(
     thread_id: String,
     model_plan: serde_json::Value,
 ) -> Result<String, AppError> {
-    let raw_plan: RuntimeModelPlan = serde_json::from_value(model_plan).unwrap_or_default();
+    let raw_plan: RuntimeModelPlan = serde_json::from_value(model_plan).map_err(|e| {
+        AppError::recoverable(
+            ErrorSource::Settings,
+            "settings.title.invalid_model_plan",
+            format!("Invalid model plan for title generation: {e}"),
+        )
+    })?;
     let selected_model = select_title_model_role(&raw_plan)?;
     let mut model_role = resolve_runtime_model_role(&state.pool, selected_model).await?;
 

--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -1,10 +1,26 @@
 use std::time::Duration;
 
 use tauri::State;
+use tiycore::provider::get_provider;
+use tiycore::types::{
+    Context as TiyContext, Message as TiyMessage, StreamOptions as TiyStreamOptions, UserMessage,
+};
 
+use crate::core::agent_run_manager::{
+    build_provider_options_payload_hook, normalize_generated_title, truncate_chars,
+    TITLE_CONTEXT_MAX_CHARS, TITLE_GENERATION_MAX_TOKENS, TITLE_GENERATION_MAX_TOKENS_REASONING,
+    TITLE_GENERATION_TIMEOUT,
+};
+use crate::core::agent_session::{
+    normalize_profile_response_language, normalize_profile_response_style,
+    resolve_runtime_model_role, ProfileResponseStyle, RuntimeModelPlan, RuntimeModelRole,
+};
 use crate::core::app_state::AppState;
-use crate::model::errors::AppError;
+use crate::core::tiycode_default_headers;
+use crate::core::tiycode_url_policy;
+use crate::model::errors::{AppError, ErrorSource};
 use crate::model::thread::{AddMessageInput, MessageDto, ThreadSnapshotDto, ThreadSummaryDto};
+use crate::persistence::repo::{message_repo, profile_repo};
 
 #[tauri::command]
 pub async fn thread_list(
@@ -76,4 +92,180 @@ pub async fn thread_add_message(
     input: AddMessageInput,
 ) -> Result<MessageDto, AppError> {
     state.thread_manager.add_message(&thread_id, input).await
+}
+
+#[tauri::command]
+pub async fn thread_regenerate_title(
+    state: State<'_, AppState>,
+    thread_id: String,
+    model_plan: serde_json::Value,
+) -> Result<String, AppError> {
+    let raw_plan: RuntimeModelPlan = serde_json::from_value(model_plan).unwrap_or_default();
+    let selected_model = select_title_model_role(&raw_plan)?;
+    let mut model_role = resolve_runtime_model_role(&state.pool, selected_model).await?;
+
+    // Disable reasoning for lightweight title generation.
+    let was_reasoning = model_role.model.reasoning;
+    model_role.model.reasoning = false;
+
+    // Load the profile to resolve language/style preferences.
+    let profile = match raw_plan.profile_id {
+        Some(ref profile_id) => profile_repo::find_by_id(&state.pool, profile_id).await?,
+        None => None,
+    };
+    let response_language = profile
+        .as_ref()
+        .and_then(|p| normalize_profile_response_language(p.response_language.as_deref()));
+    let response_style = normalize_profile_response_style(
+        profile.as_ref().and_then(|p| p.response_style.as_deref()),
+    );
+
+    // Load the most recent 5 plain messages for context.
+    // `list_recent` returns messages in reverse-chronological order (newest first).
+    // We filter and take 5, then reverse in the prompt to show chronological order.
+    let messages = message_repo::list_recent(&state.pool, &thread_id, None, 10).await?;
+    let relevant: Vec<_> = messages
+        .iter()
+        .filter(|m| {
+            m.message_type == "plain_message" && (m.role == "user" || m.role == "assistant")
+        })
+        .take(5)
+        .collect();
+
+    if relevant.is_empty() {
+        return Err(AppError::recoverable(
+            ErrorSource::Thread,
+            "thread.regenerate_title.no_messages",
+            "No messages available to generate a title from.",
+        ));
+    }
+
+    let prompt =
+        build_regenerate_title_prompt(&relevant, response_language.as_deref(), response_style);
+
+    let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
+        AppError::recoverable(
+            ErrorSource::Settings,
+            "settings.title.provider_missing",
+            format!(
+                "Provider type '{:?}' is not registered for title generation.",
+                model_role.model.provider
+            ),
+        )
+    })?;
+
+    let context = TiyContext {
+        system_prompt: Some(
+            "You write concise conversation titles. Return only the title text.".to_string(),
+        ),
+        messages: vec![TiyMessage::User(UserMessage::text(prompt))],
+        tools: None,
+    };
+
+    let options = TiyStreamOptions {
+        api_key: model_role.api_key.clone(),
+        max_tokens: Some(if was_reasoning {
+            TITLE_GENERATION_MAX_TOKENS_REASONING
+        } else {
+            TITLE_GENERATION_MAX_TOKENS
+        }),
+        headers: Some(tiycode_default_headers()),
+        on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
+        security: Some(tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy())),
+        ..TiyStreamOptions::default()
+    };
+
+    let completion = provider
+        .stream(&model_role.model, &context, options)
+        .try_result(TITLE_GENERATION_TIMEOUT)
+        .await;
+
+    let message = match completion {
+        Some(msg) => msg,
+        None => {
+            return Err(AppError::recoverable(
+                ErrorSource::Thread,
+                "thread.regenerate_title.timeout",
+                "Title generation timed out or returned no result.",
+            ))
+        }
+    };
+
+    if message.stop_reason == tiycore::types::StopReason::Error {
+        return Err(AppError::recoverable(
+            ErrorSource::Thread,
+            "thread.regenerate_title.model_error",
+            "The model returned an error during title generation.",
+        ));
+    }
+
+    let title = normalize_generated_title(&message.text_content()).ok_or_else(|| {
+        AppError::recoverable(
+            ErrorSource::Thread,
+            "thread.regenerate_title.empty",
+            "The model returned an empty or unusable title.",
+        )
+    })?;
+
+    Ok(title)
+}
+
+fn select_title_model_role(raw_plan: &RuntimeModelPlan) -> Result<RuntimeModelRole, AppError> {
+    raw_plan
+        .lightweight
+        .clone()
+        .or_else(|| raw_plan.auxiliary.clone())
+        .or_else(|| raw_plan.primary.clone())
+        .ok_or_else(|| {
+            AppError::recoverable(
+                ErrorSource::Settings,
+                "settings.title.model_missing",
+                "Select an enabled lightweight, auxiliary, or primary model in the current profile before generating a title.",
+            )
+        })
+}
+
+fn build_regenerate_title_prompt(
+    messages: &[&crate::model::thread::MessageRecord],
+    response_language: Option<&str>,
+    response_style: ProfileResponseStyle,
+) -> String {
+    let language_rule = match response_language {
+        Some(language) => format!("- Write the title in {language}."),
+        None => "- Match the conversation language.".to_string(),
+    };
+    let style_rule = match response_style {
+        ProfileResponseStyle::Balanced => {
+            "- Keep the title clear and natural, with enough specificity to scan quickly."
+        }
+        ProfileResponseStyle::Concise => {
+            "- Keep the title especially terse, direct, and low-friction."
+        }
+        ProfileResponseStyle::Guide => {
+            "- Prefer a title that signals the user's goal or decision focus clearly."
+        }
+    };
+
+    let mut conversation = String::new();
+    for msg in messages.iter().rev() {
+        let role_label = if msg.role == "user" {
+            "User"
+        } else {
+            "Assistant"
+        };
+        let content = truncate_chars(msg.content_markdown.trim(), TITLE_CONTEXT_MAX_CHARS);
+        conversation.push_str(&format!("{role_label}:\n{content}\n\n"));
+    }
+
+    format!(
+        "Create a short thread title for this conversation.\n\
+Rules:\n\
+{language_rule}\n\
+{style_rule}\n\
+- Prefer concrete nouns and actions.\n\
+- Max 18 Chinese characters or 7 English words.\n\
+- No quotes, no markdown, no prefixes.\n\
+\n\
+Conversation:\n{conversation}"
+    )
 }

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -41,13 +41,13 @@ use crate::persistence::repo::{
     message_repo, profile_repo, run_repo, thread_repo, tool_call_repo, workspace_repo,
 };
 
-const TITLE_GENERATION_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const TITLE_GENERATION_TIMEOUT: Duration = Duration::from_secs(60);
 const COMPACT_SUMMARY_TIMEOUT: Duration = Duration::from_secs(60);
-const TITLE_GENERATION_MAX_TOKENS: u32 = 512;
-const TITLE_GENERATION_MAX_TOKENS_REASONING: u32 = 2048;
+pub(crate) const TITLE_GENERATION_MAX_TOKENS: u32 = 512;
+pub(crate) const TITLE_GENERATION_MAX_TOKENS_REASONING: u32 = 2048;
 const COMPACT_SUMMARY_MAX_TOKENS: u32 = 4096;
 const COMPACT_SUMMARY_MAX_TOKENS_REASONING: u32 = 8192;
-const TITLE_CONTEXT_MAX_CHARS: usize = 1_200;
+pub(crate) const TITLE_CONTEXT_MAX_CHARS: usize = 1_200;
 const COMPACT_SUMMARY_CONTEXT_MAX_CHARS: usize = 18_000;
 const FRONTEND_EVENT_BUFFER_SIZE: usize = 2048;
 
@@ -2001,7 +2001,7 @@ async fn generate_thread_title(
     Ok(normalize_generated_title(&message.text_content()))
 }
 
-fn build_title_prompt(
+pub(crate) fn build_title_prompt(
     user_message: &str,
     assistant_message: &str,
     response_language: Option<&str>,
@@ -2038,7 +2038,7 @@ Assistant reply:\n{assistant_message}"
     )
 }
 
-fn normalize_generated_title(raw: &str) -> Option<String> {
+pub(crate) fn normalize_generated_title(raw: &str) -> Option<String> {
     let mut title = raw
         .lines()
         .map(str::trim)
@@ -2074,7 +2074,7 @@ fn normalize_generated_title(raw: &str) -> Option<String> {
     Some(truncate_chars(&title, 40))
 }
 
-fn collapse_whitespace(value: &str) -> String {
+pub(crate) fn collapse_whitespace(value: &str) -> String {
     value.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
@@ -2093,7 +2093,7 @@ fn should_complete_reasoning_for_event(event: &ThreadStreamEvent) -> bool {
     )
 }
 
-fn truncate_chars(value: &str, max_chars: usize) -> String {
+pub(crate) fn truncate_chars(value: &str, max_chars: usize) -> String {
     let truncated: String = value.chars().take(max_chars).collect();
     if value.chars().count() > max_chars {
         truncated.trim_end().to_string()
@@ -2102,7 +2102,7 @@ fn truncate_chars(value: &str, max_chars: usize) -> String {
     }
 }
 
-fn build_provider_options_payload_hook(
+pub(crate) fn build_provider_options_payload_hook(
     provider_options: Option<serde_json::Value>,
 ) -> Option<OnPayloadFn> {
     let provider_options = provider_options?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -294,6 +294,7 @@ pub fn run() {
             commands::thread::thread_create,
             commands::thread::thread_load,
             commands::thread::thread_update_title,
+            commands::thread::thread_regenerate_title,
             commands::thread::thread_delete,
             commands::thread::thread_add_message,
             // Agent Run

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -231,6 +231,9 @@ const en: Record<TranslationKey, string> = {
   "sidebar.showMore": "Show more",
   "sidebar.delete": "Delete",
   "sidebar.deleting": "Deleting",
+  "sidebar.regenerateTitle": "AI Generate",
+  "sidebar.regenerateTitleFailed": "Failed to generate title",
+  "sidebar.noLiteModel": "Configure a lightweight model first",
 
   // ── New Thread Empty State ─────────────────────────────────
   "newThread.headline": "Whenever you need, Tiy is here.",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -233,6 +233,7 @@ const en: Record<TranslationKey, string> = {
   "sidebar.deleting": "Deleting",
   "sidebar.regenerateTitle": "AI Generate",
   "sidebar.regenerateTitleFailed": "Failed to generate title",
+"sidebar.renameThread": "Rename thread",
   "sidebar.noLiteModel": "Configure a lightweight model first",
 
   // ── New Thread Empty State ─────────────────────────────────

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -231,6 +231,9 @@ const zhCN = {
   "sidebar.showMore": "显示更多",
   "sidebar.delete": "删除",
   "sidebar.deleting": "正在删除",
+  "sidebar.regenerateTitle": "智能生成",
+  "sidebar.regenerateTitleFailed": "标题生成失败",
+  "sidebar.noLiteModel": "请先配置轻量模型",
 
   // ── New Thread Empty State ─────────────────────────────────
   "newThread.headline": "一切所需，聊聊即达。",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -233,6 +233,7 @@ const zhCN = {
   "sidebar.deleting": "正在删除",
   "sidebar.regenerateTitle": "智能生成",
   "sidebar.regenerateTitleFailed": "标题生成失败",
+"sidebar.renameThread": "重命名对话",
   "sidebar.noLiteModel": "请先配置轻量模型",
 
   // ── New Thread Empty State ─────────────────────────────────

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -49,6 +49,7 @@ import type {
   GitSnapshotDto,
   MessageAttachmentDto,
   RunMode,
+  RunModelPlanDto,
   ThreadSummaryDto,
   WorkspaceDto,
 } from "@/shared/types/api";
@@ -364,6 +365,130 @@ type PendingThreadRun = {
   threadId: string;
 };
 
+// ---------------------------------------------------------------------------
+// ThreadRenameInput — isolated component for inline thread title editing.
+// Keeps per-keystroke state local to avoid re-rendering the entire dashboard.
+// ---------------------------------------------------------------------------
+
+function ThreadRenameInput({
+  threadId,
+  initialName,
+  isActive,
+  status,
+  modelPlan,
+  onDone,
+}: {
+  threadId: string;
+  initialName: string;
+  isActive: boolean;
+  status: import("@/modules/workbench-shell/model/types").ThreadStatus;
+  modelPlan: RunModelPlanDto | null;
+  onDone: (newTitle: string | null) => void;
+}) {
+  const t = useT();
+  const [value, setValue] = useState(initialName);
+  const [isRegenerating, setRegenerating] = useState(false);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // After regeneration completes, re-focus the input so the user
+  // is not left in a stuck editing state without a focused input.
+  const refocusAfterRegenerate = useCallback(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const save = useCallback(() => {
+    const trimmed = value.trim();
+    onDone(trimmed || null);
+  }, [value, onDone]);
+
+  const cancel = useCallback(() => {
+    onDone(null);
+  }, [onDone]);
+
+  const handleRegenerate = useCallback(() => {
+    if (!modelPlan || isRegenerating) return;
+    setRegenerating(true);
+    void threadRegenerateTitle(threadId, modelPlan)
+      .then((title) => {
+        setValue(title);
+      })
+      .catch((error) => {
+        const message = getInvokeErrorMessage(error, "Failed to regenerate title");
+        console.warn("[thread] failed to regenerate title:", message);
+      })
+      .finally(() => {
+        setRegenerating(false);
+        refocusAfterRegenerate();
+      });
+  }, [threadId, modelPlan, isRegenerating, refocusAfterRegenerate]);
+
+  return (
+    <div
+      className={cn(
+        `${DRAWER_LIST_ROW_CLASS} border pr-1.5`,
+        isActive
+          ? "border-app-border-strong bg-app-surface-active text-app-foreground"
+          : "border-transparent bg-transparent text-app-muted",
+      )}
+    >
+      <div className="flex min-w-0 flex-1 items-center gap-1">
+        <ThreadStatusIndicator
+          status={status}
+          emphasis={isActive ? "default" : "subtle"}
+        />
+        <input
+          ref={inputRef}
+          autoFocus
+          className="min-w-0 flex-1 truncate border-none bg-transparent text-[13px] leading-tight text-app-foreground outline-none placeholder:text-app-muted"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              save();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancel();
+            }
+          }}
+          onBlur={(e) => {
+            // Ignore blur when clicking the regenerate button
+            // or while regeneration is in progress.
+            if (isRegenerating) return;
+            const related = e.relatedTarget as HTMLElement | null;
+            if (related?.dataset.threadRegenerateBtn === "true") return;
+            save();
+          }}
+          onFocus={(e) => e.target.select()}
+        />
+        <button
+          type="button"
+          data-thread-regenerate-btn="true"
+          title={
+            modelPlan
+              ? t("sidebar.regenerateTitle")
+              : t("sidebar.noLiteModel")
+          }
+          disabled={!modelPlan || isRegenerating}
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-app-subtle transition-colors hover:bg-app-surface-hover hover:text-app-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={(e) => {
+            e.stopPropagation();
+            handleRegenerate();
+          }}
+        >
+          <Sparkles
+            className={cn(
+              "size-3.5",
+              isRegenerating && "animate-spin",
+            )}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function DashboardWorkbench() {
   const { data } = useSystemMetadata();
   const { theme, setTheme } = useTheme();
@@ -537,8 +662,6 @@ export function DashboardWorkbench() {
   >(null);
   const [deletingThreadId, setDeletingThreadId] = useState<string | null>(null);
   const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
-  const [editingThreadValue, setEditingThreadValue] = useState("");
-  const [isRegeneratingTitle, setRegeneratingTitle] = useState(false);
   const [isAddingWorkspace, setAddingWorkspace] = useState(false);
   const [activeWorkspaceMenuId, setActiveWorkspaceMenuId] = useState<
     string | null
@@ -1952,26 +2075,19 @@ export function DashboardWorkbench() {
   );
 
   const handleThreadEditStart = useCallback(
-    (threadId: string, currentName: string) => {
+    (threadId: string) => {
       setEditingThreadId(threadId);
       editingThreadIdRef.current = threadId;
-      setEditingThreadValue(currentName);
     },
     [],
   );
 
-  const handleThreadEditCancel = useCallback(() => {
-    setEditingThreadId(null);
-    editingThreadIdRef.current = null;
-    setEditingThreadValue("");
-  }, []);
+  const handleThreadEditDone = useCallback(
+    (threadId: string, newTitle: string | null, originalName: string) => {
+      setEditingThreadId(null);
+      editingThreadIdRef.current = null;
 
-  const handleThreadEditSave = useCallback(
-    (threadId: string, originalName: string) => {
-      const trimmed = editingThreadValue.trim();
-
-      if (!trimmed || trimmed === originalName) {
-        handleThreadEditCancel();
+      if (!newTitle || newTitle === originalName) {
         return;
       }
 
@@ -1980,14 +2096,14 @@ export function DashboardWorkbench() {
           ...workspace,
           threads: workspace.threads.map((thread) =>
             thread.id === threadId
-              ? { ...thread, name: trimmed }
+              ? { ...thread, name: newTitle }
               : thread,
           ),
         })),
       );
 
       if (isTauri()) {
-        void threadUpdateTitle(threadId, trimmed).catch((error) => {
+        void threadUpdateTitle(threadId, newTitle).catch((error) => {
           console.warn("[thread] failed to update title:", error);
           // Rollback: restore the original name on failure.
           setWorkspaces((current) =>
@@ -2002,33 +2118,8 @@ export function DashboardWorkbench() {
           );
         });
       }
-
-      handleThreadEditCancel();
     },
-    [editingThreadValue, handleThreadEditCancel],
-  );
-
-  const handleThreadRegenerateTitle = useCallback(
-    (threadId: string) => {
-      if (!commitMessageModelPlan || isRegeneratingTitle) {
-        return;
-      }
-
-      setRegeneratingTitle(true);
-
-      void threadRegenerateTitle(threadId, commitMessageModelPlan)
-        .then((title) => {
-          setEditingThreadValue(title);
-        })
-        .catch((error) => {
-          const message = getInvokeErrorMessage(error, "Failed to regenerate title");
-          console.warn("[thread] failed to regenerate title:", message);
-        })
-        .finally(() => {
-          setRegeneratingTitle(false);
-        });
-    },
-    [commitMessageModelPlan, isRegeneratingTitle],
+    [],
   );
 
   const handleThreadDeleteRequest = useCallback((threadId: string) => {
@@ -2958,92 +3049,20 @@ export function DashboardWorkbench() {
                             return (
                               <div key={thread.id} className="group relative">
                                 {isEditing ? (
-                                  <div
-                                    className={cn(
-                                      `${DRAWER_LIST_ROW_CLASS} border pr-1.5`,
-                                      thread.active
-                                        ? "border-app-border-strong bg-app-surface-active text-app-foreground"
-                                        : "border-transparent bg-transparent text-app-muted",
-                                    )}
-                                  >
-                                    <div className="flex min-w-0 flex-1 items-center gap-1">
-                                      <ThreadStatusIndicator
-                                        status={thread.status}
-                                        emphasis={
-                                          thread.active ? "default" : "subtle"
-                                        }
-                                      />
-                                      <input
-                                        autoFocus
-                                        className="min-w-0 flex-1 truncate border-none bg-transparent text-[13px] leading-tight text-app-foreground outline-none placeholder:text-app-muted"
-                                        value={editingThreadValue}
-                                        onChange={(e) =>
-                                          setEditingThreadValue(e.target.value)
-                                        }
-                                        onKeyDown={(e) => {
-                                          if (e.key === "Enter") {
-                                            e.preventDefault();
-                                            handleThreadEditSave(
-                                              thread.id,
-                                              thread.name,
-                                            );
-                                          } else if (e.key === "Escape") {
-                                            e.preventDefault();
-                                            handleThreadEditCancel();
-                                          }
-                                        }}
-                                        onBlur={(e) => {
-                                          // Ignore blur when clicking the regenerate button
-                                          // or while regeneration is in progress.
-                                          if (isRegeneratingTitle) {
-                                            return;
-                                          }
-                                          const related =
-                                            e.relatedTarget as HTMLElement | null;
-                                          if (
-                                            related?.dataset
-                                              .threadRegenerateBtn === "true"
-                                          ) {
-                                            return;
-                                          }
-                                          handleThreadEditSave(
-                                            thread.id,
-                                            thread.name,
-                                          );
-                                        }}
-                                        onFocus={(e) => e.target.select()}
-                                      />
-                                      <button
-                                        type="button"
-                                        data-thread-regenerate-btn="true"
-                                        title={
-                                          commitMessageModelPlan
-                                            ? t("sidebar.regenerateTitle")
-                                            : t("sidebar.noLiteModel")
-                                        }
-                                        disabled={
-                                          !commitMessageModelPlan ||
-                                          isRegeneratingTitle
-                                        }
-                                        className="flex size-6 shrink-0 items-center justify-center rounded-md text-app-subtle transition-colors hover:bg-app-surface-hover hover:text-app-foreground disabled:cursor-not-allowed disabled:opacity-40"
-                                        onMouseDown={(e) => e.preventDefault()}
-                                        onClick={(e) => {
-                                          e.stopPropagation();
-                                          handleThreadRegenerateTitle(
-                                            thread.id,
-                                          );
-                                        }}
-                                      >
-                                        <Sparkles
-                                          className={cn(
-                                            "size-3.5",
-                                            isRegeneratingTitle &&
-                                              "animate-spin",
-                                          )}
-                                        />
-                                      </button>
-                                    </div>
-                                  </div>
+                                  <ThreadRenameInput
+                                    threadId={thread.id}
+                                    initialName={thread.name}
+                                    isActive={thread.active}
+                                    status={thread.status}
+                                    modelPlan={commitMessageModelPlan}
+                                    onDone={(newTitle) =>
+                                      handleThreadEditDone(
+                                        thread.id,
+                                        newTitle,
+                                        thread.name,
+                                      )
+                                    }
+                                  />
                                 ) : (
                                 <button
                                   type="button"
@@ -3056,10 +3075,7 @@ export function DashboardWorkbench() {
                                   onClick={() => handleThreadSelect(thread.id)}
                                   onDoubleClick={(e) => {
                                     e.stopPropagation();
-                                    handleThreadEditStart(
-                                      thread.id,
-                                      thread.name,
-                                    );
+                                    handleThreadEditStart(thread.id);
                                   }}
                                 >
                                   <div className="flex items-center gap-2">

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -18,6 +18,7 @@ import {
   LoaderCircle,
   MessageSquarePlus,
   MoreHorizontal,
+  Sparkles,
   Trash2,
 } from "lucide-react";
 import {
@@ -57,6 +58,8 @@ import {
   threadCreate,
   threadDelete,
   threadList,
+  threadUpdateTitle,
+  threadRegenerateTitle,
   workspaceAdd,
   workspaceEnsureDefault,
   workspaceList,
@@ -533,6 +536,9 @@ export function DashboardWorkbench() {
     string | null
   >(null);
   const [deletingThreadId, setDeletingThreadId] = useState<string | null>(null);
+  const [editingThreadId, setEditingThreadId] = useState<string | null>(null);
+  const [editingThreadValue, setEditingThreadValue] = useState("");
+  const [isRegeneratingTitle, setRegeneratingTitle] = useState(false);
   const [isAddingWorkspace, setAddingWorkspace] = useState(false);
   const [activeWorkspaceMenuId, setActiveWorkspaceMenuId] = useState<
     string | null
@@ -587,6 +593,7 @@ export function DashboardWorkbench() {
   const userMenuRef = useRef<HTMLDivElement | null>(null);
   const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
   const syncVersionRef = useRef(0);
+  const editingThreadIdRef = useRef<string | null>(null);
   const sidebarAutoRefreshUntilRef = useRef(0);
   const sidebarSyncInFlightRef = useRef(false);
   const workspaceThreadDisplayCountsRef = useRef<Record<string, number>>(
@@ -1172,6 +1179,11 @@ export function DashboardWorkbench() {
           const trimmedTitle = title.trim();
 
           if (!trimmedTitle) {
+            return;
+          }
+
+          // Skip update for the thread currently being edited inline.
+          if (editingThreadIdRef.current === threadId) {
             return;
           }
 
@@ -1937,6 +1949,75 @@ export function DashboardWorkbench() {
       }));
     },
     [],
+  );
+
+  const handleThreadEditStart = useCallback(
+    (threadId: string, currentName: string) => {
+      setEditingThreadId(threadId);
+      editingThreadIdRef.current = threadId;
+      setEditingThreadValue(currentName);
+    },
+    [],
+  );
+
+  const handleThreadEditCancel = useCallback(() => {
+    setEditingThreadId(null);
+    editingThreadIdRef.current = null;
+    setEditingThreadValue("");
+  }, []);
+
+  const handleThreadEditSave = useCallback(
+    (threadId: string, originalName: string) => {
+      const trimmed = editingThreadValue.trim();
+
+      if (!trimmed || trimmed === originalName) {
+        handleThreadEditCancel();
+        return;
+      }
+
+      setWorkspaces((current) =>
+        current.map((workspace) => ({
+          ...workspace,
+          threads: workspace.threads.map((thread) =>
+            thread.id === threadId
+              ? { ...thread, name: trimmed }
+              : thread,
+          ),
+        })),
+      );
+
+      if (isTauri()) {
+        void threadUpdateTitle(threadId, trimmed).catch((error) => {
+          console.warn("[thread] failed to update title:", error);
+        });
+      }
+
+      handleThreadEditCancel();
+    },
+    [editingThreadValue, handleThreadEditCancel],
+  );
+
+  const handleThreadRegenerateTitle = useCallback(
+    (threadId: string) => {
+      if (!commitMessageModelPlan || isRegeneratingTitle) {
+        return;
+      }
+
+      setRegeneratingTitle(true);
+
+      void threadRegenerateTitle(threadId, commitMessageModelPlan)
+        .then((title) => {
+          setEditingThreadValue(title);
+        })
+        .catch((error) => {
+          const message = getInvokeErrorMessage(error, "Failed to regenerate title");
+          console.warn("[thread] failed to regenerate title:", message);
+        })
+        .finally(() => {
+          setRegeneratingTitle(false);
+        });
+    },
+    [commitMessageModelPlan, isRegeneratingTitle],
   );
 
   const handleThreadDeleteRequest = useCallback((threadId: string) => {
@@ -2861,9 +2942,98 @@ export function DashboardWorkbench() {
                             const isDeletePending =
                               pendingDeleteThreadId === thread.id;
                             const isDeleting = deletingThreadId === thread.id;
+                            const isEditing = editingThreadId === thread.id;
 
                             return (
                               <div key={thread.id} className="group relative">
+                                {isEditing ? (
+                                  <div
+                                    className={cn(
+                                      `${DRAWER_LIST_ROW_CLASS} border pr-1.5`,
+                                      thread.active
+                                        ? "border-app-border-strong bg-app-surface-active text-app-foreground"
+                                        : "border-transparent bg-transparent text-app-muted",
+                                    )}
+                                  >
+                                    <div className="flex min-w-0 flex-1 items-center gap-1">
+                                      <ThreadStatusIndicator
+                                        status={thread.status}
+                                        emphasis={
+                                          thread.active ? "default" : "subtle"
+                                        }
+                                      />
+                                      <input
+                                        autoFocus
+                                        className="min-w-0 flex-1 truncate border-none bg-transparent text-[13px] leading-tight text-app-foreground outline-none placeholder:text-app-muted"
+                                        value={editingThreadValue}
+                                        onChange={(e) =>
+                                          setEditingThreadValue(e.target.value)
+                                        }
+                                        onKeyDown={(e) => {
+                                          if (e.key === "Enter") {
+                                            e.preventDefault();
+                                            handleThreadEditSave(
+                                              thread.id,
+                                              thread.name,
+                                            );
+                                          } else if (e.key === "Escape") {
+                                            e.preventDefault();
+                                            handleThreadEditCancel();
+                                          }
+                                        }}
+                                        onBlur={(e) => {
+                                          // Ignore blur when clicking the regenerate button
+                                          // or while regeneration is in progress.
+                                          if (isRegeneratingTitle) {
+                                            return;
+                                          }
+                                          const related =
+                                            e.relatedTarget as HTMLElement | null;
+                                          if (
+                                            related?.dataset
+                                              .threadRegenerateBtn === "true"
+                                          ) {
+                                            return;
+                                          }
+                                          handleThreadEditSave(
+                                            thread.id,
+                                            thread.name,
+                                          );
+                                        }}
+                                        onFocus={(e) => e.target.select()}
+                                      />
+                                      <button
+                                        type="button"
+                                        data-thread-regenerate-btn="true"
+                                        title={
+                                          commitMessageModelPlan
+                                            ? t("sidebar.regenerateTitle")
+                                            : t("sidebar.noLiteModel")
+                                        }
+                                        disabled={
+                                          !commitMessageModelPlan ||
+                                          isRegeneratingTitle
+                                        }
+                                        className="flex size-6 shrink-0 items-center justify-center rounded-md text-app-subtle transition-colors hover:bg-app-surface-hover hover:text-app-foreground disabled:cursor-not-allowed disabled:opacity-40"
+                                        onMouseDown={(e) => e.preventDefault()}
+                                        onClick={(e) => {
+                                          e.stopPropagation();
+                                          handleThreadRegenerateTitle(
+                                            thread.id,
+                                          );
+                                        }}
+                                      >
+                                        <Sparkles
+                                          className={cn(
+                                            "size-3.5",
+                                            isRegeneratingTitle &&
+                                              "animate-spin",
+                                          )}
+                                        />
+                                      </button>
+                                    </div>
+                                  </div>
+                                ) : (
                                 <button
                                   type="button"
                                   className={cn(
@@ -2873,6 +3043,13 @@ export function DashboardWorkbench() {
                                       : "border-transparent bg-transparent text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
                                   )}
                                   onClick={() => handleThreadSelect(thread.id)}
+                                  onDoubleClick={(e) => {
+                                    e.stopPropagation();
+                                    handleThreadEditStart(
+                                      thread.id,
+                                      thread.name,
+                                    );
+                                  }}
                                 >
                                   <div className="flex items-center gap-2">
                                     <ThreadStatusIndicator
@@ -2886,6 +3063,9 @@ export function DashboardWorkbench() {
                                     </p>
                                   </div>
                                 </button>
+                                )}
+                                {isEditing ? null : (
+                                <>
                                 <span
                                   className={cn(
                                     "pointer-events-none absolute right-2.5 top-1/2 -translate-y-1/2 text-[11px] text-app-subtle transition-opacity duration-200",
@@ -2931,6 +3111,8 @@ export function DashboardWorkbench() {
                                   >
                                     <Trash2 className="size-4" />
                                   </button>
+                                )}
+                                </>
                                 )}
                               </div>
                             );

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -442,13 +442,14 @@ function ThreadRenameInput({
         <input
           ref={inputRef}
           autoFocus
+          aria-label={t("sidebar.renameThread")}
           className="min-w-0 flex-1 truncate border-none bg-transparent text-[13px] leading-tight text-app-foreground outline-none placeholder:text-app-muted"
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === "Enter") {
               e.preventDefault();
-              save();
+              if (!isRegenerating) save();
             } else if (e.key === "Escape") {
               e.preventDefault();
               cancel();

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -1989,6 +1989,17 @@ export function DashboardWorkbench() {
       if (isTauri()) {
         void threadUpdateTitle(threadId, trimmed).catch((error) => {
           console.warn("[thread] failed to update title:", error);
+          // Rollback: restore the original name on failure.
+          setWorkspaces((current) =>
+            current.map((workspace) => ({
+              ...workspace,
+              threads: workspace.threads.map((thread) =>
+                thread.id === threadId
+                  ? { ...thread, name: originalName }
+                  : thread,
+              ),
+            })),
+          );
         });
       }
 

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -388,6 +388,7 @@ function ThreadRenameInput({
   const t = useT();
   const [value, setValue] = useState(initialName);
   const [isRegenerating, setRegenerating] = useState(false);
+  const [regenError, setRegenError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   // After regeneration completes, re-focus the input so the user
@@ -408,6 +409,7 @@ function ThreadRenameInput({
   const handleRegenerate = useCallback(() => {
     if (!modelPlan || isRegenerating) return;
     setRegenerating(true);
+    setRegenError(null);
     void threadRegenerateTitle(threadId, modelPlan)
       .then((title) => {
         setValue(title);
@@ -415,6 +417,7 @@ function ThreadRenameInput({
       .catch((error) => {
         const message = getInvokeErrorMessage(error, "Failed to regenerate title");
         console.warn("[thread] failed to regenerate title:", message);
+        setRegenError(t("sidebar.regenerateTitleFailed"));
       })
       .finally(() => {
         setRegenerating(false);
@@ -465,9 +468,11 @@ function ThreadRenameInput({
           type="button"
           data-thread-regenerate-btn="true"
           title={
-            modelPlan
-              ? t("sidebar.regenerateTitle")
-              : t("sidebar.noLiteModel")
+            regenError
+              ? regenError
+              : modelPlan
+                ? t("sidebar.regenerateTitle")
+                : t("sidebar.noLiteModel")
           }
           disabled={!modelPlan || isRegenerating}
           className="flex size-6 shrink-0 items-center justify-center rounded-md text-app-subtle transition-colors hover:bg-app-surface-hover hover:text-app-foreground disabled:cursor-not-allowed disabled:opacity-40"
@@ -480,6 +485,7 @@ function ThreadRenameInput({
           <Sparkles
             className={cn(
               "size-3.5",
+              regenError && "text-red-500",
               isRegenerating && "animate-spin",
             )}
           />
@@ -2085,9 +2091,9 @@ export function DashboardWorkbench() {
   const handleThreadEditDone = useCallback(
     (threadId: string, newTitle: string | null, originalName: string) => {
       setEditingThreadId(null);
-      editingThreadIdRef.current = null;
 
       if (!newTitle || newTitle === originalName) {
+        editingThreadIdRef.current = null;
         return;
       }
 
@@ -2103,20 +2109,26 @@ export function DashboardWorkbench() {
       );
 
       if (isTauri()) {
-        void threadUpdateTitle(threadId, newTitle).catch((error) => {
-          console.warn("[thread] failed to update title:", error);
-          // Rollback: restore the original name on failure.
-          setWorkspaces((current) =>
-            current.map((workspace) => ({
-              ...workspace,
-              threads: workspace.threads.map((thread) =>
-                thread.id === threadId
-                  ? { ...thread, name: originalName }
-                  : thread,
-              ),
-            })),
-          );
-        });
+        void threadUpdateTitle(threadId, newTitle)
+          .catch((error) => {
+            console.warn("[thread] failed to update title:", error);
+            // Rollback: restore the original name on failure.
+            setWorkspaces((current) =>
+              current.map((workspace) => ({
+                ...workspace,
+                threads: workspace.threads.map((thread) =>
+                  thread.id === threadId
+                    ? { ...thread, name: originalName }
+                    : thread,
+                ),
+              })),
+            );
+          })
+          .finally(() => {
+            editingThreadIdRef.current = null;
+          });
+      } else {
+        editingThreadIdRef.current = null;
       }
     },
     [],

--- a/src/services/bridge/thread-commands.ts
+++ b/src/services/bridge/thread-commands.ts
@@ -4,6 +4,7 @@ import type {
   ThreadSnapshotDto,
   MessageDto,
   AddMessageInput,
+  RunModelPlanDto,
 } from "@/shared/types/api";
 
 const requireTauri = (cmd: string) => {
@@ -66,4 +67,12 @@ export async function threadAddMessage(
 ): Promise<MessageDto> {
   requireTauri("thread_add_message");
   return invoke<MessageDto>("thread_add_message", { threadId, input });
+}
+
+export async function threadRegenerateTitle(
+  threadId: string,
+  modelPlan: RunModelPlanDto,
+): Promise<string> {
+  requireTauri("thread_regenerate_title");
+  return invoke<string>("thread_regenerate_title", { threadId, modelPlan });
 }


### PR DESCRIPTION
## Summary
- Support double-clicking thread titles in the sidebar to enter inline edit mode
- Add Sparkles (✨) button for AI-powered title regeneration using the lightweight model
- New Rust command `thread_regenerate_title` takes the most recent 5 messages as context

## Test Plan
- [ ] Double-click thread title → inline input appears, auto-focused with text selected
- [ ] Edit text + Enter → title saved and persisted
- [ ] Press Escape → cancel editing, restore original title
- [ ] Click outside (blur) → save current value
- [ ] Click Sparkles → loading animation → generated title fills input (not auto-saved)
- [ ] Sparkles disabled when no lightweight model configured (tooltip shown)
- [ ] External `thread-title-updated` events skipped for the thread being edited
- [ ] Empty title not allowed to save
- [ ] `cargo check` ✅ `npm run typecheck` ✅ `npm run test:unit` ✅

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)