### PR TITLE
feat(policy): ✨ Allow shell in plan mode via approval policy with read-only constraint

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -1585,6 +1585,22 @@ You may call this tool multiple times in a run to incrementally refine the plan.
     ];
     tools.extend(runtime_orchestration_tools());
 
+    // Shell is available in both profiles (plan mode applies read-only constraints via prompt).
+    tools.push(AgentTool::new(
+        "shell",
+        "Run Command",
+        "Run a non-interactive shell command inside the current workspace.",
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "command": { "type": "string" },
+                "cwd": { "type": "string" },
+                "timeout": { "type": "number" }
+            },
+            "required": ["command"]
+        }),
+    ));
+
     if profile_name == DEFAULT_FULL_TOOL_PROFILE {
         tools.push(AgentTool::new(
             "edit",
@@ -1624,20 +1640,6 @@ You may call this tool multiple times in a run to incrementally refine the plan.
                     "content": { "type": "string" }
                 },
                 "required": ["path", "content"]
-            }),
-        ));
-        tools.push(AgentTool::new(
-            "shell",
-            "Run Command",
-            "Run a non-interactive shell command inside the current workspace.",
-            serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "command": { "type": "string" },
-                    "cwd": { "type": "string" },
-                    "timeout": { "type": "number" }
-                },
-                "required": ["command"]
             }),
         ));
         tools.push(AgentTool::new(
@@ -3097,10 +3099,13 @@ mod tests {
     }
 
     #[test]
-    fn plan_read_only_profile_does_not_expose_mutating_terminal_tools() {
+    fn plan_read_only_profile_includes_shell_excludes_mutating_terminal_tools() {
         let tools = runtime_tools_for_profile(PLAN_READ_ONLY_TOOL_PROFILE);
         let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name.as_str()).collect();
 
+        // Shell is available in plan mode (follows normal approval policy).
+        assert!(tool_names.contains(&"shell"));
+        // Write-oriented terminal tools are excluded.
         assert!(!tool_names.contains(&"term_write"));
         assert!(!tool_names.contains(&"term_restart"));
         assert!(!tool_names.contains(&"term_close"));

--- a/src-tauri/src/core/policy_engine.rs
+++ b/src-tauri/src/core/policy_engine.rs
@@ -4,7 +4,7 @@
 //! 1. Built-in dangerous pattern hard deny
 //! 2. User deny list
 //! 3. Workspace boundary check
-//! 4. Run mode restrictions (plan mode blocks mutations)
+//! 4. Run mode restrictions (plan mode blocks hard-deny mutations; shell follows normal approval)
 //! 5. User allow list
 //! 6. Approval policy fallback
 
@@ -48,6 +48,27 @@ const MUTATING_TOOLS: &[&str] = &[
     "edit",
     "patch",
     "shell",
+    "git_add",
+    "git_stage",
+    "git_unstage",
+    "git_commit",
+    "git_push",
+    "git_pull",
+    "git_fetch",
+    "term_write",
+    "term_restart",
+    "term_close",
+    "market_install",
+];
+
+/// Tools that are hard-denied in plan mode.
+/// Shell is intentionally excluded — it follows the normal approval policy so that
+/// read-only commands (git log, npm ls, command -v, skill CLIs, etc.) remain
+/// available for information gathering in plan mode.
+const PLAN_HARD_DENY_TOOLS: &[&str] = &[
+    "write",
+    "edit",
+    "patch",
     "git_add",
     "git_stage",
     "git_unstage",
@@ -207,8 +228,9 @@ impl PolicyEngine {
             }
         }
 
-        // 4. Run mode restriction (plan mode blocks mutations)
-        if run_mode == "plan" && MUTATING_TOOLS.contains(&tool_name) {
+        // 4. Run mode restriction (plan mode blocks hard-deny mutations;
+        //    shell is excluded so it falls through to the normal approval policy)
+        if run_mode == "plan" && PLAN_HARD_DENY_TOOLS.contains(&tool_name) {
             checked.push("plan_mode_restriction".to_string());
             return Ok(PolicyCheck {
                 tool_name: tool_name.to_string(),

--- a/src-tauri/src/core/prompt/providers.rs
+++ b/src-tauri/src/core/prompt/providers.rs
@@ -304,7 +304,7 @@ async fn build_sandbox_permissions_body(
         .unwrap_or_else(|| merge_writable_roots(&[]));
 
     let run_mode_line = if run_mode == "plan" {
-        "Plan mode is active, so mutating tools are blocked."
+        "Plan mode is active, so mutating tools are blocked; shell follows the configured approval policy and must be used only for read-only commands."
     } else {
         "Default mode is active, so tool use follows the configured approval policy."
     };
@@ -485,9 +485,10 @@ Your sole objective is to produce a concrete, evidence-based implementation plan
 \n\
 ## Available tools\n\
 Read-only tools: read, list, search, find, term_status, term_output, agent_explore.\n\
+Shell tool: shell — use ONLY for read-only commands (e.g. git log, npm ls, command -v, skill CLIs for information gathering). Never use shell to create, modify, or delete files or to run system-changing commands.\n\
 Planning tools: clarify, update_plan.\n\
 {TERM_PANEL_USAGE_NOTE}\n\
-Do NOT use edit, write, shell, or any mutating tool unless the user explicitly requests execution.\n\
+Do NOT use edit, write, or any mutating tool unless the user explicitly requests execution.\n\
 \n\
 ## Workflow — follow these phases in order\n\
 \n\

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -409,8 +409,8 @@ async fn test_policy_allow_list_pattern_must_match() {
 // =========================================================================
 
 #[test]
-fn test_plan_mode_blocks_mutating_tools() {
-    let mutating_tools = vec![
+fn test_plan_mode_blocks_hard_deny_tools() {
+    let hard_deny_tools = vec![
         "write",
         "patch",
         "git_add",
@@ -425,9 +425,9 @@ fn test_plan_mode_blocks_mutating_tools() {
     ];
 
     let run_mode = "plan";
-    for tool in &mutating_tools {
-        let should_block = run_mode == "plan" && mutating_tools.contains(tool);
-        assert!(should_block, "Plan mode should block mutating tool: {tool}");
+    for tool in &hard_deny_tools {
+        let should_block = run_mode == "plan" && hard_deny_tools.contains(tool);
+        assert!(should_block, "Plan mode should hard-deny tool: {tool}");
     }
 }
 
@@ -442,7 +442,7 @@ fn test_plan_mode_allows_read_tools() {
         "git_log",
     ];
 
-    let mutating_tools = vec![
+    let hard_deny_tools = vec![
         "write",
         "patch",
         "git_add",
@@ -457,12 +457,12 @@ fn test_plan_mode_allows_read_tools() {
     ];
 
     for tool in &read_only_tools {
-        let blocked = mutating_tools.contains(tool);
+        let blocked = hard_deny_tools.contains(tool);
         assert!(!blocked, "Plan mode should allow read-only tool: {tool}");
     }
 
     // Shell is not in the hard-deny list; it follows the normal approval policy.
-    let blocked = mutating_tools.contains(&"shell");
+    let blocked = hard_deny_tools.contains(&"shell");
     assert!(
         !blocked,
         "Shell should follow normal approval policy in plan mode, not be hard-denied"

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -413,7 +413,6 @@ fn test_plan_mode_blocks_mutating_tools() {
     let mutating_tools = vec![
         "write",
         "patch",
-        "shell",
         "git_add",
         "git_stage",
         "git_unstage",
@@ -446,7 +445,6 @@ fn test_plan_mode_allows_read_tools() {
     let mutating_tools = vec![
         "write",
         "patch",
-        "shell",
         "git_add",
         "git_stage",
         "git_unstage",
@@ -462,6 +460,45 @@ fn test_plan_mode_allows_read_tools() {
         let blocked = mutating_tools.contains(tool);
         assert!(!blocked, "Plan mode should allow read-only tool: {tool}");
     }
+
+    // Shell is not in the hard-deny list; it follows the normal approval policy.
+    let blocked = mutating_tools.contains(&"shell");
+    assert!(!blocked, "Shell should follow normal approval policy in plan mode, not be hard-denied");
+}
+
+// =========================================================================
+// T1.6.2b — Shell in plan mode follows normal approval policy (not hard-denied)
+// =========================================================================
+
+#[tokio::test]
+async fn test_plan_mode_shell_follows_approval_policy() {
+    let pool = test_helpers::setup_test_pool().await;
+    let engine = PolicyEngine::new(pool);
+
+    // shell in plan mode should NOT be hard-denied; it falls through to the
+    // normal approval policy.  With default settings (no allow/deny rules),
+    // a non-dangerous command should require approval.
+    let result = engine
+        .evaluate(
+            "shell",
+            &json!({ "command": "git log --oneline -5" }),
+            None,
+            &[],
+            "plan",
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        !matches!(result.verdict, PolicyVerdict::Deny { .. }),
+        "shell in plan mode should not be hard-denied, got: {:?}",
+        result.verdict
+    );
+    assert!(
+        result.checked_rules.contains(&"plan_mode_restriction".to_string()) == false,
+        "shell should not trigger plan_mode_restriction rule"
+    );
 }
 
 // =========================================================================

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -463,7 +463,10 @@ fn test_plan_mode_allows_read_tools() {
 
     // Shell is not in the hard-deny list; it follows the normal approval policy.
     let blocked = mutating_tools.contains(&"shell");
-    assert!(!blocked, "Shell should follow normal approval policy in plan mode, not be hard-denied");
+    assert!(
+        !blocked,
+        "Shell should follow normal approval policy in plan mode, not be hard-denied"
+    );
 }
 
 // =========================================================================
@@ -496,7 +499,10 @@ async fn test_plan_mode_shell_follows_approval_policy() {
         result.verdict
     );
     assert!(
-        result.checked_rules.contains(&"plan_mode_restriction".to_string()) == false,
+        result
+            .checked_rules
+            .contains(&"plan_mode_restriction".to_string())
+            == false,
         "shell should not trigger plan_mode_restriction rule"
     );
 }


### PR DESCRIPTION
## Summary
- Add `shell` tool to `plan_read_only` tool profile so it is available in plan mode
- Shell in plan mode follows the user's configured approval policy instead of being hard-denied
- Prompt constrains shell to read-only commands only (git log, npm ls, command -v, etc.)
- New `PLAN_HARD_DENY_TOOLS` constant excludes shell from plan mode hard-deny

## Changes
- **`agent_session.rs`**: Move shell tool definition out of `DEFAULT_FULL_TOOL_PROFILE`-only block into shared section
- **`policy_engine.rs`**: Add `PLAN_HARD_DENY_TOOLS` (all mutating tools except shell). Plan mode check uses `PLAN_HARD_DENY_TOOLS` instead of `MUTATING_TOOLS`, so shell falls through to normal approval policy
- **`providers.rs`**: Plan mode prompt adds "Shell tool: shell — use ONLY for read-only commands" constraint line; removes shell from "Do NOT use" list
- **`m1_6_tool_gateway.rs`**: Remove shell from `mutating_tools` test vecs; add `test_plan_mode_shell_follows_approval_policy` test
- **`agent_session.rs` tests**: Rename test to `plan_read_only_profile_includes_shell_excludes_mutating_terminal_tools`, add shell presence assertion

## Test Plan
- [x] `cargo test` — all 245 unit tests pass including new `test_plan_mode_shell_follows_approval_policy`
- [x] `test_plan_mode_blocks_mutating_tools` — still blocks write/edit/patch/etc but NOT shell
- [x] `plan_read_only_profile_includes_shell_excludes_mutating_terminal_tools` — shell IS in plan profile
- [x] `npm run typecheck` — passes

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)