### PR TITLE
fix(settings-center): 🐛 show worktree icon and hash tag in workspace list

### DIFF
--- a/src/modules/settings-center/model/types.ts
+++ b/src/modules/settings-center/model/types.ts
@@ -12,6 +12,9 @@ export type WorkspaceEntry = {
   isDefault: boolean;
   isGit: boolean;
   autoWorkTree: boolean;
+  kind?: "standalone" | "repo" | "worktree";
+  parentWorkspaceId?: string | null;
+  worktreeHash?: string | null;
 };
 
 export type ProviderKind = "builtin" | "custom";

--- a/src/modules/settings-center/model/use-settings-controller.ts
+++ b/src/modules/settings-center/model/use-settings-controller.ts
@@ -321,10 +321,13 @@ function mapWorkspaceDto(workspace: WorkspaceDto): WorkspaceEntry {
   return {
     id: workspace.id,
     name: workspace.name,
-    path: workspace.path,
+    path: workspace.canonicalPath || workspace.path,
     isDefault: workspace.isDefault,
     isGit: workspace.isGit,
     autoWorkTree: workspace.autoWorkTree,
+    kind: workspace.kind,
+    parentWorkspaceId: workspace.parentWorkspaceId,
+    worktreeHash: workspace.worktreeName ? workspace.worktreeName.slice(0, 6) : null,
   };
 }
 

--- a/src/modules/settings-center/ui/settings-center-overlay.tsx
+++ b/src/modules/settings-center/ui/settings-center-overlay.tsx
@@ -3279,6 +3279,9 @@ function WorkspaceSettingsPanel({
         isDefault: false,
         isGit: false,
         autoWorkTree: false,
+        kind: "standalone",
+        parentWorkspaceId: null,
+        worktreeHash: null,
       });
       return;
     }
@@ -3298,6 +3301,9 @@ function WorkspaceSettingsPanel({
         isDefault: false,
         isGit: false,
         autoWorkTree: false,
+        kind: "standalone",
+        parentWorkspaceId: null,
+        worktreeHash: null,
       });
     });
   };
@@ -3362,64 +3368,74 @@ function WorkspaceSettingsPanel({
           </div>
         ) : (
           <div className="divide-y divide-app-border">
-            {workspaces.map((workspace) => (
-              <div
-                key={workspace.id}
-                className="group flex items-center gap-3 px-4 py-3 transition-colors"
-              >
-                <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-app-surface-muted text-app-subtle">
-                  {workspace.autoWorkTree ? <Shuffle className="size-4" /> : <FolderOpen className="size-4" />}
-                </div>
+            {workspaces.map((workspace) => {
+              const isWorktreeRow = workspace.kind === "worktree";
+              const worktreeTag = workspace.worktreeHash && workspace.worktreeHash.length > 0
+                ? workspace.worktreeHash
+                : null;
 
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[13px] font-medium text-app-foreground">{workspace.name}</span>
-                    {workspace.isDefault ? (
-                      <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
-                        <Star className="size-2.5 fill-current" />
-                        Default
-                      </span>
-                    ) : null}
-                    {workspace.isGit ? (
-                      <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
-                        <GitBranch className="size-2.5" />
-                        Git
-                      </span>
-                    ) : null}
-                    {workspace.autoWorkTree ? (
-                      <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
-                        <Shuffle className="size-2.5" />
-                        Worktree
-                      </span>
-                    ) : null}
+              return (
+                <div
+                  key={workspace.id}
+                  className="group flex items-center gap-3 px-4 py-3 transition-colors"
+                >
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-app-surface-muted text-app-subtle">
+                    {isWorktreeRow ? <Shuffle className="size-4" /> : <FolderOpen className="size-4" />}
                   </div>
-                  <p className="mt-0.5 truncate text-[12px] text-app-subtle" title={workspace.path}>
-                    {workspace.path}
-                  </p>
-                </div>
 
-                <div className="flex shrink-0 items-center gap-1">
-                  <WorkspaceActionButton
-                    icon={Star}
-                    label="Set as default"
-                    active={workspace.isDefault}
-                    className="invisible group-hover:visible"
-                    onClick={() => onSetDefaultWorkspace(workspace.id)}
-                  />
-                  <WorkspaceActionButton
-                    icon={FolderOpen}
-                    label={activeOpenWorkspaceId === workspace.id ? "Opening folder" : openWorkspaceLabel}
-                    disabled={activeOpenWorkspaceId === workspace.id}
-                    onClick={() => handleOpenWorkspace(workspace)}
-                  />
-                  <WorkspaceActionButton
-                    icon={Trash2}
-                    label="Remove workspace"
-                    onClick={() => onRemoveWorkspace(workspace.id)}
-                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="text-[13px] font-medium text-app-foreground">{workspace.name}</span>
+                      {workspace.isDefault ? (
+                        <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
+                          <Star className="size-2.5 fill-current" />
+                          Default
+                        </span>
+                      ) : null}
+                      {workspace.isGit ? (
+                        <span className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 text-[11px] text-app-muted">
+                          <GitBranch className="size-2.5" />
+                          Git
+                        </span>
+                      ) : null}
+                      {worktreeTag ? (
+                        <span
+                          title={t("worktree.tag.label")}
+                          className="inline-flex items-center gap-1 rounded-md border border-app-border bg-app-surface-muted px-1.5 py-0.5 font-mono text-[11px] text-app-muted"
+                        >
+                          <Shuffle className="size-2.5" />
+                          {worktreeTag}
+                        </span>
+                      ) : null}
+                    </div>
+                    <p className="mt-0.5 truncate text-[12px] text-app-subtle" title={workspace.path}>
+                      {workspace.path}
+                    </p>
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-1">
+                    <WorkspaceActionButton
+                      icon={Star}
+                      label="Set as default"
+                      active={workspace.isDefault}
+                      className="invisible group-hover:visible"
+                      onClick={() => onSetDefaultWorkspace(workspace.id)}
+                    />
+                    <WorkspaceActionButton
+                      icon={FolderOpen}
+                      label={activeOpenWorkspaceId === workspace.id ? "Opening folder" : openWorkspaceLabel}
+                      disabled={activeOpenWorkspaceId === workspace.id}
+                      onClick={() => handleOpenWorkspace(workspace)}
+                    />
+                    <WorkspaceActionButton
+                      icon={Trash2}
+                      label="Remove workspace"
+                      onClick={() => onRemoveWorkspace(workspace.id)}
+                    />
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </SettingsSection>


### PR DESCRIPTION
## Summary
- Settings workspace 列表误用 `autoWorkTree` 判断 worktree 类型，导致 worktree 行不显示统一 Shuffle icon 和 worktree hash tag
- 补回 `WorkspaceEntry` 的 `kind / parentWorkspaceId / worktreeHash` 字段，与 workbench-shell 侧保持一致
- 列表渲染改为基于 `kind === "worktree"` 判定，tag 显示 `worktreeName.slice(0,6)`，与侧栏逻辑对齐
- 修正 `mapWorkspaceDto` 中 path 取值：优先 `canonicalPath`，fallback `workspace.path`

## Test Plan
- [x] `npm run typecheck` 通过
- [ ] 手动验证：Settings → Workspace 页，worktree 类型的 workspace 显示 Shuffle icon + hash tag
- [ ] 非 worktree workspace 仍显示 FolderOpen icon，无 worktree tag

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)