### PR TITLE
fix(settings-center): 🐛 auto-enable edit mode for newly added commands

### DIFF
--- a/src/modules/settings-center/ui/settings-center-overlay.tsx
+++ b/src/modules/settings-center/ui/settings-center-overlay.tsx
@@ -1560,8 +1560,17 @@ function CommandsSection({
 }) {
   const t = useT();
   const [editingId, setEditingId] = useState<string | null>(null);
+  const pendingAddRef = useRef(false);
+
+  useEffect(() => {
+    if (pendingAddRef.current && commands.length > 0) {
+      pendingAddRef.current = false;
+      setEditingId(commands[commands.length - 1].id);
+    }
+  }, [commands]);
 
   const handleAddCommand = () => {
+    pendingAddRef.current = true;
     onAddCommand({
       name: "",
       path: "",


### PR DESCRIPTION
## Summary
- Settings Commands 页面点击 "Add Prompt" 后，新条目虽已创建但编辑表单不会自动展开，表现为按钮无响应
- 在 `CommandsSection` 中补充 `pendingAddRef` + `useEffect` 模式，与 `PatternSubsection` / `WritableRootsSubsection` 保持一致
- 新增命令后自动将该条目 id 设为 `editingId`，编辑表单立即展开

## Test Plan
- [ ] 打开 Settings → Commands，点击 Add Prompt，确认新条目自动进入编辑状态
- [ ] 确认已有命令的编辑/删除行为不受影响
- [ ] 运行 `npm run typecheck` 通过

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)