### PR TITLE
feat(worktree): ✨ Support checking out existing branch into new worktree

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -753,7 +753,7 @@ const en: Record<TranslationKey, string> = {
 
   // ── Worktree ───────────────────────────────────────────
   "worktree.createTitle": "New worktree",
-  "worktree.createDescription": "Create a new worktree with a new branch for this Git repository.",
+  "worktree.createDescription": "Create a new worktree for this Git repository.",
   "worktree.field.branch": "New branch name",
   "worktree.field.branchPlaceholder": "Type a new branch name",
   "worktree.field.baseBranch": "Base branch",
@@ -772,6 +772,11 @@ const en: Record<TranslationKey, string> = {
   "worktree.empty.branches": "No branches yet",
   "worktree.loading.branches": "Loading…",
   "worktree.tag.label": "Worktree",
+  "worktree.mode.newBranch": "New branch",
+  "worktree.mode.existingBranch": "Existing branch",
+  "worktree.field.selectBranch": "Select branch",
+  "worktree.field.selectBranchHint": "Check out this existing branch into a new worktree",
+  "worktree.error.selectBranch": "Please select a branch",
 };
 
 export default en;

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -791,7 +791,7 @@ const zhCN = {
 
   // ── Worktree ───────────────────────────────────────────
   "worktree.createTitle": "新建 Worktree",
-  "worktree.createDescription": "为当前 Git 仓库创建一个新的 worktree，基于现有分支新建分支。",
+  "worktree.createDescription": "为当前 Git 仓库创建一个新的 worktree。",
   "worktree.field.branch": "新分支名",
   "worktree.field.branchPlaceholder": "输入新分支名称",
   "worktree.field.baseBranch": "基于分支",
@@ -810,6 +810,11 @@ const zhCN = {
   "worktree.empty.branches": "暂无分支",
   "worktree.loading.branches": "加载中…",
   "worktree.tag.label": "Worktree",
+  "worktree.mode.newBranch": "新建分支",
+  "worktree.mode.existingBranch": "已有分支",
+  "worktree.field.selectBranch": "选择分支",
+  "worktree.field.selectBranchHint": "将检出此已有分支到新 worktree",
+  "worktree.error.selectBranch": "请选择一个分支",
 } as const;
 
 export type TranslationKey = keyof typeof zhCN;

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -27,6 +27,8 @@ import type {
   WorktreeCreateInput,
 } from "@/shared/types/api";
 
+type WorktreeMode = "newBranch" | "existingBranch";
+
 export type NewWorktreeDialogContext = {
   /** The repo workspace this worktree will belong to. */
   repo: Pick<WorkspaceDto, "id" | "name" | "canonicalPath">;
@@ -44,8 +46,10 @@ export function NewWorktreeDialog({
   const t = useT();
   const isOpen = context !== null;
 
+  const [mode, setMode] = useState<WorktreeMode>("newBranch");
   const [branch, setBranch] = useState("");
   const [baseBranch, setBaseBranch] = useState("");
+  const [selectedExistingBranch, setSelectedExistingBranch] = useState("");
   const [path, setPath] = useState("");
   const [pathTouched, setPathTouched] = useState(false);
   const [branches, setBranches] = useState<GitBranchDto[]>([]);
@@ -56,8 +60,10 @@ export function NewWorktreeDialog({
   // Reset state whenever the dialog opens for a new repo.
   useEffect(() => {
     if (!isOpen) return;
+    setMode("newBranch");
     setBranch("");
     setBaseBranch("");
+    setSelectedExistingBranch("");
     setPath("");
     setPathTouched(false);
     setError(null);
@@ -100,33 +106,75 @@ export function NewWorktreeDialog({
     }
   }, [isOpen, pathTouched]);
 
-  const canSubmit = Boolean(context && branch.trim() && !submitting);
+  const localBranches = useMemo(
+    () => branches.filter((b) => !b.isRemote),
+    [branches],
+  );
+
+  const canSubmit =
+    mode === "newBranch"
+      ? Boolean(context && branch.trim() && !submitting)
+      : Boolean(context && selectedExistingBranch && !submitting);
 
   const handleSubmit = useCallback(async () => {
     if (!context) return;
-    const trimmed = branch.trim();
-    if (!trimmed) {
-      setError(t("worktree.error.branchRequired"));
-      return;
+
+    if (mode === "newBranch") {
+      const trimmed = branch.trim();
+      if (!trimmed) {
+        setError(t("worktree.error.branchRequired"));
+        return;
+      }
+      setError(null);
+      setSubmitting(true);
+      try {
+        const input: WorktreeCreateInput = {
+          branch: trimmed,
+          createBranch: true,
+          baseRef: baseBranch || undefined,
+          path: path.trim() || undefined,
+        };
+        const created = await workspaceCreateWorktree(context.repo.id, input);
+        onCreated?.(created);
+        onClose();
+      } catch (e) {
+        setError(getInvokeErrorMessage(e, "Failed to create worktree"));
+      } finally {
+        setSubmitting(false);
+      }
+    } else {
+      if (!selectedExistingBranch) {
+        setError(t("worktree.error.selectBranch"));
+        return;
+      }
+      setError(null);
+      setSubmitting(true);
+      try {
+        const input: WorktreeCreateInput = {
+          branch: selectedExistingBranch,
+          createBranch: false,
+          path: path.trim() || undefined,
+        };
+        const created = await workspaceCreateWorktree(context.repo.id, input);
+        onCreated?.(created);
+        onClose();
+      } catch (e) {
+        setError(getInvokeErrorMessage(e, "Failed to create worktree"));
+      } finally {
+        setSubmitting(false);
+      }
     }
-    setError(null);
-    setSubmitting(true);
-    try {
-      const input: WorktreeCreateInput = {
-        branch: trimmed,
-        createBranch: true,
-        baseRef: baseBranch || undefined,
-        path: path.trim() || undefined,
-      };
-      const created = await workspaceCreateWorktree(context.repo.id, input);
-      onCreated?.(created);
-      onClose();
-    } catch (e) {
-      setError(getInvokeErrorMessage(e, "Failed to create worktree"));
-    } finally {
-      setSubmitting(false);
-    }
-  }, [context, branch, baseBranch, path, t, onCreated, onClose]);
+  }, [
+    context,
+    mode,
+    branch,
+    baseBranch,
+    selectedExistingBranch,
+    path,
+    t,
+    onCreated,
+    onClose,
+  ]);
 
   const handleBrowsePath = useCallback(async () => {
     const selected = await openDialog({
@@ -157,59 +205,137 @@ export function NewWorktreeDialog({
         </DialogHeader>
 
         <div className="flex flex-col gap-4">
-          {/* New branch name */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium">{t("worktree.field.branch")}</label>
-            <Input
-              value={branch}
-              onChange={(e) => setBranch(e.target.value)}
-              placeholder={t("worktree.field.branchPlaceholder")}
-              autoFocus
-            />
+          {/* Mode toggle */}
+          <div className="flex rounded-lg border bg-muted/20 p-0.5">
+            <button
+              type="button"
+              onClick={() => setMode("newBranch")}
+              className={cn(
+                "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                mode === "newBranch"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t("worktree.mode.newBranch")}
+            </button>
+            <button
+              type="button"
+              onClick={() => setMode("existingBranch")}
+              className={cn(
+                "flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+                mode === "existingBranch"
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {t("worktree.mode.existingBranch")}
+            </button>
           </div>
 
-          {/* Base branch selector */}
-          <div className="flex flex-col gap-1.5">
-            <label className="text-sm font-medium">{t("worktree.field.baseBranch")}</label>
-            <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
-              {branchesLoading ? (
-                <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
-                  <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
-                  {t("worktree.loading.branches")}
-                </div>
-              ) : branches.length === 0 ? (
-                <div className="px-2 py-4 text-sm text-muted-foreground">
-                  {t("worktree.empty.branches")}
-                </div>
-              ) : (
-                branches.map((b) => {
-                  const isActive = baseBranch === b.name;
-                  const label = b.isRemote ? "remote" : "local";
-                  return (
-                    <button
-                      key={`${label}:${b.name}`}
-                      type="button"
-                      onClick={() => setBaseBranch(b.name)}
-                      className={cn(
-                        "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
-                        isActive && "bg-background font-medium",
-                      )}
-                    >
-                      <span className="truncate">{b.name}</span>
-                      <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
-                        {label}
-                      </span>
-                    </button>
-                  );
-                })
-              )}
-            </div>
-            {baseBranch && (
-              <div className="text-xs text-muted-foreground">
-                {t("worktree.field.baseBranchHint", { branch: baseBranch })}
+          {mode === "newBranch" ? (
+            <>
+              {/* New branch name */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">{t("worktree.field.branch")}</label>
+                <Input
+                  value={branch}
+                  onChange={(e) => setBranch(e.target.value)}
+                  placeholder={t("worktree.field.branchPlaceholder")}
+                  autoFocus
+                />
               </div>
-            )}
-          </div>
+
+              {/* Base branch selector */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">{t("worktree.field.baseBranch")}</label>
+                <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
+                  {branchesLoading ? (
+                    <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      {t("worktree.loading.branches")}
+                    </div>
+                  ) : branches.length === 0 ? (
+                    <div className="px-2 py-4 text-sm text-muted-foreground">
+                      {t("worktree.empty.branches")}
+                    </div>
+                  ) : (
+                    branches.map((b) => {
+                      const isActive = baseBranch === b.name;
+                      const label = b.isRemote ? "remote" : "local";
+                      return (
+                        <button
+                          key={`${label}:${b.name}`}
+                          type="button"
+                          onClick={() => setBaseBranch(b.name)}
+                          className={cn(
+                            "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                            isActive && "bg-background font-medium",
+                          )}
+                        >
+                          <span className="truncate">{b.name}</span>
+                          <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                            {label}
+                          </span>
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+                {baseBranch && (
+                  <div className="text-xs text-muted-foreground">
+                    {t("worktree.field.baseBranchHint", { branch: baseBranch })}
+                  </div>
+                )}
+              </div>
+            </>
+          ) : (
+            <>
+              {/* Existing branch selector (local only) */}
+              <div className="flex flex-col gap-1.5">
+                <label className="text-sm font-medium">{t("worktree.field.selectBranch")}</label>
+                <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
+                  {branchesLoading ? (
+                    <div className="flex items-center gap-2 px-2 py-4 text-sm text-muted-foreground">
+                      <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
+                      {t("worktree.loading.branches")}
+                    </div>
+                  ) : localBranches.length === 0 ? (
+                    <div className="px-2 py-4 text-sm text-muted-foreground">
+                      {t("worktree.empty.branches")}
+                    </div>
+                  ) : (
+                    localBranches.map((b) => {
+                      const isActive = selectedExistingBranch === b.name;
+                      return (
+                        <button
+                          key={b.name}
+                          type="button"
+                          onClick={() => setSelectedExistingBranch(b.name)}
+                          className={cn(
+                            "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                            isActive && "bg-background font-medium",
+                          )}
+                        >
+                          <span className="truncate">{b.name}</span>
+                          {b.isHead && (
+                            <span className="ml-2 rounded bg-muted px-1 text-[10px] font-medium text-muted-foreground">
+                              HEAD
+                            </span>
+                          )}
+                        </button>
+                      );
+                    })
+                  )}
+                </div>
+                {selectedExistingBranch && (
+                  <div className="text-xs text-muted-foreground">
+                    {t("worktree.field.selectBranchHint")}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
 
           {/* Path */}
           <div className="flex flex-col gap-1.5">


### PR DESCRIPTION
## Summary
- Add mode toggle in NewWorktreeDialog to switch between "New branch" and "Existing branch"
- Existing branch mode shows only local branches for selection (filters out remote tracking branches)
- Backend already supported `createBranch: false`; frontend now exposes this path
- Update dialog description to be mode-neutral (no longer says "with a new branch")
- Add 5 new i18n keys for the mode toggle UI in both en and zh-CN

## Changes
- `src/modules/workbench-shell/ui/new-worktree-dialog.tsx` — Added `mode` state (`newBranch` | `existingBranch`), `selectedExistingBranch` state, segmented toggle UI, conditional form fields, and `createBranch: false` submission path
- `src/i18n/locales/en.ts` — Updated `worktree.createDescription` to mode-neutral wording; added `worktree.mode.newBranch`, `worktree.mode.existingBranch`, `worktree.field.selectBranch`, `worktree.field.selectBranchHint`, `worktree.error.selectBranch`
- `src/i18n/locales/zh-CN.ts` — Synced identical key changes in Chinese

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` passes (54/54)
- [ ] Manual: Open New Worktree dialog → switch to "Existing branch" → select a local branch → submit → verify worktree created
- [ ] Manual: Verify "New branch" mode still works as before (regression)

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)