### PR TITLE
fix(search): 🐛 Accept extension aliases as type filter & fix tool error layout

### DIFF
--- a/src-tauri/src/core/local_search.rs
+++ b/src-tauri/src/core/local_search.rs
@@ -827,32 +827,36 @@ fn supported_file_type(
 )> {
     let value = match normalized {
         "rust" | "rs" => ("rust", &["rs"][..], &[][..]),
-        "typescript" | "ts" => ("typescript", &["ts", "tsx", "mts", "cts"][..], &[][..]),
-        "javascript" | "js" => ("javascript", &["js", "jsx", "mjs", "cjs"][..], &[][..]),
+        "typescript" | "ts" | "tsx" | "mts" | "cts" => {
+            ("typescript", &["ts", "tsx", "mts", "cts"][..], &[][..])
+        }
+        "javascript" | "js" | "jsx" | "mjs" | "cjs" => {
+            ("javascript", &["js", "jsx", "mjs", "cjs"][..], &[][..])
+        }
         "python" | "py" => ("python", &["py"][..], &[][..]),
         "go" => ("go", &["go"][..], &[][..]),
         "java" => ("java", &["java"][..], &[][..]),
         "json" => ("json", &["json"][..], &[][..]),
         "yaml" | "yml" => ("yaml", &["yaml", "yml"][..], &[][..]),
         "toml" => ("toml", &["toml"][..], &[][..]),
-        "markdown" | "md" => ("markdown", &["md", "mdx"][..], &[][..]),
-        "css" => ("css", &["css", "scss", "sass", "less"][..], &[][..]),
-        "html" => ("html", &["html", "htm"][..], &[][..]),
+        "markdown" | "md" | "mdx" => ("markdown", &["md", "mdx"][..], &[][..]),
+        "css" | "scss" | "sass" | "less" => ("css", &["css", "scss", "sass", "less"][..], &[][..]),
+        "html" | "htm" => ("html", &["html", "htm"][..], &[][..]),
         "sql" => ("sql", &["sql"][..], &[][..]),
-        "shell" | "sh" | "bash" => (
+        "shell" | "sh" | "bash" | "zsh" | "fish" => (
             "shell",
             &["sh", "bash", "zsh", "fish", "ksh"][..],
             &[".bashrc", ".zshrc"][..],
         ),
         "powershell" | "ps" | "ps1" => ("powershell", &["ps1", "psm1", "psd1"][..], &[][..]),
-        "c" => ("c", &["c", "h"][..], &[][..]),
-        "cpp" | "c++" | "cc" => (
+        "c" | "h" => ("c", &["c", "h"][..], &[][..]),
+        "cpp" | "c++" | "cc" | "cxx" | "hpp" => (
             "cpp",
             &["cc", "cpp", "cxx", "hpp", "hh", "hxx"][..],
             &[][..],
         ),
         "swift" => ("swift", &["swift"][..], &[][..]),
-        "kotlin" | "kt" => ("kotlin", &["kt", "kts"][..], &[][..]),
+        "kotlin" | "kt" | "kts" => ("kotlin", &["kt", "kts"][..], &[][..]),
         "ruby" | "rb" => ("ruby", &["rb"][..], &["Gemfile", "Rakefile"][..]),
         "php" => ("php", &["php"][..], &[][..]),
         "docker" => ("docker", &[][..], &["Dockerfile", "Containerfile"][..]),
@@ -1332,6 +1336,47 @@ mod tests {
             Some(&matcher),
             Path::new("/workspace/src/component.rs"),
         ));
+    }
+
+    #[test]
+    fn file_type_extension_aliases_resolve_to_parent_type() {
+        // tsx/jsx/mdx/scss etc. should be accepted as type filters
+        // and match the same set of extensions as their parent type.
+        for alias in &["tsx", "mts", "cts"] {
+            let matcher = compile_file_type(Some(alias)).unwrap().unwrap();
+            assert!(
+                matches_file_type(Some(&matcher), Path::new("/w/app.ts")),
+                "{alias} should match .ts"
+            );
+            assert!(
+                matches_file_type(Some(&matcher), Path::new("/w/app.tsx")),
+                "{alias} should match .tsx"
+            );
+            assert!(
+                !matches_file_type(Some(&matcher), Path::new("/w/app.js")),
+                "{alias} should not match .js"
+            );
+        }
+
+        for alias in &["jsx", "mjs", "cjs"] {
+            let matcher = compile_file_type(Some(alias)).unwrap().unwrap();
+            assert!(
+                matches_file_type(Some(&matcher), Path::new("/w/app.js")),
+                "{alias} should match .js"
+            );
+            assert!(
+                matches_file_type(Some(&matcher), Path::new("/w/app.jsx")),
+                "{alias} should match .jsx"
+            );
+        }
+
+        let mdx = compile_file_type(Some("mdx")).unwrap().unwrap();
+        assert!(matches_file_type(Some(&mdx), Path::new("/w/readme.md")));
+        assert!(matches_file_type(Some(&mdx), Path::new("/w/doc.mdx")));
+
+        let scss = compile_file_type(Some("scss")).unwrap().unwrap();
+        assert!(matches_file_type(Some(&scss), Path::new("/w/style.css")));
+        assert!(matches_file_type(Some(&scss), Path::new("/w/style.scss")));
     }
 
     #[test]

--- a/src/components/ai-elements/tool.tsx
+++ b/src/components/ai-elements/tool.tsx
@@ -183,51 +183,68 @@ export const ToolOutput = ({
     return null;
   }
 
+  // Avoid rendering the same error text twice as both error block and output.
+  const effectiveOutput =
+    errorText && output && String(output) === String(errorText)
+      ? undefined
+      : output;
+
   const hasCodeBlockOutput =
-    (typeof output === "object" && !isValidElement(output)) ||
-    typeof output === "string";
+    effectiveOutput != null &&
+    ((typeof effectiveOutput === "object" && !isValidElement(effectiveOutput)) ||
+      typeof effectiveOutput === "string");
 
-  let Output = <div>{output as ReactNode}</div>;
+  let Output: ReactNode = null;
 
-  if (typeof output === "object" && !isValidElement(output)) {
-    Output = (
-      <CodeBlock
-        className={errorText ? "border-app-danger/20 bg-app-danger/6" : undefined}
-        code={JSON.stringify(output, null, 2)}
-        contentClassName={codeBlockContentClassName}
-        language="json"
-      />
-    );
-  } else if (typeof output === "string") {
-    Output = (
-      <CodeBlock
-        className={errorText ? "border-app-danger/20 bg-app-danger/6" : undefined}
-        code={output}
-        contentClassName={codeBlockContentClassName}
-        language="json"
-      />
-    );
+  if (effectiveOutput != null) {
+    if (typeof effectiveOutput === "object" && !isValidElement(effectiveOutput)) {
+      Output = (
+        <CodeBlock
+          code={JSON.stringify(effectiveOutput, null, 2)}
+          contentClassName={codeBlockContentClassName}
+          language="json"
+        />
+      );
+    } else if (typeof effectiveOutput === "string") {
+      Output = (
+        <CodeBlock
+          code={effectiveOutput}
+          contentClassName={codeBlockContentClassName}
+          language="json"
+        />
+      );
+    } else {
+      Output = <div>{effectiveOutput as ReactNode}</div>;
+    }
   }
 
   return (
     <div className={cn("space-y-2", className)} {...props}>
-      <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-        {errorText ? resolvedErrorLabel : resolvedLabel}
-      </h4>
-      <div
-        className={cn(
-          "overflow-x-auto text-xs [&_table]:w-full",
-          !hasCodeBlockOutput &&
-            errorText
-            ? "bg-destructive/10 text-destructive"
-            : !hasCodeBlockOutput
-              ? "rounded-md bg-muted/50 text-foreground"
-              : undefined
-        )}
-      >
-        {errorText && <div>{errorText}</div>}
-        {Output}
-      </div>
+      {errorText ? (
+        <>
+          <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+            {resolvedErrorLabel}
+          </h4>
+          <div className="overflow-hidden rounded-md border border-app-danger/20 bg-app-danger/6 px-3 py-2 text-xs text-app-danger">
+            <span className="break-words [overflow-wrap:anywhere]">{errorText}</span>
+          </div>
+        </>
+      ) : null}
+      {Output ? (
+        <>
+          <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+            {resolvedLabel}
+          </h4>
+          <div
+            className={cn(
+              "overflow-x-auto text-xs [&_table]:w-full",
+              !hasCodeBlockOutput ? "rounded-md bg-muted/50 text-foreground" : undefined,
+            )}
+          >
+            {Output}
+          </div>
+        </>
+      ) : null}
     </div>
   );
 };

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -3474,7 +3474,10 @@ export function RuntimeThreadSurface({
           <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
             <div
               className={cn(
-                "flex w-full items-start justify-between gap-3 text-left",
+                "flex w-full text-left",
+                readTool.error
+                  ? "flex-col gap-1"
+                  : "items-start justify-between gap-3",
                 inset ? "pl-0" : undefined,
               )}
             >
@@ -3490,7 +3493,7 @@ export function RuntimeThreadSurface({
                 )}
               </div>
               {readTool.error ? (
-                <span className="shrink-0 truncate text-xs text-app-danger" title={readTool.error}>
+                <span className="line-clamp-1 break-words text-xs text-app-danger" title={readTool.error}>
                   {readTool.error}
                 </span>
               ) : (
@@ -3510,7 +3513,10 @@ export function RuntimeThreadSurface({
           <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
             <div
               className={cn(
-                "flex w-full items-start justify-between gap-3 text-left",
+                "flex w-full text-left",
+                queryTool.error
+                  ? "flex-col gap-1"
+                  : "items-start justify-between gap-3",
                 inset ? "pl-0" : undefined,
               )}
             >
@@ -3529,7 +3535,7 @@ export function RuntimeThreadSurface({
                 ) : null}
               </div>
               {queryTool.error ? (
-                <span className="shrink-0 truncate text-xs text-app-danger" title={queryTool.error}>
+                <span className="line-clamp-1 break-words text-xs text-app-danger" title={queryTool.error}>
                   {queryTool.error}
                 </span>
               ) : (
@@ -3549,7 +3555,10 @@ export function RuntimeThreadSurface({
           <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
             <div
               className={cn(
-                "flex w-full items-start justify-between gap-3 text-left",
+                "flex w-full text-left",
+                listTool.error
+                  ? "flex-col gap-1"
+                  : "items-start justify-between gap-3",
                 inset ? "pl-0" : undefined,
               )}
             >
@@ -3565,7 +3574,7 @@ export function RuntimeThreadSurface({
                 ) : null}
               </div>
               {listTool.error ? (
-                <span className="shrink-0 truncate text-xs text-app-danger" title={listTool.error}>
+                <span className="line-clamp-1 break-words text-xs text-app-danger" title={listTool.error}>
                   {listTool.error}
                 </span>
               ) : (
@@ -3768,7 +3777,7 @@ export function RuntimeThreadSurface({
                     errorLabel={t("tool.label.error")}
                     errorText={tool.state === "output-available" ? undefined : tool.error}
                     label={t("tool.label.output")}
-                    output={stringifyToolValue(tool.state === "output-available" ? tool.result : tool.error ?? tool.result)}
+                    output={stringifyToolValue(tool.result)}
                   />
                 ) : null}
 


### PR DESCRIPTION
## Summary
- Fix `unsupported type filter 'tsx'` error by extending `supported_file_type()` in `local_search.rs` to accept common extension aliases (`tsx`, `jsx`, `mts`, `cts`, `mjs`, `cjs`, `mdx`, `scss`, `htm`, etc.), resolving them to their parent language type.
- Fix tool error display in compact summary cards (read/search/list) — error text now renders on its own line below the primary label instead of competing for horizontal space, preventing layout breakage.
- Refactor `ToolOutput` component to separate error block from output block, with proper text wrapping and deduplication of error-as-output rendering.

## Test Plan
- [x] `cargo test local_search` — all 17 tests pass including new `file_type_extension_aliases_resolve_to_parent_type`
- [x] `cargo fmt --check` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: verify failed tool cards show error on second line without squeezing primary label
- [ ] Manual: verify expanded tool detail shows error block separately from output

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)