### PR TITLE
fix(workbench): 🐛 restore thinking placeholder during reasoning-to-action gaps

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2032,6 +2032,7 @@ function shouldCompleteThinkingPhase(event: ThreadStreamEvent) {
     case "run_interrupted":
     case "run_limit_reached":
     case "run_checkpointed":
+    case "plan_updated":
       return true;
     default:
       return false;
@@ -2564,7 +2565,9 @@ export function RuntimeThreadSurface({
       showThinkingPlaceholder(event.runId);
     });
 
-    stream.onPlan = withActiveStream((_event) => {});
+    stream.onPlan = withActiveStream((event) => {
+      scheduleThinkingPhase(event.runId);
+    });
 
     stream.onReasoning = withActiveStream((event) => {
       clearScheduledThinkingPhase();

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2570,8 +2570,8 @@ export function RuntimeThreadSurface({
     });
 
     stream.onReasoning = withActiveStream((event) => {
-      clearScheduledThinkingPhase();
       setThinkingPlaceholder(null);
+      scheduleThinkingPhase(event.runId);
       const reasoningMessageId = event.messageId ?? `reasoning-${event.runId}`;
       setMessages((current) =>
         appendOrReplaceMessage(


### PR DESCRIPTION
## Summary
- `plan_updated` 事件现在会触发 `scheduleThinkingPhase`，避免 plan 生成期间的空白等待
- `plan_updated` 加入 `shouldCompleteThinkingPhase` 事件列表，确保 plan 内容到达时正确完成思考阶段
- `onReasoning` 回调中将 `clearScheduledThinkingPhase()` 替换为 `scheduleThinkingPhase(event.runId)`，解决 reasoning 结束后到工具/消息事件到达之间的思考占位符缺失问题

## Root Cause
Reasoning 流式事件期间，`onReasoning` 回调执行了 `clearScheduledThinkingPhase()` + `setThinkingPlaceholder(null)`，彻底清除了思考占位符且不安排恢复。当模型结束推理后开始生成大段 tool_input（如 edit/plan），中间无任何事件到达，用户看到一段空白的等待时间。

## Fix Logic
- `scheduleThinkingPhase` 内部已包含 `clearScheduledThinkingPhase()`，功能等价，但额外在 160ms 后重新调度显示思考占位符
- Reasoning 事件密集到达时（~50ms 间隔），计时器不断重置，占位符不出现（reasoning 组件本身在显示）
- Reasoning 停止后计时器到期，思考占位符自动重新显示
- 下一个 `tool_requested`/`message_delta` 等事件通过 `shouldCompleteThinkingPhase` 正常完成思考阶段

## Test Plan
- [x] `npm run typecheck` 通过
- [x] `npm run test:unit` 通过（33/33 tests）
- [ ] 手动测试：触发 plan 生成流程，确认 thinking placeholder 连续显示
- [ ] 手动测试：触发包含大段 edit 的推理流程，确认 reasoning 结束后到工具执行间有思考占位符

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)