### PR TITLE
feat(ui): ✨ add worktree status indicator and bump tiycore to 0.1.9-rc.0

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6121,9 +6121,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.7"
+version = "0.1.9-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715650f7b19213b381a1acaf6424dcdd262bfe035def69e5fcb600be24fb402b"
+checksum = "c2787c7c341544686abad8e82b055c532c23b02e42bd4898c54f6b0b70d3f268"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.7"
+tiycore = "0.1.9-rc.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src/modules/settings-center/ui/settings-center-overlay.tsx
+++ b/src/modules/settings-center/ui/settings-center-overlay.tsx
@@ -29,6 +29,7 @@ import {
   Server,
   Settings2,
   ShieldCheck,
+  Shuffle,
   Star,
   TerminalSquare,
   Trash2,
@@ -3367,7 +3368,7 @@ function WorkspaceSettingsPanel({
                 className="group flex items-center gap-3 px-4 py-3 transition-colors"
               >
                 <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-app-surface-muted text-app-subtle">
-                  <FolderOpen className="size-4" />
+                  {workspace.autoWorkTree ? <Shuffle className="size-4" /> : <FolderOpen className="size-4" />}
                 </div>
 
                 <div className="min-w-0 flex-1">
@@ -3383,6 +3384,12 @@ function WorkspaceSettingsPanel({
                       <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
                         <GitBranch className="size-2.5" />
                         Git
+                      </span>
+                    ) : null}
+                    {workspace.autoWorkTree ? (
+                      <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
+                        <Shuffle className="size-2.5" />
+                        Worktree
                       </span>
                     ) : null}
                   </div>


### PR DESCRIPTION
## Summary
- Add worktree status indicator (Shuffle icon + "Worktree" badge) to workspace list items in settings center
- Bump tiycore dependency from 0.1.7 to 0.1.9-rc.0

## Test Plan
- [ ] Verify worktree badge appears only for workspaces with `autoWorkTree` enabled
- [ ] Verify non-worktree workspaces still show FolderOpen icon
- [ ] Confirm `cargo build` succeeds with new tiycore version

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)