### PR TITLE
feat(workbench-shell): ✨ integrate task boards and thread profiles

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6126,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.10"
+version = "0.1.11-rc.26042020"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b64bcb758e71a9ada41979c767c4740e392d5e542be1b5446a08f986919401f"
+checksum = "85b0edf2277e0c6c99cadc992daf0574d18e15ecb7a749fc94f07b22e6cc6b72"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.10"
+tiycore = "0.1.11-rc.26042020"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/migrations/20260420000000_thread_profile_id.sql
+++ b/src-tauri/migrations/20260420000000_thread_profile_id.sql
@@ -1,0 +1,50 @@
+-- Persist thread-level profile selection.
+-- Date: 2026-04-20
+-- Description: Adds threads.profile_id and backfills it from latest run profile,
+--              then legacy thread_profile_bindings, then active_profile_id.
+
+ALTER TABLE threads ADD COLUMN profile_id TEXT;
+
+UPDATE threads
+SET profile_id = (
+  SELECT tr.profile_id
+  FROM thread_runs tr
+  WHERE tr.thread_id = threads.id
+    AND tr.profile_id IS NOT NULL
+    AND TRIM(tr.profile_id) <> ''
+  ORDER BY tr.started_at DESC
+  LIMIT 1
+)
+WHERE profile_id IS NULL;
+
+UPDATE threads
+SET profile_id = (
+  SELECT json_extract(s.value_json, '$.' || threads.id)
+  FROM settings s
+  WHERE s.key = 'thread_profile_bindings'
+)
+WHERE profile_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM settings s
+    WHERE s.key = 'thread_profile_bindings'
+      AND json_extract(s.value_json, '$.' || threads.id) IS NOT NULL
+      AND TRIM(json_extract(s.value_json, '$.' || threads.id)) <> ''
+  );
+
+UPDATE threads
+SET profile_id = (
+  SELECT json_extract(s.value_json, '$')
+  FROM settings s
+  WHERE s.key = 'active_profile_id'
+)
+WHERE profile_id IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM settings s
+    WHERE s.key = 'active_profile_id'
+      AND json_extract(s.value_json, '$') IS NOT NULL
+      AND TRIM(json_extract(s.value_json, '$')) <> ''
+  );
+
+CREATE INDEX IF NOT EXISTS idx_threads_profile_id ON threads(profile_id);

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -215,14 +215,20 @@ mod tests {
         .expect("failed to seed workspace");
     }
 
-    async fn seed_thread(pool: &sqlx::SqlitePool, thread_id: &str, workspace_id: &str) {
+    async fn seed_thread(
+        pool: &sqlx::SqlitePool,
+        thread_id: &str,
+        workspace_id: &str,
+        profile_id: Option<&str>,
+    ) {
         let now = chrono::Utc::now().to_rfc3339();
         sqlx::query(
-            "INSERT INTO threads (id, workspace_id, title, status, last_active_at, created_at, updated_at)
-             VALUES (?, ?, 'Test Thread', 'idle', ?, ?, ?)",
+            "INSERT INTO threads (id, workspace_id, profile_id, title, status, last_active_at, created_at, updated_at)
+             VALUES (?, ?, ?, 'Test Thread', 'idle', ?, ?, ?)",
         )
         .bind(thread_id)
         .bind(workspace_id)
+        .bind(profile_id)
         .bind(&now)
         .bind(&now)
         .bind(&now)
@@ -333,7 +339,7 @@ mod tests {
             std::fs::canonicalize(&target_file).expect("failed to canonicalize test file");
 
         seed_workspace(&pool, "ws-dup-approval", workspace_path.to_str().unwrap()).await;
-        seed_thread(&pool, "t-dup-approval", "ws-dup-approval").await;
+        seed_thread(&pool, "t-dup-approval", "ws-dup-approval", None).await;
         seed_run(
             &pool,
             "r-dup-approval",

--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -48,8 +48,12 @@ pub async fn thread_create(
     state: State<'_, AppState>,
     workspace_id: String,
     title: Option<String>,
+    profile_id: Option<String>,
 ) -> Result<ThreadSummaryDto, AppError> {
-    state.thread_manager.create(&workspace_id, title).await
+    state
+        .thread_manager
+        .create(&workspace_id, title, profile_id)
+        .await
 }
 
 #[tauri::command]
@@ -72,6 +76,18 @@ pub async fn thread_update_title(
     title: String,
 ) -> Result<(), AppError> {
     state.thread_manager.update_title(&id, &title).await
+}
+
+#[tauri::command]
+pub async fn thread_update_profile(
+    state: State<'_, AppState>,
+    id: String,
+    profile_id: Option<String>,
+) -> Result<(), AppError> {
+    state
+        .thread_manager
+        .update_profile(&id, profile_id.as_deref())
+        .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/core/prompt_command_manager.rs
+++ b/src-tauri/src/core/prompt_command_manager.rs
@@ -846,7 +846,7 @@ impl PromptCommandManager {
             path: command_path,
             argument_hint: meta.argument_hint.unwrap_or_default(),
             description: meta.description.unwrap_or_default(),
-            prompt: body.trim().to_string(),
+            prompt: body.trim_end().to_string(),
             source,
             enabled: meta.enabled.unwrap_or(true),
             version: meta.version.unwrap_or(DEFAULT_PROMPT_VERSION),
@@ -893,7 +893,7 @@ impl PromptCommandManager {
             path: normalize_command_path(input.path),
             argument_hint: input.argument_hint.unwrap_or_default(),
             description: input.description.unwrap_or_default(),
-            prompt: input.prompt.trim().to_string(),
+            prompt: input.prompt,
             source: normalized_source,
             enabled: input
                 .enabled

--- a/src-tauri/src/core/thread_manager.rs
+++ b/src-tauri/src/core/thread_manager.rs
@@ -49,10 +49,12 @@ impl ThreadManager {
         &self,
         workspace_id: &str,
         title: Option<String>,
+        profile_id: Option<String>,
     ) -> Result<ThreadSummaryDto, AppError> {
         let record = ThreadRecord {
             id: uuid::Uuid::now_v7().to_string(),
             workspace_id: workspace_id.to_string(),
+            profile_id,
             title: title.unwrap_or_default(),
             status: ThreadStatus::Idle,
             summary: None,
@@ -144,6 +146,15 @@ impl ThreadManager {
     /// Update thread title.
     pub async fn update_title(&self, id: &str, title: &str) -> Result<(), AppError> {
         thread_repo::update_title(&self.pool, id, title).await
+    }
+
+    /// Update the profile bound to a thread.
+    pub async fn update_profile(&self, id: &str, profile_id: Option<&str>) -> Result<(), AppError> {
+        let updated = thread_repo::update_profile(&self.pool, id, profile_id).await?;
+        if !updated {
+            return Err(AppError::not_found(ErrorSource::Thread, "thread"));
+        }
+        Ok(())
     }
 
     /// Delete a thread and all its messages.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -298,6 +298,7 @@ pub fn run() {
             commands::thread::thread_create,
             commands::thread::thread_load,
             commands::thread::thread_update_title,
+            commands::thread::thread_update_profile,
             commands::thread::thread_regenerate_title,
             commands::thread::thread_delete,
             commands::thread::thread_add_message,

--- a/src-tauri/src/model/thread.rs
+++ b/src-tauri/src/model/thread.rs
@@ -51,6 +51,7 @@ impl ThreadStatus {
 pub struct ThreadRecord {
     pub id: String,
     pub workspace_id: String,
+    pub profile_id: Option<String>,
     pub title: String,
     pub status: ThreadStatus,
     pub summary: Option<String>,
@@ -65,6 +66,7 @@ pub struct ThreadRecord {
 pub struct ThreadSummaryDto {
     pub id: String,
     pub workspace_id: String,
+    pub profile_id: Option<String>,
     pub title: String,
     pub status: ThreadStatus,
     pub last_active_at: String,
@@ -76,6 +78,7 @@ impl From<ThreadRecord> for ThreadSummaryDto {
         Self {
             id: r.id,
             workspace_id: r.workspace_id,
+            profile_id: r.profile_id,
             title: r.title,
             status: r.status,
             last_active_at: r.last_active_at,

--- a/src-tauri/src/persistence/repo/thread_repo.rs
+++ b/src-tauri/src/persistence/repo/thread_repo.rs
@@ -8,6 +8,7 @@ use crate::model::thread::{ThreadRecord, ThreadStatus};
 struct ThreadRow {
     id: String,
     workspace_id: String,
+    profile_id: Option<String>,
     title: String,
     status: String,
     summary: Option<String>,
@@ -21,6 +22,7 @@ impl ThreadRow {
         ThreadRecord {
             id: self.id,
             workspace_id: self.workspace_id,
+            profile_id: self.profile_id,
             title: self.title,
             status: ThreadStatus::from_str(&self.status),
             summary: self.summary,
@@ -38,7 +40,7 @@ pub async fn list_by_workspace(
     offset: i64,
 ) -> Result<Vec<ThreadRecord>, AppError> {
     let rows = sqlx::query_as::<_, ThreadRow>(
-        "SELECT id, workspace_id, title, status, summary, last_active_at, created_at, updated_at
+        "SELECT id, workspace_id, profile_id, title, status, summary, last_active_at, created_at, updated_at
          FROM threads
          WHERE workspace_id = ?
          ORDER BY last_active_at DESC
@@ -55,7 +57,7 @@ pub async fn list_by_workspace(
 
 pub async fn find_by_id(pool: &SqlitePool, id: &str) -> Result<Option<ThreadRecord>, AppError> {
     let row = sqlx::query_as::<_, ThreadRow>(
-        "SELECT id, workspace_id, title, status, summary, last_active_at, created_at, updated_at
+        "SELECT id, workspace_id, profile_id, title, status, summary, last_active_at, created_at, updated_at
          FROM threads WHERE id = ?",
     )
     .bind(id)
@@ -80,11 +82,12 @@ pub async fn list_ids_with_active_status(pool: &SqlitePool) -> Result<Vec<String
 pub async fn insert(pool: &SqlitePool, record: &ThreadRecord) -> Result<(), AppError> {
     let now = Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO threads (id, workspace_id, title, status, summary, last_active_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO threads (id, workspace_id, profile_id, title, status, summary, last_active_at, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&record.id)
     .bind(&record.workspace_id)
+    .bind(&record.profile_id)
     .bind(&record.title)
     .bind(record.status.as_str())
     .bind(&record.summary)
@@ -114,6 +117,21 @@ pub async fn update_title(pool: &SqlitePool, id: &str, title: &str) -> Result<()
         .execute(pool)
         .await?;
     Ok(())
+}
+
+pub async fn update_profile(
+    pool: &SqlitePool,
+    id: &str,
+    profile_id: Option<&str>,
+) -> Result<bool, AppError> {
+    let now = Utc::now().to_rfc3339();
+    let result = sqlx::query("UPDATE threads SET profile_id = ?, updated_at = ? WHERE id = ?")
+        .bind(profile_id)
+        .bind(&now)
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
 }
 
 pub async fn update_status(

--- a/src-tauri/tests/m1_2_workspace.rs
+++ b/src-tauri/tests/m1_2_workspace.rs
@@ -283,7 +283,7 @@ async fn test_workspace_repo_delete_removes_messages_before_runs() {
     let manager = WorkspaceManager::new(pool.clone());
 
     test_helpers::seed_workspace(&pool, "ws-del-repo", "/tmp/delete-repo").await;
-    test_helpers::seed_thread(&pool, "t-del-repo", "ws-del-repo").await;
+    test_helpers::seed_thread(&pool, "t-del-repo", "ws-del-repo", None).await;
     test_helpers::seed_run(&pool, "r-del-repo", "t-del-repo", "completed", "default").await;
 
     sqlx::query(

--- a/src-tauri/tests/m1_4_thread.rs
+++ b/src-tauri/tests/m1_4_thread.rs
@@ -20,7 +20,7 @@ use tiycode::core::thread_manager::ThreadManager;
 async fn test_thread_create() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-t", "/tmp/threads").await;
-    test_helpers::seed_thread(&pool, "t-001", "ws-t").await;
+    test_helpers::seed_thread(&pool, "t-001", "ws-t", None).await;
 
     let row = sqlx::query("SELECT title, status FROM threads WHERE id = 't-001'")
         .fetch_one(&pool)
@@ -32,11 +32,83 @@ async fn test_thread_create() {
 }
 
 #[tokio::test]
+async fn test_thread_manager_create_persists_profile_id() {
+    let pool = test_helpers::setup_test_pool().await;
+    test_helpers::seed_workspace(&pool, "ws-create-profile", "/tmp/create-profile").await;
+    let manager = ThreadManager::new(pool.clone());
+
+    let thread = manager
+        .create(
+            "ws-create-profile",
+            Some("Profile thread".to_string()),
+            Some("profile-1".to_string()),
+        )
+        .await
+        .expect("thread create should succeed");
+
+    assert_eq!(thread.profile_id.as_deref(), Some("profile-1"));
+
+    let row = sqlx::query("SELECT profile_id FROM threads WHERE id = ?")
+        .bind(&thread.id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<String, _>("profile_id"), "profile-1");
+}
+
+#[tokio::test]
+async fn test_thread_manager_update_profile_persists_new_value() {
+    let pool = test_helpers::setup_test_pool().await;
+    test_helpers::seed_workspace(&pool, "ws-update-profile", "/tmp/update-profile").await;
+    test_helpers::seed_thread(
+        &pool,
+        "t-update-profile",
+        "ws-update-profile",
+        Some("profile-old"),
+    )
+    .await;
+    let manager = ThreadManager::new(pool.clone());
+
+    manager
+        .update_profile("t-update-profile", Some("profile-new"))
+        .await
+        .expect("thread profile update should succeed");
+
+    let row = sqlx::query("SELECT profile_id FROM threads WHERE id = 't-update-profile'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<String, _>("profile_id"), "profile-new");
+}
+
+#[tokio::test]
+async fn test_thread_list_returns_profile_id() {
+    let pool = test_helpers::setup_test_pool().await;
+    test_helpers::seed_workspace(&pool, "ws-list-profile", "/tmp/list-profile").await;
+    test_helpers::seed_thread(
+        &pool,
+        "t-list-profile",
+        "ws-list-profile",
+        Some("profile-list"),
+    )
+    .await;
+    let manager = ThreadManager::new(pool.clone());
+
+    let threads = manager
+        .list("ws-list-profile", None, None)
+        .await
+        .expect("thread list should succeed");
+
+    assert_eq!(threads.len(), 1);
+    assert_eq!(threads[0].profile_id.as_deref(), Some("profile-list"));
+}
+
+#[tokio::test]
 async fn test_thread_belongs_to_workspace() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-own", "/tmp/own").await;
-    test_helpers::seed_thread(&pool, "t-own-1", "ws-own").await;
-    test_helpers::seed_thread(&pool, "t-own-2", "ws-own").await;
+    test_helpers::seed_thread(&pool, "t-own-1", "ws-own", None).await;
+    test_helpers::seed_thread(&pool, "t-own-2", "ws-own", None).await;
 
     let rows = sqlx::query("SELECT id FROM threads WHERE workspace_id = 'ws-own'")
         .fetch_all(&pool)
@@ -84,7 +156,7 @@ async fn test_thread_list_sorted_by_last_active() {
 async fn test_thread_update_title() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-title", "/tmp/title").await;
-    test_helpers::seed_thread(&pool, "t-title", "ws-title").await;
+    test_helpers::seed_thread(&pool, "t-title", "ws-title", None).await;
 
     sqlx::query("UPDATE threads SET title = 'New Title' WHERE id = 't-title'")
         .execute(&pool)
@@ -103,7 +175,7 @@ async fn test_thread_update_title() {
 async fn test_thread_delete() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-del", "/tmp/del").await;
-    test_helpers::seed_thread(&pool, "t-del", "ws-del").await;
+    test_helpers::seed_thread(&pool, "t-del", "ws-del", None).await;
 
     sqlx::query("DELETE FROM threads WHERE id = 't-del'")
         .execute(&pool)
@@ -122,7 +194,7 @@ async fn test_thread_delete() {
 async fn test_thread_delete_cascades_runtime_records() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-del-cascade", "/tmp/del-cascade").await;
-    test_helpers::seed_thread(&pool, "t-del-cascade", "ws-del-cascade").await;
+    test_helpers::seed_thread(&pool, "t-del-cascade", "ws-del-cascade", None).await;
     test_helpers::seed_run(
         &pool,
         "r-del-cascade",
@@ -214,7 +286,7 @@ async fn test_thread_delete_cascades_runtime_records() {
 async fn test_message_append_and_persist() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-msg", "/tmp/msg").await;
-    test_helpers::seed_thread(&pool, "t-msg", "ws-msg").await;
+    test_helpers::seed_thread(&pool, "t-msg", "ws-msg", None).await;
     test_helpers::seed_message(&pool, "m-001", "t-msg", "user", "Hello AI").await;
     test_helpers::seed_message(&pool, "m-002", "t-msg", "assistant", "Hello human").await;
 
@@ -239,7 +311,7 @@ async fn test_message_append_and_persist() {
 async fn test_message_pagination_cursor() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-page", "/tmp/page").await;
-    test_helpers::seed_thread(&pool, "t-page", "ws-page").await;
+    test_helpers::seed_thread(&pool, "t-page", "ws-page", None).await;
 
     // Insert messages with UUID v7-like IDs (lexicographically sortable)
     // Use a pattern that ensures ordering: 019... prefix is UUIDv7 format
@@ -285,7 +357,7 @@ async fn test_message_pagination_cursor() {
 async fn test_message_has_more_detection() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-more", "/tmp/more").await;
-    test_helpers::seed_thread(&pool, "t-more", "ws-more").await;
+    test_helpers::seed_thread(&pool, "t-more", "ws-more", None).await;
 
     // Insert 5 messages
     for i in 0..5 {
@@ -312,7 +384,7 @@ async fn test_message_has_more_detection() {
 async fn test_thread_snapshot_keeps_latest_message_when_more_than_default_page_size() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-snap-page", "/tmp/snap-page").await;
-    test_helpers::seed_thread(&pool, "t-snap-page", "ws-snap-page").await;
+    test_helpers::seed_thread(&pool, "t-snap-page", "ws-snap-page", None).await;
 
     for i in 0..51 {
         let id = format!("01900000-0000-7000-8000-{i:012}");
@@ -350,7 +422,7 @@ async fn test_thread_snapshot_keeps_latest_message_when_more_than_default_page_s
 async fn test_thread_status_idle_when_no_runs() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-stat", "/tmp/stat").await;
-    test_helpers::seed_thread(&pool, "t-stat", "ws-stat").await;
+    test_helpers::seed_thread(&pool, "t-stat", "ws-stat", None).await;
 
     let row = sqlx::query("SELECT status FROM threads WHERE id = 't-stat'")
         .fetch_one(&pool)
@@ -364,7 +436,7 @@ async fn test_thread_status_idle_when_no_runs() {
 async fn test_thread_status_running_with_active_run() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-run", "/tmp/run").await;
-    test_helpers::seed_thread(&pool, "t-run", "ws-run").await;
+    test_helpers::seed_thread(&pool, "t-run", "ws-run", None).await;
     test_helpers::seed_run(&pool, "r-001", "t-run", "running", "default").await;
 
     // Thread status should reflect latest run
@@ -389,7 +461,7 @@ async fn test_thread_status_running_with_active_run() {
 async fn test_thread_snapshot_assembly() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-snap", "/tmp/snap").await;
-    test_helpers::seed_thread(&pool, "t-snap", "ws-snap").await;
+    test_helpers::seed_thread(&pool, "t-snap", "ws-snap", None).await;
     test_helpers::seed_message(&pool, "m-s1", "t-snap", "user", "Q").await;
     test_helpers::seed_message(&pool, "m-s2", "t-snap", "assistant", "A").await;
     test_helpers::seed_run(&pool, "r-snap", "t-snap", "completed", "default").await;
@@ -420,7 +492,7 @@ async fn test_thread_snapshot_assembly() {
 async fn test_thread_snapshot_includes_latest_failed_run_error() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-fail", "/tmp/fail").await;
-    test_helpers::seed_thread(&pool, "t-fail", "ws-fail").await;
+    test_helpers::seed_thread(&pool, "t-fail", "ws-fail", None).await;
     test_helpers::seed_message(&pool, "m-f1", "t-fail", "user", "Q").await;
 
     sqlx::query(
@@ -451,7 +523,7 @@ async fn test_thread_snapshot_includes_latest_failed_run_error() {
 async fn test_thread_snapshot_includes_runtime_artifacts_for_visible_runs() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-runtime", "/tmp/runtime").await;
-    test_helpers::seed_thread(&pool, "t-runtime", "ws-runtime").await;
+    test_helpers::seed_thread(&pool, "t-runtime", "ws-runtime", None).await;
 
     sqlx::query(
         "INSERT INTO thread_runs (
@@ -556,9 +628,9 @@ async fn test_thread_snapshot_includes_runtime_artifacts_for_visible_runs() {
 async fn test_recover_interrupted_runs_reconciles_thread_statuses() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-rec", "/tmp/rec").await;
-    test_helpers::seed_thread(&pool, "t-active", "ws-rec").await;
-    test_helpers::seed_thread(&pool, "t-stale", "ws-rec").await;
-    test_helpers::seed_thread(&pool, "t-empty", "ws-rec").await;
+    test_helpers::seed_thread(&pool, "t-active", "ws-rec", None).await;
+    test_helpers::seed_thread(&pool, "t-stale", "ws-rec", None).await;
+    test_helpers::seed_thread(&pool, "t-empty", "ws-rec", None).await;
 
     sqlx::query(
         "UPDATE threads
@@ -612,7 +684,7 @@ async fn test_recover_interrupted_runs_reconciles_thread_statuses() {
 async fn test_message_with_metadata() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-meta", "/tmp/meta").await;
-    test_helpers::seed_thread(&pool, "t-meta", "ws-meta").await;
+    test_helpers::seed_thread(&pool, "t-meta", "ws-meta", None).await;
 
     sqlx::query(
         "INSERT INTO messages (id, thread_id, role, content_markdown, message_type, status, metadata_json)

--- a/src-tauri/tests/m1_4_thread.rs
+++ b/src-tauri/tests/m1_4_thread.rs
@@ -82,6 +82,34 @@ async fn test_thread_manager_update_profile_persists_new_value() {
 }
 
 #[tokio::test]
+async fn test_thread_manager_update_profile_can_clear_to_none() {
+    let pool = test_helpers::setup_test_pool().await;
+    test_helpers::seed_workspace(&pool, "ws-clear-profile", "/tmp/clear-profile").await;
+    test_helpers::seed_thread(
+        &pool,
+        "t-clear-profile",
+        "ws-clear-profile",
+        Some("profile-to-clear"),
+    )
+    .await;
+    let manager = ThreadManager::new(pool.clone());
+
+    manager
+        .update_profile("t-clear-profile", None)
+        .await
+        .expect("thread profile clear should succeed");
+
+    let row = sqlx::query("SELECT profile_id FROM threads WHERE id = 't-clear-profile'")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        row.get::<Option<String>, _>("profile_id").is_none(),
+        "profile_id should be NULL after clearing"
+    );
+}
+
+#[tokio::test]
 async fn test_thread_list_returns_profile_id() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-list-profile", "/tmp/list-profile").await;

--- a/src-tauri/tests/m1_5_agent_run.rs
+++ b/src-tauri/tests/m1_5_agent_run.rs
@@ -21,7 +21,7 @@ use tiycode::core::thread_manager::ThreadManager;
 async fn test_run_creation_with_default_status() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-run", "/tmp/run").await;
-    test_helpers::seed_thread(&pool, "t-run", "ws-run").await;
+    test_helpers::seed_thread(&pool, "t-run", "ws-run", None).await;
     test_helpers::seed_run(&pool, "r-create", "t-run", "created", "default").await;
 
     let row = sqlx::query("SELECT status, run_mode FROM thread_runs WHERE id = 'r-create'")
@@ -37,7 +37,7 @@ async fn test_run_creation_with_default_status() {
 async fn test_run_state_transitions() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-sm", "/tmp/sm").await;
-    test_helpers::seed_thread(&pool, "t-sm", "ws-sm").await;
+    test_helpers::seed_thread(&pool, "t-sm", "ws-sm", None).await;
     test_helpers::seed_run(&pool, "r-sm", "t-sm", "created", "default").await;
 
     // Transition: created → dispatching
@@ -83,7 +83,7 @@ async fn test_run_state_transitions() {
 async fn test_run_failure_with_error() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-fail", "/tmp/fail").await;
-    test_helpers::seed_thread(&pool, "t-fail", "ws-fail").await;
+    test_helpers::seed_thread(&pool, "t-fail", "ws-fail", None).await;
     test_helpers::seed_run(&pool, "r-fail", "t-fail", "running", "default").await;
 
     sqlx::query(
@@ -109,7 +109,7 @@ async fn test_run_failure_with_error() {
 async fn test_run_cancellation() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-cancel", "/tmp/cancel").await;
-    test_helpers::seed_thread(&pool, "t-cancel", "ws-cancel").await;
+    test_helpers::seed_thread(&pool, "t-cancel", "ws-cancel", None).await;
     test_helpers::seed_run(&pool, "r-cancel", "t-cancel", "running", "default").await;
 
     sqlx::query("UPDATE thread_runs SET status = 'cancelled', finished_at = strftime('%Y-%m-%dT%H:%M:%fZ','now') WHERE id = 'r-cancel'")
@@ -129,7 +129,7 @@ async fn test_run_cancellation() {
 async fn test_limit_reached_run_syncs_thread_to_needs_reply() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-limit", "/tmp/limit").await;
-    test_helpers::seed_thread(&pool, "t-limit", "ws-limit").await;
+    test_helpers::seed_thread(&pool, "t-limit", "ws-limit", None).await;
     test_helpers::seed_run(&pool, "r-limit", "t-limit", "running", "default").await;
 
     sqlx::query(
@@ -162,7 +162,7 @@ async fn test_limit_reached_run_syncs_thread_to_needs_reply() {
 async fn test_recover_interrupted_runs() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-rec", "/tmp/rec").await;
-    test_helpers::seed_thread(&pool, "t-rec", "ws-rec").await;
+    test_helpers::seed_thread(&pool, "t-rec", "ws-rec", None).await;
 
     // Create "dangling" runs that were in-progress when app crashed
     test_helpers::seed_run(&pool, "r-dangling-1", "t-rec", "running", "default").await;
@@ -297,7 +297,7 @@ async fn test_recover_interrupted_runs() {
 async fn test_active_runs_index() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-idx", "/tmp/idx").await;
-    test_helpers::seed_thread(&pool, "t-idx", "ws-idx").await;
+    test_helpers::seed_thread(&pool, "t-idx", "ws-idx", None).await;
 
     test_helpers::seed_run(&pool, "r-active", "t-idx", "running", "default").await;
     test_helpers::seed_run(&pool, "r-done", "t-idx", "completed", "default").await;
@@ -326,7 +326,7 @@ async fn test_active_runs_index() {
 async fn test_only_one_active_run_per_thread_check() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-1run", "/tmp/1run").await;
-    test_helpers::seed_thread(&pool, "t-1run", "ws-1run").await;
+    test_helpers::seed_thread(&pool, "t-1run", "ws-1run", None).await;
     test_helpers::seed_run(&pool, "r-existing", "t-1run", "running", "default").await;
 
     // Application-level check: count active runs before starting a new one
@@ -350,7 +350,7 @@ async fn test_only_one_active_run_per_thread_check() {
 async fn test_effective_model_plan_stored() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-mp", "/tmp/mp").await;
-    test_helpers::seed_thread(&pool, "t-mp", "ws-mp").await;
+    test_helpers::seed_thread(&pool, "t-mp", "ws-mp", None).await;
 
     let model_plan = r#"{"primary":{"provider":"openai","model":"gpt-4"},"auxiliary":{"provider":"anthropic","model":"claude-3"}}"#;
 
@@ -383,7 +383,7 @@ async fn test_build_session_spec_resolves_primary_model_and_profile_prompt() {
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-runtime", "/tmp/runtime").await;
-    test_helpers::seed_thread(&pool, "t-runtime", "ws-runtime").await;
+    test_helpers::seed_thread(&pool, "t-runtime", "ws-runtime", None).await;
     test_helpers::seed_message(
         &pool,
         "m-runtime",
@@ -463,7 +463,7 @@ async fn test_build_session_spec_uses_runtime_custom_instructions_when_profile_l
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-runtime-inline", "/tmp/runtime-inline").await;
-    test_helpers::seed_thread(&pool, "t-runtime-inline", "ws-runtime-inline").await;
+    test_helpers::seed_thread(&pool, "t-runtime-inline", "ws-runtime-inline", None).await;
 
     sqlx::query(
         "INSERT INTO providers (
@@ -521,7 +521,7 @@ async fn test_build_session_spec_adds_plan_mode_guardrails() {
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-plan", "/tmp/plan").await;
-    test_helpers::seed_thread(&pool, "t-plan", "ws-plan").await;
+    test_helpers::seed_thread(&pool, "t-plan", "ws-plan", None).await;
     test_helpers::seed_message(
         &pool,
         "m-plan",
@@ -592,7 +592,7 @@ async fn test_build_session_spec_keeps_reasoning_disabled_when_thinking_level_is
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-thinking-off", "/tmp/thinking-off").await;
-    test_helpers::seed_thread(&pool, "t-thinking-off", "ws-thinking-off").await;
+    test_helpers::seed_thread(&pool, "t-thinking-off", "ws-thinking-off", None).await;
 
     sqlx::query(
         "INSERT INTO providers (
@@ -641,7 +641,7 @@ async fn test_build_session_spec_enables_reasoning_when_thinking_level_is_set() 
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-thinking-on", "/tmp/thinking-on").await;
-    test_helpers::seed_thread(&pool, "t-thinking-on", "ws-thinking-on").await;
+    test_helpers::seed_thread(&pool, "t-thinking-on", "ws-thinking-on", None).await;
 
     sqlx::query(
         "INSERT INTO providers (
@@ -689,7 +689,7 @@ async fn test_build_session_spec_defaults_openai_compatible_to_system_role_compa
 
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-openai-compat", "/tmp/openai-compat").await;
-    test_helpers::seed_thread(&pool, "t-openai-compat", "ws-openai-compat").await;
+    test_helpers::seed_thread(&pool, "t-openai-compat", "ws-openai-compat", None).await;
 
     sqlx::query(
         "INSERT INTO providers (
@@ -751,7 +751,7 @@ async fn test_build_session_spec_includes_structured_runtime_context_sections() 
     fs::write(temp_dir.path().join("AGENTS.md"), "Agents instructions").unwrap();
 
     test_helpers::seed_workspace(&pool, "ws-ctx", &workspace_path).await;
-    test_helpers::seed_thread(&pool, "t-ctx", "ws-ctx").await;
+    test_helpers::seed_thread(&pool, "t-ctx", "ws-ctx", None).await;
     test_helpers::seed_message(&pool, "m-ctx", "t-ctx", "user", "Inspect the setup").await;
     test_helpers::seed_policy(&pool, "approval_policy", r#""require_all""#).await;
 
@@ -868,7 +868,7 @@ async fn test_build_session_spec_reads_object_style_approval_policy() {
     let workspace_path = temp_dir.path().to_string_lossy().to_string();
 
     test_helpers::seed_workspace(&pool, "ws-ctx-object", &workspace_path).await;
-    test_helpers::seed_thread(&pool, "t-ctx-object", "ws-ctx-object").await;
+    test_helpers::seed_thread(&pool, "t-ctx-object", "ws-ctx-object", None).await;
     test_helpers::seed_policy(&pool, "approval_policy", r#"{"mode":"require_all"}"#).await;
 
     sqlx::query(
@@ -913,7 +913,7 @@ async fn test_build_session_spec_reads_object_style_approval_policy() {
 async fn test_run_helpers_table_persists_collapsed_helper_summary() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-helper", "/tmp/helper").await;
-    test_helpers::seed_thread(&pool, "t-helper", "ws-helper").await;
+    test_helpers::seed_thread(&pool, "t-helper", "ws-helper", None).await;
     test_helpers::seed_run(&pool, "r-helper", "t-helper", "running", "default").await;
 
     sqlx::query(

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -598,7 +598,7 @@ async fn test_policy_allows_mutating_paths_in_writable_roots() {
 async fn test_tool_call_crud() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-tc", "/tmp/tc").await;
-    test_helpers::seed_thread(&pool, "t-tc", "ws-tc").await;
+    test_helpers::seed_thread(&pool, "t-tc", "ws-tc", None).await;
     test_helpers::seed_run(&pool, "r-tc", "t-tc", "running", "default").await;
     test_helpers::seed_tool_call(&pool, "tc-001", "r-tc", "t-tc", "read", "requested").await;
 
@@ -615,7 +615,7 @@ async fn test_tool_call_crud() {
 async fn test_tool_call_approval_flow() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-appr", "/tmp/appr").await;
-    test_helpers::seed_thread(&pool, "t-appr", "ws-appr").await;
+    test_helpers::seed_thread(&pool, "t-appr", "ws-appr", None).await;
     test_helpers::seed_run(&pool, "r-appr", "t-appr", "running", "default").await;
     test_helpers::seed_tool_call(
         &pool,
@@ -651,7 +651,7 @@ async fn test_tool_call_approval_flow() {
 async fn test_tool_call_rejection() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-rej", "/tmp/rej").await;
-    test_helpers::seed_thread(&pool, "t-rej", "ws-rej").await;
+    test_helpers::seed_thread(&pool, "t-rej", "ws-rej", None).await;
     test_helpers::seed_run(&pool, "r-rej", "t-rej", "running", "default").await;
     test_helpers::seed_tool_call(
         &pool,
@@ -683,7 +683,7 @@ async fn test_tool_call_rejection() {
 async fn test_tool_call_completed_with_output() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-out", "/tmp/out").await;
-    test_helpers::seed_thread(&pool, "t-out", "ws-out").await;
+    test_helpers::seed_thread(&pool, "t-out", "ws-out", None).await;
     test_helpers::seed_run(&pool, "r-out", "t-out", "running", "default").await;
     test_helpers::seed_tool_call(&pool, "tc-out", "r-out", "t-out", "read", "running").await;
 
@@ -714,7 +714,7 @@ async fn test_tool_call_completed_with_output() {
 async fn test_tool_call_policy_verdict_stored() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-pv", "/tmp/pv").await;
-    test_helpers::seed_thread(&pool, "t-pv", "ws-pv").await;
+    test_helpers::seed_thread(&pool, "t-pv", "ws-pv", None).await;
     test_helpers::seed_run(&pool, "r-pv", "t-pv", "running", "default").await;
 
     let verdict = r#"{"toolName":"write","verdict":{"require_approval":{"reason":"Mutating tool"}},"checkedRules":["builtin","user_deny_list","workspace_boundary"]}"#;
@@ -748,7 +748,7 @@ async fn test_audit_event_recording() {
 
     // Seed required FK references
     test_helpers::seed_workspace(&pool, "ws-audit", "/tmp/audit").await;
-    test_helpers::seed_thread(&pool, "t-audit", "ws-audit").await;
+    test_helpers::seed_thread(&pool, "t-audit", "ws-audit", None).await;
     test_helpers::seed_run(&pool, "r-audit", "t-audit", "running", "default").await;
     test_helpers::seed_tool_call(&pool, "tc-audit", "r-audit", "t-audit", "read", "completed")
         .await;
@@ -785,7 +785,7 @@ async fn test_audit_event_recording() {
 async fn test_pending_tool_calls_query() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-pending", "/tmp/pending").await;
-    test_helpers::seed_thread(&pool, "t-pending", "ws-pending").await;
+    test_helpers::seed_thread(&pool, "t-pending", "ws-pending", None).await;
     test_helpers::seed_run(&pool, "r-pending", "t-pending", "running", "default").await;
 
     test_helpers::seed_tool_call(
@@ -867,7 +867,7 @@ async fn test_tool_gateway_can_fold_approval_into_escalation() {
         workspace_root.to_str().unwrap(),
     )
     .await;
-    test_helpers::seed_thread(&pool, "t-helper-escalate", "ws-helper-escalate").await;
+    test_helpers::seed_thread(&pool, "t-helper-escalate", "ws-helper-escalate", None).await;
     test_helpers::seed_run(
         &pool,
         "r-helper-escalate",
@@ -983,7 +983,7 @@ async fn test_search_repo_allows_relative_directory_within_workspace() {
         workspace_root.to_str().unwrap(),
     )
     .await;
-    test_helpers::seed_thread(&pool, "t-search-relative", "ws-search-relative").await;
+    test_helpers::seed_thread(&pool, "t-search-relative", "ws-search-relative", None).await;
     test_helpers::seed_run(
         &pool,
         "r-search-relative",
@@ -1088,7 +1088,7 @@ async fn test_search_repo_ignores_wildcard_file_pattern_and_limits_preview() {
         workspace_root.to_str().unwrap(),
     )
     .await;
-    test_helpers::seed_thread(&pool, "t-search-wildcard", "ws-search-wildcard").await;
+    test_helpers::seed_thread(&pool, "t-search-wildcard", "ws-search-wildcard", None).await;
     test_helpers::seed_run(
         &pool,
         "r-search-wildcard",
@@ -1192,7 +1192,7 @@ async fn test_search_repo_treats_regex_metacharacters_as_literal_text() {
 
     test_helpers::seed_workspace(&pool, "ws-search-literal", workspace_root.to_str().unwrap())
         .await;
-    test_helpers::seed_thread(&pool, "t-search-literal", "ws-search-literal").await;
+    test_helpers::seed_thread(&pool, "t-search-literal", "ws-search-literal", None).await;
     test_helpers::seed_run(
         &pool,
         "r-search-literal",
@@ -1299,7 +1299,7 @@ async fn test_search_repo_supports_regex_count_mode_and_case_insensitive_matchin
         workspace_root.to_str().unwrap(),
     )
     .await;
-    test_helpers::seed_thread(&pool, "t-search-regex-count", "ws-search-regex-count").await;
+    test_helpers::seed_thread(&pool, "t-search-regex-count", "ws-search-regex-count", None).await;
     test_helpers::seed_run(
         &pool,
         "r-search-regex-count",
@@ -1387,7 +1387,7 @@ async fn test_execution_timeout_fires_for_slow_tool() {
     let workspace_root = std::fs::canonicalize(&workspace_root).unwrap();
 
     test_helpers::seed_workspace(&pool, "ws-timeout", workspace_root.to_str().unwrap()).await;
-    test_helpers::seed_thread(&pool, "t-timeout", "ws-timeout").await;
+    test_helpers::seed_thread(&pool, "t-timeout", "ws-timeout", None).await;
     test_helpers::seed_run(&pool, "r-timeout", "t-timeout", "running", "default").await;
     test_helpers::seed_tool_call(
         &pool,

--- a/src-tauri/tests/m1_7_frontend_integration.rs
+++ b/src-tauri/tests/m1_7_frontend_integration.rs
@@ -587,6 +587,7 @@ fn test_thread_summary_dto_camel_case() {
     let dto = ThreadSummaryDto {
         id: "t-1".into(),
         workspace_id: "ws-1".into(),
+        profile_id: Some("profile-1".into()),
         title: "Test".into(),
         status: ThreadStatus::Idle,
         last_active_at: "2026-03-16T00:00:00Z".into(),

--- a/src-tauri/tests/m1_e2e_full_chain.rs
+++ b/src-tauri/tests/m1_e2e_full_chain.rs
@@ -22,7 +22,7 @@ async fn test_full_workspace_thread_message_chain() {
     test_helpers::seed_workspace(&pool, "ws-e2e", "/tmp/e2e-project").await;
 
     // 2. Create thread under workspace
-    test_helpers::seed_thread(&pool, "t-e2e", "ws-e2e").await;
+    test_helpers::seed_thread(&pool, "t-e2e", "ws-e2e", None).await;
 
     // 3. Add user message
     test_helpers::seed_message(&pool, "m-user", "t-e2e", "user", "Explain this codebase").await;
@@ -123,7 +123,7 @@ async fn test_full_workspace_thread_message_chain() {
 async fn test_full_approval_flow() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-appr", "/tmp/approval").await;
-    test_helpers::seed_thread(&pool, "t-appr", "ws-appr").await;
+    test_helpers::seed_thread(&pool, "t-appr", "ws-appr", None).await;
     test_helpers::seed_run(&pool, "r-appr", "t-appr", "running", "default").await;
 
     // 1. Tool requested
@@ -203,7 +203,7 @@ async fn test_full_approval_flow() {
 async fn test_multiple_runs_in_thread() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-multi", "/tmp/multi").await;
-    test_helpers::seed_thread(&pool, "t-multi", "ws-multi").await;
+    test_helpers::seed_thread(&pool, "t-multi", "ws-multi", None).await;
 
     // Run 1: completed
     test_helpers::seed_run(&pool, "r-1", "t-multi", "completed", "default").await;
@@ -327,7 +327,7 @@ async fn test_settings_provider_profile_chain() {
 async fn test_workspace_deletion_blocks_with_threads() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-cas", "/tmp/cascade").await;
-    test_helpers::seed_thread(&pool, "t-cas", "ws-cas").await;
+    test_helpers::seed_thread(&pool, "t-cas", "ws-cas", None).await;
 
     // Deleting workspace should fail because thread references it (FK constraint)
     let result = sqlx::query("DELETE FROM workspaces WHERE id = 'ws-cas'")
@@ -348,7 +348,7 @@ async fn test_workspace_deletion_blocks_with_threads() {
 async fn test_snapshot_recovery_after_crash() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-crash", "/tmp/crash").await;
-    test_helpers::seed_thread(&pool, "t-crash", "ws-crash").await;
+    test_helpers::seed_thread(&pool, "t-crash", "ws-crash", None).await;
     test_helpers::seed_message(&pool, "m-c1", "t-crash", "user", "Help me").await;
     test_helpers::seed_run(&pool, "r-crash", "t-crash", "running", "default").await;
     test_helpers::seed_tool_call(&pool, "tc-crash", "r-crash", "t-crash", "read", "running").await;

--- a/src-tauri/tests/m2_1_terminal_manager.rs
+++ b/src-tauri/tests/m2_1_terminal_manager.rs
@@ -35,7 +35,7 @@ async fn test_terminal_session_lifecycle_and_output() {
         .to_string();
 
     test_helpers::seed_workspace(&pool, "ws-terminal", &workspace_path).await;
-    test_helpers::seed_thread(&pool, "thread-terminal", "ws-terminal").await;
+    test_helpers::seed_thread(&pool, "thread-terminal", "ws-terminal", None).await;
 
     let shell = test_shell();
     let manager = Arc::new(TerminalManager::new(pool.clone()));
@@ -92,7 +92,7 @@ async fn test_terminal_recovery_marks_active_sessions_exited() {
     let now = chrono::Utc::now().to_rfc3339();
 
     test_helpers::seed_workspace(&pool, "ws-recovery", "/tmp/terminal-recovery").await;
-    test_helpers::seed_thread(&pool, "thread-recovery", "ws-recovery").await;
+    test_helpers::seed_thread(&pool, "thread-recovery", "ws-recovery", None).await;
 
     sqlx::query(
         "INSERT INTO terminal_sessions (id, thread_id, workspace_id, shell_path, cwd, status, created_at)

--- a/src-tauri/tests/m2_3_task_tracking.rs
+++ b/src-tauri/tests/m2_3_task_tracking.rs
@@ -26,7 +26,7 @@ use tiycode::model::task_item::TaskStage;
 async fn test_create_task_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-task", "/tmp/task").await;
-    test_helpers::seed_thread(&pool, "t-task-1", "ws-task").await;
+    test_helpers::seed_thread(&pool, "t-task-1", "ws-task", None).await;
 
     let input = CreateTaskInput {
         title: "Implement Feature X".to_string(),
@@ -69,7 +69,7 @@ async fn test_create_task_board() {
 async fn test_auto_complete_previous_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-auto", "/tmp/auto").await;
-    test_helpers::seed_thread(&pool, "t-auto", "ws-auto").await;
+    test_helpers::seed_thread(&pool, "t-auto", "ws-auto", None).await;
 
     // Create first board
     let input1 = CreateTaskInput {
@@ -112,7 +112,7 @@ async fn test_auto_complete_previous_board() {
 async fn test_update_task_start_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-start", "/tmp/start").await;
-    test_helpers::seed_thread(&pool, "t-start", "ws-start").await;
+    test_helpers::seed_thread(&pool, "t-start", "ws-start", None).await;
 
     let input = CreateTaskInput {
         title: "Test Task".to_string(),
@@ -149,7 +149,7 @@ async fn test_update_task_start_step() {
 async fn test_update_task_complete_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-complete", "/tmp/complete").await;
-    test_helpers::seed_thread(&pool, "t-complete", "ws-complete").await;
+    test_helpers::seed_thread(&pool, "t-complete", "ws-complete", None).await;
 
     let input = CreateTaskInput {
         title: "Test Task".to_string(),
@@ -188,7 +188,7 @@ async fn test_update_task_complete_step() {
 async fn test_update_task_complete_last_step_auto_completes_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-last", "/tmp/last").await;
-    test_helpers::seed_thread(&pool, "t-last", "ws-last").await;
+    test_helpers::seed_thread(&pool, "t-last", "ws-last", None).await;
 
     let input = CreateTaskInput {
         title: "Single Step Task".to_string(),
@@ -222,7 +222,7 @@ async fn test_update_task_complete_last_step_auto_completes_board() {
 async fn test_update_task_advance_step_uses_active_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-advance", "/tmp/advance").await;
-    test_helpers::seed_thread(&pool, "t-advance", "ws-advance").await;
+    test_helpers::seed_thread(&pool, "t-advance", "ws-advance", None).await;
 
     let input = CreateTaskInput {
         title: "Advance Task".to_string(),
@@ -259,7 +259,7 @@ async fn test_update_task_advance_step_uses_active_step() {
 async fn test_update_task_advance_step_treats_empty_step_id_as_missing() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-advance-empty", "/tmp/advance-empty").await;
-    test_helpers::seed_thread(&pool, "t-advance-empty", "ws-advance-empty").await;
+    test_helpers::seed_thread(&pool, "t-advance-empty", "ws-advance-empty", None).await;
 
     let input = CreateTaskInput {
         title: "Advance Task Empty Step Id".to_string(),
@@ -298,7 +298,7 @@ async fn test_update_task_advance_step_treats_empty_step_id_as_missing() {
 async fn test_update_task_fail_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-fail", "/tmp/fail").await;
-    test_helpers::seed_thread(&pool, "t-fail", "ws-fail").await;
+    test_helpers::seed_thread(&pool, "t-fail", "ws-fail", None).await;
 
     let input = CreateTaskInput {
         title: "Test Task".to_string(),
@@ -342,7 +342,7 @@ async fn test_update_task_fail_step() {
 async fn test_update_task_complete_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-board", "/tmp/board").await;
-    test_helpers::seed_thread(&pool, "t-board", "ws-board").await;
+    test_helpers::seed_thread(&pool, "t-board", "ws-board", None).await;
 
     let input = CreateTaskInput {
         title: "Test Task".to_string(),
@@ -369,7 +369,7 @@ async fn test_update_task_complete_board() {
 async fn test_query_task_active_returns_only_active_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-query-active", "/tmp/query-active").await;
-    test_helpers::seed_thread(&pool, "t-query-active", "ws-query-active").await;
+    test_helpers::seed_thread(&pool, "t-query-active", "ws-query-active", None).await;
 
     let first_board = task_board_manager::create_task_board(
         &pool,
@@ -419,7 +419,7 @@ async fn test_query_task_active_returns_only_active_board() {
 async fn test_query_task_active_returns_empty_when_no_active_board_exists() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-query-none", "/tmp/query-none").await;
-    test_helpers::seed_thread(&pool, "t-query-none", "ws-query-none").await;
+    test_helpers::seed_thread(&pool, "t-query-none", "ws-query-none", None).await;
 
     let board = task_board_manager::create_task_board(
         &pool,
@@ -459,7 +459,7 @@ async fn test_query_task_active_returns_empty_when_no_active_board_exists() {
 async fn test_query_task_all_returns_all_boards_and_active_id() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-query-all", "/tmp/query-all").await;
-    test_helpers::seed_thread(&pool, "t-query-all", "ws-query-all").await;
+    test_helpers::seed_thread(&pool, "t-query-all", "ws-query-all", None).await;
 
     let first_board = task_board_manager::create_task_board(
         &pool,
@@ -511,7 +511,7 @@ async fn test_query_task_all_returns_all_boards_and_active_id() {
 async fn test_cannot_start_already_started_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-sm1", "/tmp/sm1").await;
-    test_helpers::seed_thread(&pool, "t-sm1", "ws-sm1").await;
+    test_helpers::seed_thread(&pool, "t-sm1", "ws-sm1", None).await;
 
     let input = CreateTaskInput {
         title: "SM Test".to_string(),
@@ -542,7 +542,7 @@ async fn test_cannot_start_already_started_step() {
 async fn test_cannot_complete_pending_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-sm2", "/tmp/sm2").await;
-    test_helpers::seed_thread(&pool, "t-sm2", "ws-sm2").await;
+    test_helpers::seed_thread(&pool, "t-sm2", "ws-sm2", None).await;
 
     let input = CreateTaskInput {
         title: "SM Test".to_string(),
@@ -575,7 +575,7 @@ async fn test_cannot_complete_pending_step() {
 async fn test_reconcile_active_board_starts_next_pending_step() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-reconcile", "/tmp/reconcile").await;
-    test_helpers::seed_thread(&pool, "t-reconcile", "ws-reconcile").await;
+    test_helpers::seed_thread(&pool, "t-reconcile", "ws-reconcile", None).await;
 
     let board = task_board_manager::create_task_board(
         &pool,
@@ -623,7 +623,7 @@ async fn test_reconcile_active_board_starts_next_pending_step() {
 async fn test_cannot_update_completed_board() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-sm3", "/tmp/sm3").await;
-    test_helpers::seed_thread(&pool, "t-sm3", "ws-sm3").await;
+    test_helpers::seed_thread(&pool, "t-sm3", "ws-sm3", None).await;
 
     let input = CreateTaskInput {
         title: "SM Test".to_string(),
@@ -677,7 +677,7 @@ async fn test_cannot_update_completed_board() {
 async fn test_task_boards_deleted_with_thread() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-delete", "/tmp/delete").await;
-    test_helpers::seed_thread(&pool, "t-delete", "ws-delete").await;
+    test_helpers::seed_thread(&pool, "t-delete", "ws-delete", None).await;
 
     let input = CreateTaskInput {
         title: "To Delete".to_string(),

--- a/src-tauri/tests/m2_4_worktree.rs
+++ b/src-tauri/tests/m2_4_worktree.rs
@@ -275,7 +275,7 @@ async fn worktree_parent_remove_cascades_children() {
         .expect("create child should succeed");
 
     // Seed a thread for the child worktree to prove cascade cleanup.
-    test_helpers::seed_thread(&pool, "t-child", &child.id).await;
+    test_helpers::seed_thread(&pool, "t-child", &child.id, None).await;
 
     ws_manager
         .remove(&parent.id, false)

--- a/src-tauri/tests/test_helpers.rs
+++ b/src-tauri/tests/test_helpers.rs
@@ -51,14 +51,20 @@ pub async fn seed_workspace(pool: &SqlitePool, id: &str, canonical_path: &str) {
 }
 
 /// Create a thread record for test setup.
-pub async fn seed_thread(pool: &SqlitePool, thread_id: &str, workspace_id: &str) {
+pub async fn seed_thread(
+    pool: &SqlitePool,
+    thread_id: &str,
+    workspace_id: &str,
+    profile_id: Option<&str>,
+) {
     let now = chrono::Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO threads (id, workspace_id, title, status, last_active_at, created_at, updated_at)
-         VALUES (?, ?, 'Test Thread', 'idle', ?, ?, ?)",
+        "INSERT INTO threads (id, workspace_id, profile_id, title, status, last_active_at, created_at, updated_at)
+         VALUES (?, ?, ?, 'Test Thread', 'idle', ?, ?, ?)",
     )
     .bind(thread_id)
     .bind(workspace_id)
+    .bind(profile_id)
     .bind(&now)
     .bind(&now)
     .bind(&now)

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -62,6 +62,7 @@ const en: Record<TranslationKey, string> = {
   "dashboard.error.loadMoreThreads": "Failed to load more threads",
   "dashboard.error.deleteThread": "Failed to delete thread",
   "dashboard.error.createThread": "Failed to create thread",
+"dashboard.error.switchProfile": "Failed to switch agent profile",
 
   // ── Composer ─────────────────────────────────────────────
   "composer.removeAttachment": "Remove attachment {{name}}",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -72,6 +72,8 @@ const en: Record<TranslationKey, string> = {
   "composer.removeFileReference": "Remove file reference {{path}}",
   "composer.uploadFileOrImage": "Upload file or image",
   "composer.noProfileAvailable": "No available profile found.",
+  "composer.profileDeleted": "Profile deleted",
+  "composer.profileDeletedHint": "This thread references a deleted profile. Choose another profile to continue.",
   "composer.profileTier.primary": "Primary",
   "composer.profileTier.auxiliary": "Auxiliary",
   "composer.profileTier.lightweight": "Lightweight",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -70,6 +70,8 @@ const zhCN = {
   "composer.removeFileReference": "移除文件引用 {{path}}",
   "composer.uploadFileOrImage": "上传文件或图片",
   "composer.noProfileAvailable": "未找到可用的 profile。",
+  "composer.profileDeleted": "Profile 已删除",
+  "composer.profileDeletedHint": "当前 thread 绑定的 profile 已被删除，请手动切换到其他 profile 后继续。",
   "composer.profileTier.primary": "主力",
   "composer.profileTier.auxiliary": "辅助",
   "composer.profileTier.lightweight": "轻量",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -60,6 +60,7 @@ const zhCN = {
   "dashboard.error.loadMoreThreads": "加载更多会话失败",
   "dashboard.error.deleteThread": "删除会话失败",
   "dashboard.error.createThread": "创建会话失败",
+"dashboard.error.switchProfile": "切换 Agent 配置文件失败",
 
   // ── Composer ─────────────────────────────────────────────
   "composer.removeAttachment": "移除附件 {{name}}",

--- a/src/modules/settings-center/model/types.ts
+++ b/src/modules/settings-center/model/types.ts
@@ -97,6 +97,8 @@ export type CommandEntry = {
   enabled?: boolean;
   version?: number;
   fileName?: string;
+  /** Client-only flag: entry exists locally but hasn't been persisted to the backend yet. */
+  pendingCreate?: boolean;
 };
 
 export type AgentProfile = {

--- a/src/modules/settings-center/model/use-settings-controller.ts
+++ b/src/modules/settings-center/model/use-settings-controller.ts
@@ -289,6 +289,9 @@ function isTauriNotFoundError(error: unknown): boolean {
   );
 }
 
+/** Track IDs of pending entries whose backend create call is in-flight. */
+const inflightCreateIds = new Set<string>();
+
 function mapProviderDto(provider: ProviderSettingsDto): ProviderEntry {
   return {
     id: provider.id,
@@ -523,7 +526,11 @@ export function useSettingsController() {
               setSettings((current) => ({
                 ...current,
                 commands: {
-                  commands: resolvedPromptCommands.map(mapPromptCommandDto),
+                  // Preserve local-only pending entries that haven't been persisted yet
+                  commands: [
+                    ...resolvedPromptCommands.map(mapPromptCommandDto),
+                    ...current.commands.commands.filter((c) => c.pendingCreate),
+                  ],
                 },
                 policy: mappedPolicy,
                 agentProfiles: persistedProfiles.length > 0 ? persistedProfiles : DEFAULT_AGENT_PROFILES,
@@ -1295,67 +1302,41 @@ export function useSettingsController() {
   };
 
   const addCommand = (entry: Omit<CommandEntry, "id">) => {
-    if (!isTauri()) {
-      setSettings((current) => ({
-        ...current,
-        commands: {
-          ...current.commands,
-          commands: [...current.commands.commands, { ...entry, id: crypto.randomUUID() }],
-        },
-      }));
-      return;
-    }
-
-    void promptCommandCreate({
-      name: entry.name,
-      path: entry.path,
-      argumentHint: entry.argumentHint,
-      description: entry.description,
-      prompt: entry.prompt,
-      source: entry.source ?? "user",
-      enabled: entry.enabled ?? true,
-      version: entry.version ?? 1,
-    })
-      .then((command) => {
-        const mapped = mapPromptCommandDto(command);
-        setSettings((current) => ({
-          ...current,
-          commands: {
-            ...current.commands,
-            commands: [...current.commands.commands, mapped],
-          },
-        }));
-      })
-      .catch((error) => {
-        console.warn("Failed to create prompt command", error);
-      });
+    // Always create a local entry first. In Tauri mode, mark it as pending
+    // so the backend create is deferred until the user fills in a valid name.
+    const tempId = crypto.randomUUID();
+    setSettings((current) => ({
+      ...current,
+      commands: {
+        ...current.commands,
+        commands: [
+          ...current.commands.commands,
+          { ...entry, id: tempId, pendingCreate: isTauri() ? true : undefined },
+        ],
+      },
+    }));
   };
 
   const removeCommand = (id: string) => {
-    if (!isTauri()) {
-      setSettings((current) => ({
-        ...current,
-        commands: {
-          ...current.commands,
-          commands: current.commands.commands.filter((cmd) => cmd.id !== id),
-        },
-      }));
+    const cmd = settingsRef.current.commands.commands.find((c) => c.id === id);
+
+    // Always remove from local state immediately
+    setSettings((current) => ({
+      ...current,
+      commands: {
+        ...current.commands,
+        commands: current.commands.commands.filter((c) => c.id !== id),
+      },
+    }));
+
+    // Pending entries were never persisted — skip backend delete
+    if (!isTauri() || cmd?.pendingCreate) {
       return;
     }
 
-    void promptCommandDelete(id)
-      .then(() => {
-        setSettings((current) => ({
-          ...current,
-          commands: {
-            ...current.commands,
-            commands: current.commands.commands.filter((cmd) => cmd.id !== id),
-          },
-        }));
-      })
-      .catch((error) => {
-        console.warn("Failed to delete prompt command", error);
-      });
+    void promptCommandDelete(id).catch((error) => {
+      console.warn("Failed to delete prompt command", error);
+    });
   };
 
   const updateCommand = (id: string, patch: Partial<Omit<CommandEntry, "id">>) => {
@@ -1365,17 +1346,69 @@ export function useSettingsController() {
     }
 
     const nextCommand = { ...currentCommand, ...patch };
+    // Strip the client-only pendingCreate flag unless we need to keep it
+    // (i.e. the entry is still pending and name is still empty).
+    const isPending = currentCommand.pendingCreate;
+    const shouldKeepPending = isPending && !nextCommand.name.trim();
+    const cleanCommand = shouldKeepPending
+      ? { ...nextCommand, pendingCreate: true as const }
+      : (({ pendingCreate: _, ...rest }) => rest)({ ...nextCommand });
+
     setSettings((current) => ({
       ...current,
       commands: {
         ...current.commands,
         commands: current.commands.commands.map((cmd) =>
-          cmd.id === id ? nextCommand : cmd,
+          cmd.id === id ? cleanCommand : cmd,
         ),
       },
     }));
 
     if (!isTauri()) {
+      return;
+    }
+
+    // If this entry is still pending (not yet persisted to backend),
+    // either defer — name is still empty — or create it now.
+    if (currentCommand.pendingCreate) {
+      if (!nextCommand.name.trim()) {
+        // Name still empty — keep the entry local-only
+        return;
+      }
+      // Already creating in flight — skip duplicate backend call
+      if (inflightCreateIds.has(id)) {
+        return;
+      }
+      // Name is valid — persist to backend for the first time
+      inflightCreateIds.add(id);
+      void promptCommandCreate({
+        name: nextCommand.name,
+        path: nextCommand.path,
+        argumentHint: nextCommand.argumentHint,
+        description: nextCommand.description,
+        prompt: nextCommand.prompt,
+        source: nextCommand.source ?? "user",
+        enabled: nextCommand.enabled ?? true,
+        version: nextCommand.version ?? 1,
+      })
+        .then((command) => {
+          const mapped = mapPromptCommandDto(command);
+          setSettings((current) => ({
+            ...current,
+            commands: {
+              ...current.commands,
+              commands: current.commands.commands.map((entry) =>
+                entry.id === id ? mapped : entry,
+              ),
+            },
+          }));
+        })
+        .catch((error) => {
+          console.warn("Failed to create prompt command", error);
+        })
+        .finally(() => {
+          inflightCreateIds.delete(id);
+        });
       return;
     }
 

--- a/src/modules/workbench-shell/model/helpers.ts
+++ b/src/modules/workbench-shell/model/helpers.ts
@@ -389,6 +389,7 @@ export function buildWorkspaceThreadItem(
 
   return {
     id: thread.id,
+    profileId: thread.profileId,
     name: displayTitle,
     time: formatThreadTimeLabel(thread.lastActiveAt || thread.createdAt, language),
     active: thread.id === activeThreadId,

--- a/src/modules/workbench-shell/model/types.ts
+++ b/src/modules/workbench-shell/model/types.ts
@@ -9,6 +9,7 @@ export type ThreadItem = {
 
 export type WorkspaceThreadItem = ThreadItem & {
   id: string;
+  profileId?: string | null;
 };
 
 export type WorkspaceItem = {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
@@ -15,6 +15,10 @@ describe("resolveThreadProfileId", () => {
   it("preserves deleted profile ids instead of silently falling back", () => {
     expect(resolveThreadProfileId("p-deleted", globalActive)).toBe("p-deleted");
   });
+
+  it("falls back to global active profile when thread profile is an empty string", () => {
+    expect(resolveThreadProfileId("", globalActive)).toBe(globalActive);
+  });
 });
 
 describe("resolveActiveThreadWorkbenchProfileId", () => {
@@ -30,5 +34,9 @@ describe("resolveActiveThreadWorkbenchProfileId", () => {
 
   it("keeps deleted profile ids for existing threads so the UI can show missing state", () => {
     expect(resolveActiveThreadWorkbenchProfileId("p-deleted", globalActive)).toBe("p-deleted");
+  });
+
+  it("falls back to global active profile when thread profile is an empty string", () => {
+    expect(resolveActiveThreadWorkbenchProfileId("", globalActive)).toBe(globalActive);
   });
 });

--- a/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
@@ -2,126 +2,33 @@ import { describe, expect, it } from "vitest";
 import { resolveThreadProfileId, resolveActiveThreadWorkbenchProfileId } from "./dashboard-workbench";
 
 describe("resolveThreadProfileId", () => {
-  const profileIds = new Set(["p-1", "p-2", "p-3", "p-global"]);
   const globalActive = "p-global";
-  const firstProfile = "p-1";
 
-  it("returns global active when threadId is null", () => {
-    expect(
-      resolveThreadProfileId(null, { "t-1": "p-2" }, profileIds, globalActive, firstProfile),
-    ).toBe(globalActive);
+  it("returns the global active profile when the thread has no persisted profile", () => {
+    expect(resolveThreadProfileId(null, globalActive)).toBe(globalActive);
   });
 
-  it("returns global active when thread has no binding", () => {
-    expect(
-      resolveThreadProfileId("t-99", {}, profileIds, globalActive, firstProfile),
-    ).toBe(globalActive);
+  it("returns the persisted thread profile when present", () => {
+    expect(resolveThreadProfileId("p-thread", globalActive)).toBe("p-thread");
   });
 
-  it("returns the bound profile when it exists in profileIds", () => {
-    const bindings = { "t-1": "p-2", "t-2": "p-3" };
-    expect(
-      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, firstProfile),
-    ).toBe("p-2");
-    expect(
-      resolveThreadProfileId("t-2", bindings, profileIds, globalActive, firstProfile),
-    ).toBe("p-3");
-  });
-
-  it("prefers the thread binding over the global active profile", () => {
-    expect(
-      resolveThreadProfileId("t-1", { "t-1": "p-2" }, profileIds, "p-3", firstProfile),
-    ).toBe("p-2");
-  });
-
-  it("falls back to firstProfileId when bound profile was deleted", () => {
-    const bindings = { "t-1": "p-deleted" };
-    expect(
-      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, firstProfile),
-    ).toBe(firstProfile);
-  });
-
-  it("falls back to globalActive when bound profile was deleted and firstProfileId is null", () => {
-    const bindings = { "t-1": "p-deleted" };
-    expect(
-      resolveThreadProfileId("t-1", bindings, profileIds, globalActive, null),
-    ).toBe(globalActive);
-  });
-
-  it("returns global active when profileIds is empty and no binding", () => {
-    expect(
-      resolveThreadProfileId("t-1", {}, new Set(), globalActive, null),
-    ).toBe(globalActive);
-  });
-
-  it("falls back correctly when profileIds is empty but binding exists", () => {
-    const bindings = { "t-1": "p-1" };
-    expect(
-      resolveThreadProfileId("t-1", bindings, new Set(), globalActive, null),
-    ).toBe(globalActive);
+  it("preserves deleted profile ids instead of silently falling back", () => {
+    expect(resolveThreadProfileId("p-deleted", globalActive)).toBe("p-deleted");
   });
 });
 
 describe("resolveActiveThreadWorkbenchProfileId", () => {
-  const profileIds = new Set(["p-1", "p-2", "p-3", "p-global"]);
   const globalActive = "p-global";
-  const firstProfile = "p-1";
 
   it("uses the global active profile in new thread mode", () => {
-    expect(
-      resolveActiveThreadWorkbenchProfileId(null, {}, null, profileIds, globalActive, firstProfile),
-    ).toBe(globalActive);
+    expect(resolveActiveThreadWorkbenchProfileId(null, globalActive)).toBe(globalActive);
   });
 
-  it("prefers the persisted binding over the temporary active thread override", () => {
-    expect(
-      resolveActiveThreadWorkbenchProfileId(
-        "t-1",
-        { "t-1": "p-2" },
-        "p-3",
-        profileIds,
-        globalActive,
-        firstProfile,
-      ),
-    ).toBe("p-2");
+  it("uses the thread persisted profile for existing threads", () => {
+    expect(resolveActiveThreadWorkbenchProfileId("p-thread", globalActive)).toBe("p-thread");
   });
 
-  it("uses the persisted binding for an existing thread when no override is set", () => {
-    expect(
-      resolveActiveThreadWorkbenchProfileId(
-        "t-1",
-        { "t-1": "p-2" },
-        null,
-        profileIds,
-        globalActive,
-        firstProfile,
-      ),
-    ).toBe("p-2");
-  });
-
-  it("keeps the active thread override when the global active profile changes", () => {
-    expect(
-      resolveActiveThreadWorkbenchProfileId(
-        "t-1",
-        {},
-        "p-2",
-        profileIds,
-        "p-3",
-        firstProfile,
-      ),
-    ).toBe("p-2");
-  });
-
-  it("falls back to the first profile when the remembered binding was deleted", () => {
-    expect(
-      resolveActiveThreadWorkbenchProfileId(
-        "t-1",
-        {},
-        "p-deleted",
-        profileIds,
-        globalActive,
-        firstProfile,
-      ),
-    ).toBe(firstProfile);
+  it("keeps deleted profile ids for existing threads so the UI can show missing state", () => {
+    expect(resolveActiveThreadWorkbenchProfileId("p-deleted", globalActive)).toBe("p-deleted");
   });
 });

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -2012,12 +2012,31 @@ export function DashboardWorkbench() {
     setRecentProjects((current) => mergeRecentProjects(current, nextProject));
   };
 
-  const handleNewThreadForWorkspace = (workspace: WorkspaceItem) => {
+  const activateWorkspaceAsNewThreadTarget = useCallback(
+    (workspaceId: string, nextProject: ProjectOption) => {
+      clearNewThreadBindingForWorkspace(workspaceId);
+      deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
+      setSelectedProject(nextProject);
+      setRecentProjects((current) => mergeRecentProjects(current, nextProject));
+      setOpenWorkspaces((current) => ({
+        ...current,
+        [workspaceId]: true,
+      }));
+      setActiveThreadProfileIdOverride(null);
+      setNewThreadMode(true);
+      setWorkspaces((current) => clearActiveThreads(current));
+      setComposerError(null);
+      setPendingDeleteThreadId(null);
+      setTerminalBootstrapError(null);
+      setActiveWorkspaceMenuId(null);
+    },
+    [clearNewThreadBindingForWorkspace],
+  );
+
+  const handleNewThreadForWorkspace = useCallback((workspace: WorkspaceItem) => {
     if (!workspace.path) {
       return;
     }
-
-    clearNewThreadBindingForWorkspace(workspace.id);
 
     const projectFromPath = buildProjectOptionFromPath(workspace.path, language);
     const nextProject: ProjectOption = {
@@ -2043,21 +2062,8 @@ export function DashboardWorkbench() {
       branch: workspace.branch,
     };
 
-    deleteRemovedWorkspacePath(removedWorkspacePathsRef.current, nextProject.path);
-    setSelectedProject(nextProject);
-    setRecentProjects((current) => mergeRecentProjects(current, nextProject));
-    setOpenWorkspaces((current) => ({
-      ...current,
-      [workspace.id]: true,
-    }));
-    setActiveThreadProfileIdOverride(null);
-    setNewThreadMode(true);
-    setWorkspaces((current) => clearActiveThreads(current));
-    setComposerError(null);
-    setPendingDeleteThreadId(null);
-    setTerminalBootstrapError(null);
-    setActiveWorkspaceMenuId(null);
-  };
+    activateWorkspaceAsNewThreadTarget(workspace.id, nextProject);
+  }, [activateWorkspaceAsNewThreadTarget, language, t]);
 
   const updateActiveThreadStatus = useCallback(
     (status: WorkbenchThreadStatus) => {
@@ -2603,12 +2609,16 @@ export function DashboardWorkbench() {
         const workspace =
           existingWorkspace ??
           (await workspaceAdd(selectedPath, nextProject.name));
+        const workspaceProject =
+          buildProjectOptionFromWorkspace(workspace, language) ?? {
+            ...nextProject,
+            id: workspace.id,
+            name: workspace.name,
+            path: workspace.canonicalPath || workspace.path,
+          };
 
+        activateWorkspaceAsNewThreadTarget(workspace.id, workspaceProject);
         await syncWorkspaceSidebar();
-        setOpenWorkspaces((current) => ({
-          ...current,
-          [workspace.id]: true,
-        }));
       } catch (error) {
         const message = getInvokeErrorMessage(error, "Failed to add workspace");
         setTerminalBootstrapError(message);
@@ -2616,7 +2626,12 @@ export function DashboardWorkbench() {
         setAddingWorkspace(false);
       }
     })();
-  }, [isAddingWorkspace, syncWorkspaceSidebar]);
+  }, [
+    activateWorkspaceAsNewThreadTarget,
+    isAddingWorkspace,
+    language,
+    syncWorkspaceSidebar,
+  ]);
 
   const handleWorkspaceMenuToggle = (workspaceId: string) => {
     setActiveWorkspaceMenuId((current) =>
@@ -3744,7 +3759,21 @@ export function DashboardWorkbench() {
       <NewWorktreeDialog
         context={worktreeDialogContext}
         onClose={() => setWorktreeDialogContext(null)}
-        onCreated={() => {
+        onCreated={(workspace) => {
+          const nextProject =
+            buildProjectOptionFromWorkspace(workspace, language) ?? {
+              id: workspace.id,
+              name: workspace.name,
+              path: workspace.canonicalPath || workspace.path,
+              lastOpenedLabel: t("time.justNow"),
+              kind: workspace.kind,
+              parentWorkspaceId: workspace.parentWorkspaceId,
+              worktreeHash: workspace.worktreeName
+                ? workspace.worktreeName.slice(0, 6)
+                : null,
+              branch: workspace.branch,
+            };
+          activateWorkspaceAsNewThreadTarget(workspace.id, nextProject);
           void syncWorkspaceSidebar().catch(() => {});
         }}
       />

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -55,11 +55,10 @@ import type {
   WorkspaceDto,
 } from "@/shared/types/api";
 import {
-  settingsGet,
-  settingsSet,
   threadCreate,
   threadDelete,
   threadList,
+  threadUpdateProfile,
   threadUpdateTitle,
   threadRegenerateTitle,
   workspaceAdd,
@@ -157,53 +156,22 @@ const SIDEBAR_AUTO_REFRESH_GRACE_MS = 20_000;
 /**
  * Resolve which profile the workbench should use for a given thread context.
  *
- * Priority:
- *  1. Global active profile when no thread is selected yet (new thread mode).
- *  2. Persisted binding for this thread, if the profile still exists.
- *  3. Global active profile when this thread has no binding yet.
- *  4. First profile in the list when the bound profile was deleted.
+ * New thread mode uses the global current profile. Existing threads use their
+ * persisted thread-level profile_id; deleted profile ids are preserved so the
+ * UI can render a missing-profile state instead of silently falling back.
  */
 export function resolveThreadProfileId(
-  threadId: string | null,
-  bindings: Record<string, string>,
-  profileIds: ReadonlySet<string>,
+  threadProfileId: string | null,
   globalActiveProfileId: string,
-  firstProfileId: string | null,
 ): string {
-  if (!threadId) return globalActiveProfileId;
-  const boundId = bindings[threadId];
-  if (!boundId) return globalActiveProfileId;
-  if (profileIds.has(boundId)) return boundId;
-  // Bound profile was deleted → fall back to first available profile.
-  return firstProfileId ?? globalActiveProfileId;
+  return threadProfileId ?? globalActiveProfileId;
 }
 
 export function resolveActiveThreadWorkbenchProfileId(
-  threadId: string | null,
-  persistedBindings: Record<string, string>,
-  activeThreadProfileOverride: string | null,
-  profileIds: ReadonlySet<string>,
+  threadProfileId: string | null,
   globalActiveProfileId: string,
-  firstProfileId: string | null,
 ): string {
-  if (!threadId) {
-    return globalActiveProfileId;
-  }
-
-  const persistedBoundId = persistedBindings[threadId];
-  if (persistedBoundId) {
-    return profileIds.has(persistedBoundId)
-      ? persistedBoundId
-      : (firstProfileId ?? globalActiveProfileId);
-  }
-
-  if (activeThreadProfileOverride) {
-    return profileIds.has(activeThreadProfileOverride)
-      ? activeThreadProfileOverride
-      : (firstProfileId ?? globalActiveProfileId);
-  }
-
-  return globalActiveProfileId;
+  return threadProfileId ?? globalActiveProfileId;
 }
 
 function buildInitialWorkspaceThreadDisplayCounts() {
@@ -685,11 +653,7 @@ export function DashboardWorkbench() {
   const [terminalThreadBindings, setTerminalThreadBindings] = useState<
     Record<string, string>
   >({});
-  const [threadProfileBindings, setThreadProfileBindings] = useState<
-    Record<string, string>
-  >({});
   const [activeThreadProfileIdOverride, setActiveThreadProfileIdOverride] = useState<string | null>(null);
-  const threadProfileBindingsLoadedRef = useRef(false);
   const [composerValue, setComposerValue] = useState("");
   const [composerDrafts, setComposerDrafts] = useState<Record<string, string>>({});
   const [composerError, setComposerError] = useState<string | null>(null);
@@ -779,11 +743,6 @@ export function DashboardWorkbench() {
   const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
   const activeThread = getActiveThread(workspaces);
-  const profileIdSet = useMemo(
-    () => new Set(agentProfiles.map((p) => p.id)),
-    [agentProfiles],
-  );
-  const firstProfileId = agentProfiles[0]?.id ?? null;
   const selectedProjectWorkspaceId = getWorkspaceBindingId(
     terminalWorkspaceBindings,
     selectedProject?.path ?? null,
@@ -834,22 +793,10 @@ export function DashboardWorkbench() {
   const workbenchActiveProfileId = useMemo(
     () =>
       resolveActiveThreadWorkbenchProfileId(
-        isNewThreadMode ? null : (activeThread?.id ?? null),
-        threadProfileBindings,
-        activeThreadProfileIdOverride,
-        profileIdSet,
+        isNewThreadMode ? null : activeThreadProfileIdOverride,
         activeAgentProfileId,
-        firstProfileId,
       ),
-    [
-      activeAgentProfileId,
-      activeThread?.id,
-      activeThreadProfileIdOverride,
-      firstProfileId,
-      isNewThreadMode,
-      profileIdSet,
-      threadProfileBindings,
-    ],
+    [activeAgentProfileId, activeThreadProfileIdOverride, isNewThreadMode],
   );
   const selectedRunModelPlan = useMemo(
     () =>
@@ -861,11 +808,14 @@ export function DashboardWorkbench() {
     [workbenchActiveProfileId, agentProfiles, providers],
   );
   const workbenchActiveAgentProfile = useMemo(
-    () =>
-      agentProfiles.find((profile) => profile.id === workbenchActiveProfileId) ??
-      agentProfiles[0] ??
-      null,
-    [workbenchActiveProfileId, agentProfiles],
+    () => {
+      const matchedProfile = agentProfiles.find((profile) => profile.id === workbenchActiveProfileId) ?? null;
+      if (matchedProfile) {
+        return matchedProfile;
+      }
+      return isNewThreadMode ? (agentProfiles[0] ?? null) : null;
+    },
+    [workbenchActiveProfileId, agentProfiles, isNewThreadMode],
   );
   const commitMessageModelPlan = useMemo(
     () =>
@@ -1077,8 +1027,22 @@ export function DashboardWorkbench() {
         return inFlight;
       }
 
-      const creationPromise = threadCreate(workspaceId, "")
+      const creationPromise = threadCreate(workspaceId, "", activeAgentProfileId)
         .then((thread) => {
+          setActiveThreadProfileIdOverride(thread.profileId ?? activeAgentProfileId);
+          setWorkspaces((current) =>
+            current.map((workspace) => ({
+              ...workspace,
+              threads: workspace.threads.map((candidate) =>
+                candidate.id === thread.id
+                  ? {
+                      ...candidate,
+                      profileId: thread.profileId,
+                    }
+                  : candidate,
+              ),
+            })),
+          );
           setTerminalThreadBindings((current) => {
             const bindingKey = getNewThreadTerminalBindingKey(workspaceId);
             if (current[bindingKey] === thread.id) {
@@ -1107,7 +1071,7 @@ export function DashboardWorkbench() {
 
       return creationPromise;
     },
-    [terminalThreadBindings],
+    [activeAgentProfileId, terminalThreadBindings],
   );
 
   useEffect(() => {
@@ -1470,24 +1434,6 @@ export function DashboardWorkbench() {
       await waitForBackendReady();
       if (cancelled) return;
 
-      // Hydrate thread-profile bindings from backend KV
-      try {
-        const stored = await settingsGet("thread_profile_bindings");
-        if (!cancelled && stored?.value) {
-          const parsed = JSON.parse(String(stored.value));
-          if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-            // Mark to skip the persistence effect that will fire from this setState.
-            threadProfileBindingsSkipNextPersistRef.current = true;
-            setThreadProfileBindings(parsed as Record<string, string>);
-          }
-        }
-      } catch {
-        // Ignore corrupted JSON – fall back to empty bindings
-      }
-      if (!cancelled) {
-        threadProfileBindingsLoadedRef.current = true;
-      }
-
       await syncWorkspaceSidebar();
     })()
       .then(() => {
@@ -1509,53 +1455,6 @@ export function DashboardWorkbench() {
       cancelled = true;
     };
   }, [syncWorkspaceSidebar]);
-
-  // Persist thread-profile bindings to backend KV whenever they change.
-  const threadProfileBindingsSkipNextPersistRef = useRef(false);
-  useEffect(() => {
-    if (!threadProfileBindingsLoadedRef.current) return;
-    if (!isTauri()) return;
-
-    // Skip the write triggered immediately after hydration (same data).
-    if (threadProfileBindingsSkipNextPersistRef.current) {
-      threadProfileBindingsSkipNextPersistRef.current = false;
-      return;
-    }
-
-    // Cap to most recent 200 entries (by insertion order, which is recent-enough for UUIDv7 keys).
-    const MAX_THREAD_PROFILE_BINDINGS = 200;
-    const entries = Object.entries(threadProfileBindings);
-    const trimmed =
-      entries.length > MAX_THREAD_PROFILE_BINDINGS
-        ? Object.fromEntries(entries.slice(-MAX_THREAD_PROFILE_BINDINGS))
-        : threadProfileBindings;
-
-    void settingsSet("thread_profile_bindings", JSON.stringify(trimmed)).catch(
-      () => {
-        // Best-effort persistence — silently ignore write failures.
-      },
-    );
-  }, [threadProfileBindings]);
-
-  // Remove thread-profile bindings that reference a deleted profile.
-  useEffect(() => {
-    if (!agentProfiles.length) return;
-    setThreadProfileBindings((current) => {
-      let changed = false;
-      const next: Record<string, string> = {};
-      for (const [tid, pid] of Object.entries(current)) {
-        if (profileIdSet.has(pid)) {
-          next[tid] = pid;
-        } else {
-          changed = true;
-        }
-      }
-      return changed ? next : current;
-    });
-    setActiveThreadProfileIdOverride((current) =>
-      current && !profileIdSet.has(current) ? null : current,
-    );
-  }, [agentProfiles, profileIdSet]);
 
   useEffect(() => {
     if (!terminalResize || typeof window === "undefined") {
@@ -1964,12 +1863,12 @@ export function DashboardWorkbench() {
     if (isNewThreadMode && selectedProjectWorkspaceId) {
       clearNewThreadBindingForWorkspace(selectedProjectWorkspaceId);
     }
+    const nextActiveThread = workspaces
+      .flatMap((workspace) => workspace.threads)
+      .find((thread) => thread.id === threadId) ?? null;
     const resolvedProfileId = resolveThreadProfileId(
-      threadId,
-      threadProfileBindings,
-      profileIdSet,
+      nextActiveThread?.profileId ?? null,
       activeAgentProfileId,
-      firstProfileId,
     );
     setActiveThreadProfileIdOverride(resolvedProfileId);
     setNewThreadMode(false);
@@ -2247,12 +2146,6 @@ export function DashboardWorkbench() {
             );
             return next;
           });
-          setThreadProfileBindings((current) => {
-            if (!(threadId in current)) return current;
-            const next = { ...current };
-            delete next[threadId];
-            return next;
-          });
 
           if (isDeletingActiveThread) {
             setSelectedProject((current) => activeThreadProject ?? current);
@@ -2391,13 +2284,13 @@ export function DashboardWorkbench() {
             : (terminalThreadBindings[
                 getNewThreadTerminalBindingKey(nextWorkspaceId)
               ] ?? null);
+        let persistedThreadProfileId = activeAgentProfileId;
         const nextThreadName = buildThreadTitle(trimmedValue || effectivePrompt);
 
         try {
           if (isTauri() && nextWorkspaceId) {
             if (!persistedThreadId) {
-              persistedThreadId =
-                await getOrCreateNewThreadId(nextWorkspaceId);
+              persistedThreadId = await getOrCreateNewThreadId(nextWorkspaceId);
             }
           }
         } catch (error) {
@@ -2408,6 +2301,7 @@ export function DashboardWorkbench() {
 
         const nextThread = {
           id: persistedThreadId ?? `${project.id}-thread-${Date.now()}`,
+          profileId: persistedThreadProfileId,
           name: nextThreadName,
           time: t("time.justNow"),
           active: true,
@@ -2501,10 +2395,19 @@ export function DashboardWorkbench() {
 
         // Bind the current profile to the newly created thread.
         if (persistedThreadId) {
-          setThreadProfileBindings((current) => ({
-            ...current,
-            [persistedThreadId]: activeAgentProfileId,
-          }));
+          setWorkspaces((current) =>
+            current.map((workspace) => ({
+              ...workspace,
+              threads: workspace.threads.map((thread) =>
+                thread.id === persistedThreadId
+                  ? {
+                      ...thread,
+                      profileId: activeAgentProfileId,
+                    }
+                  : thread,
+              ),
+            })),
+          );
           setActiveThreadProfileIdOverride(activeAgentProfileId);
         }
 
@@ -2546,16 +2449,26 @@ export function DashboardWorkbench() {
   // change scoped to that thread. New-thread mode still updates the global
   // default profile because it defines the profile new conversations inherit.
   const handleSelectAgentProfileForThread = useCallback(
-    (profileId: string) => {
+    async (profileId: string) => {
       if (isNewThreadMode || !activeThread?.id) {
         setActiveAgentProfile(profileId);
         return;
       }
 
-      setThreadProfileBindings((current) => ({
-        ...current,
-        [activeThread.id]: profileId,
-      }));
+      await threadUpdateProfile(activeThread.id, profileId);
+      setWorkspaces((current) =>
+        current.map((workspace) => ({
+          ...workspace,
+          threads: workspace.threads.map((thread) =>
+            thread.id === activeThread.id
+              ? {
+                  ...thread,
+                  profileId,
+                }
+              : thread,
+          ),
+        })),
+      );
       setActiveThreadProfileIdOverride(profileId);
     },
     [activeThread?.id, isNewThreadMode, setActiveAgentProfile],

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -164,14 +164,14 @@ export function resolveThreadProfileId(
   threadProfileId: string | null,
   globalActiveProfileId: string,
 ): string {
-  return threadProfileId ?? globalActiveProfileId;
+  return threadProfileId || globalActiveProfileId;
 }
 
 export function resolveActiveThreadWorkbenchProfileId(
   threadProfileId: string | null,
   globalActiveProfileId: string,
 ): string {
-  return threadProfileId ?? globalActiveProfileId;
+  return threadProfileId || globalActiveProfileId;
 }
 
 function buildInitialWorkspaceThreadDisplayCounts() {
@@ -2284,6 +2284,9 @@ export function DashboardWorkbench() {
             : (terminalThreadBindings[
                 getNewThreadTerminalBindingKey(nextWorkspaceId)
               ] ?? null);
+        // Intentional: new-thread mode always uses the global active profile as the
+        // default for the new conversation; switching to an existing thread reads
+        // its own persisted profile_id via resolveThreadProfileId instead.
         let persistedThreadProfileId = activeAgentProfileId;
         const nextThreadName = buildThreadTitle(trimmedValue || effectivePrompt);
 
@@ -2455,7 +2458,14 @@ export function DashboardWorkbench() {
         return;
       }
 
-      await threadUpdateProfile(activeThread.id, profileId);
+      try {
+        await threadUpdateProfile(activeThread.id, profileId);
+      } catch (error) {
+        const message = getInvokeErrorMessage(error, t("dashboard.error.switchProfile"));
+        setComposerError(message);
+        return;
+      }
+
       setWorkspaces((current) =>
         current.map((workspace) => ({
           ...workspace,

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2042,7 +2042,6 @@ function getRoleSpacingClass(
 }
 
 const BASE_CONVERSATION_BOTTOM_PADDING = 40;
-const ACTIVE_TASK_BOARD_SPACING = 16;
 
 export function RuntimeThreadSurface({
   activeAgentProfileId,
@@ -2101,7 +2100,6 @@ export function RuntimeThreadSurface({
   const [tools, setTools] = useState<Array<SurfaceToolEntry>>([]);
   const [completedToolOpen, setCompletedToolOpen] = useState<Record<string, boolean>>({});
   const [taskBoards, setTaskBoards] = useState<TaskBoardState>(initialTaskBoardState);
-  const [activeTaskBoardHeight, setActiveTaskBoardHeight] = useState(0);
   const previousHelperStatusesRef = useRef<Record<string, SurfaceHelperEntry["status"]>>({});
   const previousToolStatesRef = useRef<Record<string, SurfaceToolState>>({});
   const snapshotLoadRequestRef = useRef(0);
@@ -2113,7 +2111,6 @@ export function RuntimeThreadSurface({
   const thinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preserveContextUsageOnNextEmptySnapshotRef = useRef(false);
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
-  const activeTaskBoardRef = useRef<HTMLDivElement | null>(null);
 
   const clearScheduledThinkingPhase = useCallback(() => {
     if (thinkingTimerRef.current !== null) {
@@ -3214,40 +3211,8 @@ export function RuntimeThreadSurface({
     : queueArtifact || showThinkingIndicator
       ? "assistant"
       : lastPresentationRole;
-  const activeTaskBoardBottomPadding = taskBoards.activeBoard
-    ? activeTaskBoardHeight + ACTIVE_TASK_BOARD_SPACING
-    : 0;
-  const conversationBottomPadding = BASE_CONVERSATION_BOTTOM_PADDING + activeTaskBoardBottomPadding;
 
-  useEffect(() => {
-    const element = activeTaskBoardRef.current;
-
-    if (!taskBoards.activeBoard || !element) {
-      setActiveTaskBoardHeight(0);
-      return;
-    }
-
-    const syncHeight = () => {
-      const nextHeight = Math.ceil(element.getBoundingClientRect().height);
-      setActiveTaskBoardHeight((current) => (current === nextHeight ? current : nextHeight));
-    };
-
-    syncHeight();
-
-    if (typeof ResizeObserver === "undefined") {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      syncHeight();
-    });
-
-    observer.observe(element);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [taskBoards.activeBoard?.id]);
+  const conversationBottomPadding = BASE_CONVERSATION_BOTTOM_PADDING;
 
   useEffect(() => {
     const previousToolStates = previousToolStatesRef.current;
@@ -4412,7 +4377,6 @@ export function RuntimeThreadSurface({
           {taskBoards.activeBoard ? (
             <div
               className="overflow-hidden rounded-t-[24px] rounded-b-none border border-b-0 border-app-border/80 bg-app-menu/96 px-2 pb-0 pt-2 shadow-[0_26px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur-xl"
-              ref={activeTaskBoardRef}
             >
               <TaskBoardCard
                 board={taskBoards.activeBoard}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2041,6 +2041,9 @@ function getRoleSpacingClass(
   return previousRole === currentRole ? "pt-3" : "pt-6";
 }
 
+const BASE_CONVERSATION_BOTTOM_PADDING = 40;
+const ACTIVE_TASK_BOARD_SPACING = 16;
+
 export function RuntimeThreadSurface({
   activeAgentProfileId,
   agentProfiles,
@@ -2097,6 +2100,7 @@ export function RuntimeThreadSurface({
   const [tools, setTools] = useState<Array<SurfaceToolEntry>>([]);
   const [completedToolOpen, setCompletedToolOpen] = useState<Record<string, boolean>>({});
   const [taskBoards, setTaskBoards] = useState<TaskBoardState>(initialTaskBoardState);
+  const [activeTaskBoardHeight, setActiveTaskBoardHeight] = useState(0);
   const previousHelperStatusesRef = useRef<Record<string, SurfaceHelperEntry["status"]>>({});
   const previousToolStatesRef = useRef<Record<string, SurfaceToolState>>({});
   const snapshotLoadRequestRef = useRef(0);
@@ -2108,6 +2112,7 @@ export function RuntimeThreadSurface({
   const thinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preserveContextUsageOnNextEmptySnapshotRef = useRef(false);
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
+  const activeTaskBoardRef = useRef<HTMLDivElement | null>(null);
 
   const clearScheduledThinkingPhase = useCallback(() => {
     if (thinkingTimerRef.current !== null) {
@@ -3182,7 +3187,7 @@ export function RuntimeThreadSurface({
 
   // Show the thinking indicator at the bottom when the run is active and no
   // tool / helper / streaming-message is already occupying the "latest action"
-  // slot.  Because this is derived from render-time state rather than toggled
+  // slot. Because this is derived from render-time state rather than toggled
   // by individual stream events, it survives React 18 batching that would
   // otherwise swallow a create+clear in the same frame.
   const hasActiveToolOrHelper =
@@ -3197,7 +3202,47 @@ export function RuntimeThreadSurface({
     showThinkingIndicator ? lastPresentationRole : null;
   const queuePreviousRole: TimelineRole | null =
     showThinkingIndicator ? "assistant" : lastPresentationRole;
-  const runtimeErrorPreviousRole: TimelineRole | null = queueArtifact ? "assistant" : lastPresentationRole;
+  const hasTaskHistoryTimeline = taskBoards.boards.some((board) => board.status !== "active");
+  const historyPreviousRole: TimelineRole | null = queueArtifact ? "assistant" : lastPresentationRole;
+  const runtimeErrorPreviousRole: TimelineRole | null = hasTaskHistoryTimeline
+    ? "assistant"
+    : queueArtifact || showThinkingIndicator
+      ? "assistant"
+      : lastPresentationRole;
+  const activeTaskBoardBottomPadding = taskBoards.activeBoard
+    ? activeTaskBoardHeight + ACTIVE_TASK_BOARD_SPACING
+    : 0;
+  const conversationBottomPadding = BASE_CONVERSATION_BOTTOM_PADDING + activeTaskBoardBottomPadding;
+
+  useEffect(() => {
+    const element = activeTaskBoardRef.current;
+
+    if (!taskBoards.activeBoard || !element) {
+      setActiveTaskBoardHeight(0);
+      return;
+    }
+
+    const syncHeight = () => {
+      const nextHeight = Math.ceil(element.getBoundingClientRect().height);
+      setActiveTaskBoardHeight((current) => (current === nextHeight ? current : nextHeight));
+    };
+
+    syncHeight();
+
+    if (typeof ResizeObserver === "undefined") {
+      return;
+    }
+
+    const observer = new ResizeObserver(() => {
+      syncHeight();
+    });
+
+    observer.observe(element);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [taskBoards.activeBoard?.id]);
 
   useEffect(() => {
     const previousToolStates = previousToolStatesRef.current;
@@ -3825,7 +3870,10 @@ export function RuntimeThreadSurface({
       <div className="pointer-events-none absolute left-1/2 top-0 h-56 w-[72rem] -translate-x-1/2 rounded-full bg-[radial-gradient(circle,rgba(120,180,255,0.11),transparent_68%)] blur-3xl" />
       <div className="relative min-h-0 flex-1">
         <Conversation className="size-full" contextRef={conversationContextRef}>
-          <ConversationContent className="mx-auto w-full max-w-4xl gap-0 px-6 pb-10 pt-8">
+          <ConversationContent
+            className="mx-auto w-full max-w-4xl gap-0 px-6 pt-8"
+            style={{ paddingBottom: `${conversationBottomPadding}px` }}
+          >
             {hasMoreMessages ? (
               <div className="pb-4">
                 <div className="flex flex-col items-center gap-2">
@@ -4314,18 +4362,8 @@ export function RuntimeThreadSurface({
               </div>
             ) : null}
 
-            {taskBoards.activeBoard ? (
-              <div className={getRoleSpacingClass(queueArtifact ? "assistant" : lastPresentationRole, "assistant")}>
-                <Message className="max-w-full" from="assistant">
-                  <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
-                    <TaskBoardCard board={taskBoards.activeBoard} />
-                  </MessageContent>
-                </Message>
-              </div>
-            ) : null}
-
-            {taskBoards.boards.length > 1 ? (
-              <div className={getRoleSpacingClass(taskBoards.activeBoard ? "assistant" : lastPresentationRole, "assistant")}>
+            {hasTaskHistoryTimeline ? (
+              <div className={getRoleSpacingClass(historyPreviousRole, "assistant")}>
                 <Message className="max-w-full" from="assistant">
                   <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
                     <TaskHistoryTimeline boards={taskBoards.boards} />
@@ -4363,6 +4401,16 @@ export function RuntimeThreadSurface({
           <ConversationScrollButton className="bottom-4" />
         </Conversation>
       </div>
+
+      {taskBoards.activeBoard ? (
+        <div className="shrink-0 px-6 pt-4">
+          <div className="mx-auto w-full max-w-4xl">
+            <div ref={activeTaskBoardRef}>
+              <TaskBoardCard board={taskBoards.activeBoard} />
+            </div>
+          </div>
+        </div>
+      ) : null}
 
       <div className="shrink-0 px-6 pb-6 pt-4">
         <WorkbenchPromptComposer

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2063,10 +2063,11 @@ export function RuntimeThreadSurface({
   workspaceId,
 }: RuntimeThreadSurfaceProps) {
   const t = useT();
-  const activeProfile = useMemo(
-    () => agentProfiles.find((profile) => profile.id === activeAgentProfileId) ?? agentProfiles[0] ?? null,
-    [activeAgentProfileId, agentProfiles],
-  );
+  const activeProfile = useMemo(() => {
+    const matchedProfile = agentProfiles.find((profile) => profile.id === activeAgentProfileId) ?? null;
+    return matchedProfile;
+  }, [activeAgentProfileId, agentProfiles]);
+  const hasMissingActiveProfile = Boolean(activeAgentProfileId) && activeProfile === null;
   const [composerError, setComposerError] = useState<string | null>(null);
   const [localComposerValue, setLocalComposerValue] = useState("");
   const composerValue = onComposerDraftChange ? composerDraft : localComposerValue;
@@ -2967,7 +2968,11 @@ export function RuntimeThreadSurface({
     }
 
     if (!activeProfile) {
-      setComposerError("Select an agent profile with an enabled model before starting a run.");
+      setComposerError(
+        hasMissingActiveProfile
+          ? t("composer.profileDeletedHint")
+          : "Select an agent profile with an enabled model before starting a run.",
+      );
       return;
     }
 
@@ -4419,6 +4424,7 @@ export function RuntimeThreadSurface({
           <WorkbenchPromptComposer
             activeAgentProfileId={activeAgentProfileId}
             agentProfiles={agentProfiles}
+            allowMissingActiveProfile
             canSubmitWhenAttachmentsOnly={false}
             className="w-full max-w-none gap-0"
             commands={commands}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -4422,12 +4422,9 @@ export function RuntimeThreadSurface({
             canSubmitWhenAttachmentsOnly={false}
             className="w-full max-w-none gap-0"
             commands={commands}
-            composerShellClassName={cn(
-              "shadow-[0_22px_50px_-42px_rgba(15,23,42,0.38)]",
-              taskBoards.activeBoard
-                ? "rounded-t-none border-t-0"
-                : undefined,
-            )}
+            composerShellClassName={taskBoards.activeBoard
+              ? "rounded-t-none border-t-0"
+              : undefined}
             enabledSkills={enabledSkills}
             error={composerError}
             onErrorMessageChange={setComposerError}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -4402,71 +4402,82 @@ export function RuntimeThreadSurface({
         </Conversation>
       </div>
 
-      {taskBoards.activeBoard ? (
-        <div className="shrink-0 px-6 pt-4">
-          <div className="mx-auto w-full max-w-4xl">
-            <div ref={activeTaskBoardRef}>
-              <TaskBoardCard board={taskBoards.activeBoard} />
-            </div>
-          </div>
-        </div>
-      ) : null}
-
       <div className="shrink-0 px-6 pb-6 pt-4">
-        <WorkbenchPromptComposer
-          activeAgentProfileId={activeAgentProfileId}
-          agentProfiles={agentProfiles}
-          canSubmitWhenAttachmentsOnly={false}
-          commands={commands}
-          enabledSkills={enabledSkills}
-          error={composerError}
-          onErrorMessageChange={setComposerError}
-          onRunModeChange={setSelectedRunMode}
-          onSelectAgentProfile={onSelectAgentProfile}
-          onStop={() => {
-            if (!threadId) {
-              return;
-            }
+        <div className="mx-auto flex w-full max-w-4xl flex-col gap-0">
+          {taskBoards.activeBoard ? (
+            <div
+              className="overflow-hidden rounded-t-[24px] rounded-b-none border border-b-0 border-app-border/80 bg-app-menu/96 px-2 pb-0 pt-2 shadow-[0_26px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur-xl"
+              ref={activeTaskBoardRef}
+            >
+              <TaskBoardCard
+                board={taskBoards.activeBoard}
+                className="rounded-[18px] rounded-b-none border-x-0 border-t-0 border-b border-app-border/55 bg-app-surface/52 px-4 pb-3 pt-3 shadow-none"
+              />
+            </div>
+          ) : null}
 
-            void streamRef.current?.cancelRun(threadId).then(() => {
-              // Optimistic UI update: immediately reflect the cancellation in
-              // the UI so the user sees instant feedback. The backend has
-              // accepted the cancel request but `RunCancelled` may arrive late
-              // if the agent loop is blocked on a long-running HTTP call.
-              completeThinkingPhase();
-              setRunState("cancelled");
-              onRunStateChange?.("cancelled");
+          <WorkbenchPromptComposer
+            activeAgentProfileId={activeAgentProfileId}
+            agentProfiles={agentProfiles}
+            canSubmitWhenAttachmentsOnly={false}
+            className="w-full max-w-none gap-0"
+            commands={commands}
+            composerShellClassName={cn(
+              "shadow-[0_22px_50px_-42px_rgba(15,23,42,0.38)]",
+              taskBoards.activeBoard
+                ? "rounded-t-none border-t-0"
+                : undefined,
+            )}
+            enabledSkills={enabledSkills}
+            error={composerError}
+            onErrorMessageChange={setComposerError}
+            onRunModeChange={setSelectedRunMode}
+            onSelectAgentProfile={onSelectAgentProfile}
+            onStop={() => {
+              if (!threadId) {
+                return;
+              }
 
-              // Safety net: if the backend event (`run_cancelled`) hasn't
-              // arrived within 5 seconds, force a snapshot reload to reconcile
-              // the UI with the actual backend state.
-              const timer = setTimeout(() => {
+              void streamRef.current?.cancelRun(threadId).then(() => {
+                // Optimistic UI update: immediately reflect the cancellation in
+                // the UI so the user sees instant feedback. The backend has
+                // accepted the cancel request but `RunCancelled` may arrive late
+                // if the agent loop is blocked on a long-running HTTP call.
+                completeThinkingPhase();
+                setRunState("cancelled");
+                onRunStateChange?.("cancelled");
+
+                // Safety net: if the backend event (`run_cancelled`) hasn't
+                // arrived within 5 seconds, force a snapshot reload to reconcile
+                // the UI with the actual backend state.
+                const timer = setTimeout(() => {
+                  void loadSnapshot();
+                }, 5_000);
+
+                // If the stream delivers a terminal event before the timeout,
+                // the next `onRunStateChange` + `loadSnapshot` will render the
+                // correct state and this timer becomes a harmless no-op.
+                return () => clearTimeout(timer);
+              }).catch(() => {
+                // The cancel request failed — most likely the run already
+                // finished on the backend but the terminal event was lost or
+                // hasn't arrived yet.  Reload the snapshot to reconcile the
+                // UI with the actual backend state.
                 void loadSnapshot();
-              }, 5_000);
-
-              // If the stream delivers a terminal event before the timeout,
-              // the next `onRunStateChange` + `loadSnapshot` will render the
-              // correct state and this timer becomes a harmless no-op.
-              return () => clearTimeout(timer);
-            }).catch(() => {
-              // The cancel request failed — most likely the run already
-              // finished on the backend but the terminal event was lost or
-              // hasn't arrived yet.  Reload the snapshot to reconcile the
-              // UI with the actual backend state.
-              void loadSnapshot();
-            });
-          }}
-          onSubmit={handleSubmit}
-          placeholder="Ask Tiy anything, @ to add files, / for commands, $ for skills"
-          providers={providers}
-          runMode={selectedRunMode}
-          runModeDisabled={runState === "running" || runState === "waiting_approval"}
-          showRunModeToggle
-          status={composerStatus}
-          value={composerValue}
-          workspaceId={workspaceId}
-          onValueChange={setComposerValue}
-        />
+              });
+            }}
+            onSubmit={handleSubmit}
+            placeholder="Ask Tiy anything, @ to add files, / for commands, $ for skills"
+            providers={providers}
+            runMode={selectedRunMode}
+            runModeDisabled={runState === "running" || runState === "waiting_approval"}
+            showRunModeToggle
+            status={composerStatus}
+            value={composerValue}
+            workspaceId={workspaceId}
+            onValueChange={setComposerValue}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/modules/workbench-shell/ui/task-board-card.tsx
+++ b/src/modules/workbench-shell/ui/task-board-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { CheckCircle2Icon, CircleIcon, Loader2Icon, XCircleIcon } from "lucide-react";
-import type { ComponentProps } from "react";
+import { CheckCircle2Icon, ChevronRightIcon, CircleIcon, Loader2Icon, XCircleIcon } from "lucide-react";
+import { ComponentProps, useCallback, useState } from "react";
 import { cn } from "@/shared/lib/utils";
 import type { TaskBoardDto, TaskItemDto, TaskStage } from "@/shared/types/api";
 import { computeProgress, hasFailedTasks, isBoardCompleted } from "../model/task-board";
@@ -86,17 +86,22 @@ export const TaskItemRow = ({
 export type TaskBoardCardProps = ComponentProps<"div"> & {
   board: TaskBoardDto;
   showTitle?: boolean;
+  defaultCollapsed?: boolean;
 };
 
 export const TaskBoardCard = ({
   board,
   showTitle = true,
+  defaultCollapsed = false,
   className,
   ...props
 }: TaskBoardCardProps) => {
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const progress = computeProgress(board);
   const completed = isBoardCompleted(board);
   const hasFailed = hasFailedTasks(board);
+
+  const toggleCollapse = useCallback(() => setCollapsed((c) => !c), []);
 
   return (
     <div
@@ -109,11 +114,23 @@ export const TaskBoardCard = ({
       {...props}
     >
       {showTitle && (
-        <div className="mb-3 flex items-center justify-between">
-          <h4 className="text-sm font-medium">{board.title}</h4>
+        <button
+          type="button"
+          onClick={toggleCollapse}
+          className="mb-3 flex w-full items-center justify-between gap-2 text-left"
+        >
+          <div className="flex min-w-0 items-center gap-2">
+            <ChevronRightIcon
+              className={cn(
+                "size-3.5 shrink-0 text-muted-foreground transition-transform duration-200",
+                !collapsed && "rotate-90"
+              )}
+            />
+            <h4 className="truncate text-sm font-medium">{board.title}</h4>
+          </div>
           <span
             className={cn(
-              "text-xs tabular-nums",
+              "shrink-0 text-xs tabular-nums",
               completed && "text-success",
               hasFailed && "text-destructive",
               !completed && !hasFailed && "text-muted-foreground"
@@ -121,7 +138,7 @@ export const TaskBoardCard = ({
           >
             {progress}%
           </span>
-        </div>
+        </button>
       )}
 
       {/* Progress bar */}
@@ -138,18 +155,20 @@ export const TaskBoardCard = ({
       </div>
 
       {/* Task list */}
-      <ul className="space-y-0.5">
-        {board.tasks.map((task: TaskItemDto) => (
-          <TaskItemRow
-            key={task.id}
-            task={task}
-            isActive={task.id === board.activeTaskId}
-          />
-        ))}
-      </ul>
+      {!collapsed && (
+        <ul className="space-y-0.5">
+          {board.tasks.map((task: TaskItemDto) => (
+            <TaskItemRow
+              key={task.id}
+              task={task}
+              isActive={task.id === board.activeTaskId}
+            />
+          ))}
+        </ul>
+      )}
 
       {/* Status badge */}
-      {board.status !== "active" && (
+      {!collapsed && board.status !== "active" && (
         <div className="mt-2 text-xs text-muted-foreground">
           {board.status === "completed" ? "✓ Completed" : "⊘ Abandoned"}
         </div>

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -96,6 +96,7 @@ const FILE_SEARCH_DEBOUNCE_MS = 120;
 type WorkbenchPromptComposerProps = {
   activeAgentProfileId: string;
   agentProfiles: ReadonlyArray<AgentProfile>;
+  allowMissingActiveProfile?: boolean;
   canSubmitWhenAttachmentsOnly?: boolean;
   className?: string;
   commands?: ReadonlyArray<CommandEntry>;
@@ -778,12 +779,14 @@ function PromptInputSubmitButton({
   activeProfile,
   allowAttachmentsOnly,
   composerValue,
+  hasMissingActiveProfile = false,
   onStop,
   status,
 }: {
   activeProfile: AgentProfile | null;
   allowAttachmentsOnly: boolean;
   composerValue: string;
+  hasMissingActiveProfile?: boolean;
   onStop: () => void;
   status: ChatStatus;
 }) {
@@ -791,7 +794,7 @@ function PromptInputSubmitButton({
   const hasText = Boolean(composerValue.trim());
   const hasAttachments = attachments.files.length > 0;
   const isStopping = status === "submitted" || status === "streaming";
-  const canSubmit = Boolean(activeProfile) && (hasText || (allowAttachmentsOnly && hasAttachments));
+  const canSubmit = Boolean(activeProfile) && !hasMissingActiveProfile && (hasText || (allowAttachmentsOnly && hasAttachments));
 
   return <PromptInputSubmit disabled={isStopping ? false : !canSubmit} onStop={onStop} status={status} />;
 }
@@ -976,6 +979,7 @@ export function ComposerMessageAttachments({
 export function WorkbenchPromptComposer({
   activeAgentProfileId,
   agentProfiles,
+  allowMissingActiveProfile = false,
   canSubmitWhenAttachmentsOnly = true,
   className,
   commands = [],
@@ -1018,11 +1022,19 @@ export function WorkbenchPromptComposer({
   const registerReferencedSourceBridge = useCallback((bridge: ReferencedSourceBridgeHandle) => {
     referencedSourceBridgeRef.current = bridge;
   }, []);
-  const activeProfile = useMemo(
-    () => agentProfiles.find((profile) => profile.id === activeAgentProfileId) ?? agentProfiles[0] ?? null,
-    [activeAgentProfileId, agentProfiles],
-  );
-  const canSwitchProfiles = Boolean(activeProfile);
+  const activeProfile = useMemo(() => {
+    const matchedProfile = agentProfiles.find((profile) => profile.id === activeAgentProfileId) ?? null;
+    if (matchedProfile) {
+      return matchedProfile;
+    }
+    if (allowMissingActiveProfile) {
+      return null;
+    }
+    return agentProfiles[0] ?? null;
+  }, [activeAgentProfileId, agentProfiles, allowMissingActiveProfile]);
+  const hasMissingActiveProfile =
+    allowMissingActiveProfile && Boolean(activeAgentProfileId) && activeProfile === null;
+  const canSwitchProfiles = agentProfiles.length > 0;
   const commandRegistry = useMemo(
     () => buildComposerCommandRegistry(commands),
     [commands],
@@ -1636,63 +1648,76 @@ export function WorkbenchPromptComposer({
             <PromptInputTools>
               <ComposerAttachmentTrigger />
 
-              {activeProfile ? (
-                <div className="flex items-center gap-2">
-                  {canSwitchProfiles ? (
-                    <ModelSelector onOpenChange={setProfileSelectorOpen} open={isProfileSelectorOpen}>
-                      <ModelSelectorTrigger asChild>
-                        <PromptInputButton className="h-auto max-w-[360px] justify-start gap-3 px-3 py-2" size="sm">
+              <div className="flex items-center gap-2">
+                {canSwitchProfiles ? (
+                  <ModelSelector onOpenChange={setProfileSelectorOpen} open={isProfileSelectorOpen}>
+                    <ModelSelectorTrigger asChild>
+                      <PromptInputButton className="h-auto max-w-[360px] justify-start gap-3 px-3 py-2" size="sm">
+                        {activeProfile ? (
                           <ProfileInlineIdentity badge={false} profile={activeProfile} providers={providers} showModel={false} />
-                        </PromptInputButton>
-                      </ModelSelectorTrigger>
-                      <ModelSelectorContent
-                        commandProps={{ value: activeAgentProfileId ?? undefined }}
-                        showCloseButton={false}
-                        title="Profile Selector"
-                      >
-                        <ModelSelectorList>
-                          <ModelSelectorEmpty>{t("composer.noProfileAvailable")}</ModelSelectorEmpty>
-                          <ModelSelectorGroup heading="Agent Profiles">
-                            {agentProfiles.map((profile) => (
-                              <ProfileSelectorItem
-                                isActive={profile.id === activeAgentProfileId}
-                                key={profile.id}
-                                onSelect={() => {
-                                  onSelectAgentProfile(profile.id);
-                                  setProfileSelectorOpen(false);
-                                }}
-                                profile={profile}
-                                providers={providers}
-                              />
-                            ))}
-                          </ModelSelectorGroup>
-                        </ModelSelectorList>
-                      </ModelSelectorContent>
-                    </ModelSelector>
-                  ) : (
-                    <PromptInputButton className="h-auto max-w-[360px] justify-start gap-3 px-3 py-2" disabled size="sm">
+                        ) : (
+                          <div className="flex min-w-0 items-center gap-2 text-app-danger">
+                            <UserStar className="size-4 shrink-0" />
+                            <span className="truncate text-sm font-medium">{t("composer.profileDeleted")}</span>
+                          </div>
+                        )}
+                      </PromptInputButton>
+                    </ModelSelectorTrigger>
+                    <ModelSelectorContent
+                      commandProps={{ value: activeAgentProfileId ?? undefined }}
+                      showCloseButton={false}
+                      title="Profile Selector"
+                    >
+                      <ModelSelectorList>
+                        <ModelSelectorEmpty>{t("composer.noProfileAvailable")}</ModelSelectorEmpty>
+                        <ModelSelectorGroup heading="Agent Profiles">
+                          {agentProfiles.map((profile) => (
+                            <ProfileSelectorItem
+                              isActive={profile.id === activeAgentProfileId}
+                              key={profile.id}
+                              onSelect={() => {
+                                onSelectAgentProfile(profile.id);
+                                setProfileSelectorOpen(false);
+                              }}
+                              profile={profile}
+                              providers={providers}
+                            />
+                          ))}
+                        </ModelSelectorGroup>
+                      </ModelSelectorList>
+                    </ModelSelectorContent>
+                  </ModelSelector>
+                ) : (
+                  <PromptInputButton className="h-auto max-w-[360px] justify-start gap-3 px-3 py-2" disabled size="sm">
+                    {activeProfile ? (
                       <ProfileInlineIdentity badge={false} muted profile={activeProfile} providers={providers} showModel={false} />
-                    </PromptInputButton>
-                  )}
+                    ) : (
+                      <div className="flex min-w-0 items-center gap-2 text-app-danger/80">
+                        <UserStar className="size-4 shrink-0" />
+                        <span className="truncate text-sm font-medium">{t("composer.profileDeleted")}</span>
+                      </div>
+                    )}
+                  </PromptInputButton>
+                )}
 
-                  {showRunModeToggle ? (
-                    <>
-                      <span aria-hidden="true" className="h-4 w-px bg-app-border/55" />
-                      <RunModeToggle
-                        disabled={runModeDisabled}
-                        onChange={onRunModeChange}
-                        runMode={runMode}
-                      />
-                    </>
-                  ) : null}
-                </div>
-              ) : null}
+                {showRunModeToggle ? (
+                  <>
+                    <span aria-hidden="true" className="h-4 w-px bg-app-border/55" />
+                    <RunModeToggle
+                      disabled={runModeDisabled || hasMissingActiveProfile}
+                      onChange={onRunModeChange}
+                      runMode={runMode}
+                    />
+                  </>
+                ) : null}
+              </div>
             </PromptInputTools>
 
             <PromptInputSubmitButton
               activeProfile={activeProfile}
               allowAttachmentsOnly={canSubmitWhenAttachmentsOnly}
               composerValue={value}
+              hasMissingActiveProfile={hasMissingActiveProfile}
               onStop={onStop}
               status={status}
             />
@@ -1701,7 +1726,9 @@ export function WorkbenchPromptComposer({
       </div>
 
       {error ? <p className="mt-2 text-xs text-app-danger">{error}</p> : null}
-      {!activeProfile ? (
+      {hasMissingActiveProfile ? (
+        <p className="mt-2 text-xs text-app-danger">{t("composer.profileDeletedHint")}</p>
+      ) : !activeProfile ? (
         <p className="mt-2 text-xs text-app-danger">No active profile is available for the composer right now.</p>
       ) : null}
     </div>

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -97,7 +97,9 @@ type WorkbenchPromptComposerProps = {
   activeAgentProfileId: string;
   agentProfiles: ReadonlyArray<AgentProfile>;
   canSubmitWhenAttachmentsOnly?: boolean;
+  className?: string;
   commands?: ReadonlyArray<CommandEntry>;
+  composerShellClassName?: string;
   enabledSkills?: ReadonlyArray<Pick<SkillRecord, "id" | "name" | "description" | "scope" | "source" | "tags" | "triggers" | "contentPreview">>;
   error?: string | null;
   onErrorMessageChange?: (message: string | null) => void;
@@ -975,7 +977,9 @@ export function WorkbenchPromptComposer({
   activeAgentProfileId,
   agentProfiles,
   canSubmitWhenAttachmentsOnly = true,
+  className,
   commands = [],
+  composerShellClassName,
   enabledSkills = [],
   error,
   onErrorMessageChange,
@@ -1323,7 +1327,7 @@ export function WorkbenchPromptComposer({
   };
 
   return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-3">
+    <div className={cn("mx-auto flex max-w-4xl flex-col gap-3", className)}>
       {suggestions && suggestions.length > 0 ? (
         <Suggestions className="gap-2">
           {suggestions.map((suggestion) => (
@@ -1332,7 +1336,10 @@ export function WorkbenchPromptComposer({
         </Suggestions>
       ) : null}
 
-      <div className="[--composer-shell-border:1px] [--composer-shell-gap:6px] [--composer-shell-radius:26px] rounded-[var(--composer-shell-radius)] border border-app-border/60 bg-app-surface/82 p-[var(--composer-shell-gap)] shadow-[0_22px_50px_-42px_rgba(15,23,42,0.38)] backdrop-blur-sm">
+      <div className={cn(
+        "[--composer-shell-border:1px] [--composer-shell-gap:6px] [--composer-shell-radius:26px] rounded-[var(--composer-shell-radius)] border border-app-border/60 bg-app-surface/82 p-[var(--composer-shell-gap)] shadow-[0_22px_50px_-42px_rgba(15,23,42,0.38)] backdrop-blur-sm",
+        composerShellClassName,
+      )}>
         <PromptInput
           accept={SUPPORTED_COMPOSER_ATTACHMENT_ACCEPT}
           className="[&_[data-slot=input-group]]:overflow-visible [&_[data-slot=input-group]]:rounded-[calc(var(--composer-shell-radius)-var(--composer-shell-border)-var(--composer-shell-gap))] [&_[data-slot=input-group]]:shadow-none [&_[data-slot=input-group]:focus-within]:!border-app-border/60 [&_[data-slot=input-group]:focus-within]:!ring-0"

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1700,9 +1700,9 @@ export function WorkbenchPromptComposer({
         </PromptInput>
       </div>
 
-      {error ? <p className="text-xs text-app-danger">{error}</p> : null}
+      {error ? <p className="mt-2 text-xs text-app-danger">{error}</p> : null}
       {!activeProfile ? (
-        <p className="text-xs text-app-danger">No active profile is available for the composer right now.</p>
+        <p className="mt-2 text-xs text-app-danger">No active profile is available for the composer right now.</p>
       ) : null}
     </div>
   );

--- a/src/services/bridge/thread-commands.ts
+++ b/src/services/bridge/thread-commands.ts
@@ -27,11 +27,13 @@ export async function threadList(
 export async function threadCreate(
   workspaceId: string,
   title?: string,
+  profileId?: string | null,
 ): Promise<ThreadSummaryDto> {
   requireTauri("thread_create");
   return invoke<ThreadSummaryDto>("thread_create", {
     workspaceId,
     title: title ?? null,
+    profileId: profileId ?? null,
   });
 }
 
@@ -54,6 +56,14 @@ export async function threadUpdateTitle(
 ): Promise<void> {
   requireTauri("thread_update_title");
   return invoke("thread_update_title", { id, title });
+}
+
+export async function threadUpdateProfile(
+  id: string,
+  profileId: string | null,
+): Promise<void> {
+  requireTauri("thread_update_profile");
+  return invoke("thread_update_profile", { id, profileId });
 }
 
 export async function threadDelete(id: string): Promise<void> {

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -257,6 +257,7 @@ export type ThreadStatus =
 export interface ThreadSummaryDto {
   id: string;
   workspaceId: string;
+  profileId: string | null;
   title: string;
   status: ThreadStatus;
   lastActiveAt: string;


### PR DESCRIPTION
## Summary
- Integrate the active task board into the workbench composer flow and move it below the conversation surface.
- Persist each thread's selected profile in the database, update it on in-thread profile switches, and show a missing-profile state when the referenced profile has been deleted.
- Reuse the new-thread activation flow across workspace entry points, refine composer spacing and shell classes, and bump `tiycore` to `0.1.11-rc.26042020`.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run test:unit -- dashboard-workbench.test.ts`
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test m1_4_thread -- --nocapture`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
