### PR TITLE
feat(workbench): ✨ Add viewport-based auto-collapse for completed timeline entries

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3480,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -3527,9 +3527,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -6126,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1f7d4e09a1ed4068d6187df5a4e7daa44ff9563b8d4998d4c5193b87d889ae"
+checksum = "09a44567663b35149de0ac89670585850d03ebd7482126b08c1c9b0d0af2ded6"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6126,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.11-rc.26042020"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b0edf2277e0c6c99cadc992daf0574d18e15ecb7a749fc94f07b22e6cc6b72"
+checksum = "4e1f7d4e09a1ed4068d6187df5a4e7daa44ff9563b8d4998d4c5193b87d889ae"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.11"
+tiycore = "0.1.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.11-rc.26042020"
+tiycore = "0.1.11"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -51,6 +51,7 @@ export type ReasoningProps = ComponentProps<typeof Collapsible> & {
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
   duration?: number;
+  autoClose?: boolean;
 };
 
 const AUTO_CLOSE_DELAY = 1000;
@@ -64,6 +65,7 @@ export const Reasoning = memo(
     defaultOpen,
     onOpenChange,
     duration: durationProp,
+    autoClose = true,
     children,
     ...props
   }: ReasoningProps) => {
@@ -108,6 +110,7 @@ export const Reasoning = memo(
     // Auto-close when streaming ends (once only, and only if it ever streamed)
     useEffect(() => {
       if (
+        autoClose &&
         hasEverStreamedRef.current &&
         !isStreaming &&
         isOpen &&
@@ -120,7 +123,7 @@ export const Reasoning = memo(
 
         return () => clearTimeout(timer);
       }
-    }, [isStreaming, isOpen, setIsOpen, hasAutoClosed]);
+    }, [autoClose, isStreaming, isOpen, setIsOpen, hasAutoClosed]);
 
     const handleOpenChange = useCallback(
       (newOpen: boolean) => {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2102,6 +2102,7 @@ export function RuntimeThreadSurface({
   const [thinkingPlaceholder, setThinkingPlaceholder] = useState<ThinkingPlaceholder | null>(null);
   const [tools, setTools] = useState<Array<SurfaceToolEntry>>([]);
   const [completedToolOpen, setCompletedToolOpen] = useState<Record<string, boolean>>({});
+  const [reasoningOpen, setReasoningOpen] = useState<Record<string, boolean>>({});
   const [taskBoards, setTaskBoards] = useState<TaskBoardState>(initialTaskBoardState);
   const previousHelperStatusesRef = useRef<Record<string, SurfaceHelperEntry["status"]>>({});
   const previousToolStatesRef = useRef<Record<string, SurfaceToolState>>({});
@@ -3221,28 +3222,35 @@ export function RuntimeThreadSurface({
         const isCompleted = entry.helper.status === "completed";
         const isOpen = helperOpen[entry.helper.id] ?? true;
         result.push({ id: entry.helper.id, completed: isCompleted, currentOpen: isOpen });
+      } else if (entry.kind === "message" && entry.message.messageType === "reasoning") {
+        const isCompleted = entry.message.status !== "streaming";
+        const isOpen = reasoningOpen[entry.message.id] ?? true;
+        result.push({ id: entry.message.id, completed: isCompleted, currentOpen: isOpen });
       }
-      // Reasoning blocks use defaultOpen + internal state; viewport auto-collapse
-      // is only applied to tool and helper blocks for now.
     }
     return result;
-  }, [presentationEntries, completedToolOpen, helperOpen]);
+  }, [presentationEntries, completedToolOpen, helperOpen, reasoningOpen]);
 
   // Keep a ref to presentationEntries for the viewport collapse callback.
   const presentationEntriesRef = useRef(presentationEntries);
   presentationEntriesRef.current = presentationEntries;
 
   const handleViewportCollapse = useCallback((id: string) => {
-    // Determine whether this id belongs to a tool or helper and only
-    // update the relevant state map.
+    // Determine whether this id belongs to a tool, helper, or reasoning
+    // and only update the relevant state map.
     const entry = presentationEntriesRef.current.find(
-      (e) => (e.kind === "tool" && e.tool.id === id) || (e.kind === "helper" && e.helper.id === id),
+      (e) =>
+        (e.kind === "tool" && e.tool.id === id)
+        || (e.kind === "helper" && e.helper.id === id)
+        || (e.kind === "message" && e.message.messageType === "reasoning" && e.message.id === id),
     );
     if (!entry) return;
     if (entry.kind === "tool") {
       setCompletedToolOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
-    } else {
+    } else if (entry.kind === "helper") {
       setHelperOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
+    } else {
+      setReasoningOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
     }
   }, []);
 
@@ -3296,7 +3304,15 @@ export function RuntimeThreadSurface({
         const previousState = previousToolStates[tool.id];
 
         if (previousState !== tool.state) {
-          next[tool.id] = !isCompletedToolState(tool.state);
+          // State changed — keep the block open (don't auto-collapse on
+          // completion).  Only force open when transitioning *to* a
+          // non-completed state so newly-started tools expand.
+          if (!isCompletedToolState(tool.state)) {
+            next[tool.id] = true;
+          } else {
+            // Completed: preserve current open state (default open).
+            next[tool.id] = tool.id in current ? current[tool.id] : true;
+          }
           continue;
         }
 
@@ -3337,10 +3353,17 @@ export function RuntimeThreadSurface({
 
       for (const helper of helpers) {
         const previousStatus = previousHelperStatuses[helper.id];
-        const preferredOpen = helper.status !== "completed";
+        const isCompleted = helper.status === "completed";
 
         if (previousStatus !== helper.status) {
-          next[helper.id] = preferredOpen;
+          // Status changed — only force open when transitioning *to* a
+          // non-completed state.  On completion, keep current open state
+          // (default open) so the block doesn't auto-collapse.
+          if (!isCompleted) {
+            next[helper.id] = true;
+          } else {
+            next[helper.id] = helper.id in current ? current[helper.id] : true;
+          }
           continue;
         }
 
@@ -3349,7 +3372,7 @@ export function RuntimeThreadSurface({
           continue;
         }
 
-        next[helper.id] = preferredOpen;
+        next[helper.id] = !isCompleted;
       }
 
       const currentKeys = Object.keys(current);
@@ -4018,15 +4041,36 @@ export function RuntimeThreadSurface({
                 }
 
                 if (message.messageType === "reasoning") {
+                  const reasoningIsStreaming = message.status === "streaming";
+                  const reasoningIsOpen = reasoningOpen[message.id] ?? (reasoningIsStreaming || runState === "running");
                   return (
-                    <div className={spacingClass} key={entry.key}>
+                    <div
+                      className={spacingClass}
+                      data-timeline-entry-id={message.id}
+                      key={entry.key}
+                      ref={(node) => {
+                        if (node) {
+                          wrapperRefsMap.current.set(message.id, node);
+                        } else {
+                          wrapperRefsMap.current.delete(message.id);
+                        }
+                      }}
+                    >
                       <Message className="max-w-full" from="assistant">
                         <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
                           <Reasoning
                             className="mb-0 w-full bg-transparent px-0 py-0"
                             autoClose={false}
-                            defaultOpen={message.status === "streaming" || runState === "running"}
-                            isStreaming={message.status === "streaming"}
+                            open={reasoningIsOpen}
+                            onOpenChange={(open) => {
+                              setReasoningOpen((current) =>
+                                current[message.id] === open ? current : { ...current, [message.id]: open },
+                              );
+                              if (open) {
+                                userManuallyOpenedIds.current.add(message.id);
+                              }
+                            }}
+                            isStreaming={reasoningIsStreaming}
                           >
                             <ReasoningTrigger />
                             <ReasoningContent>{message.content}</ReasoningContent>

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -21,7 +21,7 @@ import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-e
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { ToolInput, ToolOutput } from "@/components/ai-elements/tool";
 import { Confirmation, ConfirmationAccepted, ConfirmationAction, ConfirmationActions, ConfirmationRejected, ConfirmationRequest, ConfirmationTitle } from "@/components/ai-elements/confirmation";
-import { useViewportAutoCollapse, findScrollParent, type ViewportAutoCollapseEntry } from "@/shared/hooks/use-viewport-auto-collapse";
+import { useViewportAutoCollapse, type ViewportAutoCollapseEntry } from "@/shared/hooks/use-viewport-auto-collapse";
 import { buildRunModelPlanFromSelection } from "@/modules/settings-center/model/run-model-plan";
 import type { AgentProfile, CommandEntry, ProviderEntry } from "@/modules/settings-center/model/types";
 import { threadClearContext, threadCompactContext, threadLoad } from "@/services/bridge";
@@ -3195,14 +3195,18 @@ export function RuntimeThreadSurface({
   const presentationEntries = timelineEntries;
 
   // --- Viewport auto-collapse: detect scroll container once content mounts ---
+  // We derive the scroll container from StickToBottom's scrollRef rather than
+  // walking the DOM with findScrollParent.  A ref callback runs *before*
+  // layout effects, so StickToBottom hasn't set `overflow: auto` on the scroll
+  // div yet, causing findScrollParent to miss it and return null.
+  // A passive effect fires *after* layout effects, guaranteeing the ref is ready.
   const contentSentinelCallback = useCallback((node: HTMLDivElement | null) => {
     contentSentinelRef.current = node;
-    if (node) {
-      const scrollParent = findScrollParent(node);
-      setScrollContainerEl(scrollParent);
-    } else {
-      setScrollContainerEl(null);
-    }
+  }, []);
+
+  useEffect(() => {
+    const scrollEl = conversationContextRef.current?.scrollRef?.current ?? null;
+    setScrollContainerEl(scrollEl);
   }, []);
 
   const getIsStuckToBottom = useCallback(

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -21,6 +21,7 @@ import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-e
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { ToolInput, ToolOutput } from "@/components/ai-elements/tool";
 import { Confirmation, ConfirmationAccepted, ConfirmationAction, ConfirmationActions, ConfirmationRejected, ConfirmationRequest, ConfirmationTitle } from "@/components/ai-elements/confirmation";
+import { useViewportAutoCollapse, findScrollParent, type ViewportAutoCollapseEntry } from "@/shared/hooks/use-viewport-auto-collapse";
 import { buildRunModelPlanFromSelection } from "@/modules/settings-center/model/run-model-plan";
 import type { AgentProfile, CommandEntry, ProviderEntry } from "@/modules/settings-center/model/types";
 import { threadClearContext, threadCompactContext, threadLoad } from "@/services/bridge";
@@ -2094,6 +2095,8 @@ export function RuntimeThreadSurface({
     if (prevThreadIdRef.current !== threadId) {
       prevThreadIdRef.current = threadId;
       setSelectedRunMode("default");
+      wrapperRefsMap.current.clear();
+      userManuallyOpenedIds.current.clear();
     }
   }, [threadId]);
   const [thinkingPlaceholder, setThinkingPlaceholder] = useState<ThinkingPlaceholder | null>(null);
@@ -2111,6 +2114,12 @@ export function RuntimeThreadSurface({
   const thinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preserveContextUsageOnNextEmptySnapshotRef = useRef(false);
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
+
+  // --- Viewport auto-collapse infrastructure ---
+  const [scrollContainerEl, setScrollContainerEl] = useState<HTMLElement | null>(null);
+  const contentSentinelRef = useRef<HTMLDivElement | null>(null);
+  const wrapperRefsMap = useRef<Map<string, HTMLElement>>(new Map());
+  const userManuallyOpenedIds = useRef<Set<string>>(new Set());
 
   const clearScheduledThinkingPhase = useCallback(() => {
     if (thinkingTimerRef.current !== null) {
@@ -2136,7 +2145,7 @@ export function RuntimeThreadSurface({
     });
   }, []);
 
-  const scheduleThinkingPhase = useCallback((runId?: string | null, delayMs = 160) => {
+  const scheduleThinkingPhase = useCallback((runId?: string | null, delayMs = 500) => {
     clearScheduledThinkingPhase();
     thinkingTimerRef.current = setTimeout(() => {
       thinkingTimerRef.current = null;
@@ -3183,6 +3192,68 @@ export function RuntimeThreadSurface({
     [helpers, messages, visibleTools],
   );
   const presentationEntries = timelineEntries;
+
+  // --- Viewport auto-collapse: detect scroll container once content mounts ---
+  const contentSentinelCallback = useCallback((node: HTMLDivElement | null) => {
+    contentSentinelRef.current = node;
+    if (node) {
+      const scrollParent = findScrollParent(node);
+      setScrollContainerEl(scrollParent);
+    } else {
+      setScrollContainerEl(null);
+    }
+  }, []);
+
+  const getIsStuckToBottom = useCallback(
+    () => conversationContextRef.current?.isAtBottom ?? true,
+    [],
+  );
+
+  // Build entries for the viewport auto-collapse hook.
+  const viewportCollapseEntries = useMemo<ReadonlyArray<ViewportAutoCollapseEntry>>(() => {
+    const result: ViewportAutoCollapseEntry[] = [];
+    for (const entry of presentationEntries) {
+      if (entry.kind === "tool") {
+        const isCompleted = isCompletedToolState(entry.tool.state);
+        const isOpen = !isCompleted ? true : (completedToolOpen[entry.tool.id] ?? true);
+        result.push({ id: entry.tool.id, completed: isCompleted, currentOpen: isOpen });
+      } else if (entry.kind === "helper") {
+        const isCompleted = entry.helper.status === "completed";
+        const isOpen = helperOpen[entry.helper.id] ?? true;
+        result.push({ id: entry.helper.id, completed: isCompleted, currentOpen: isOpen });
+      }
+      // Reasoning blocks use defaultOpen + internal state; viewport auto-collapse
+      // is only applied to tool and helper blocks for now.
+    }
+    return result;
+  }, [presentationEntries, completedToolOpen, helperOpen]);
+
+  // Keep a ref to presentationEntries for the viewport collapse callback.
+  const presentationEntriesRef = useRef(presentationEntries);
+  presentationEntriesRef.current = presentationEntries;
+
+  const handleViewportCollapse = useCallback((id: string) => {
+    // Determine whether this id belongs to a tool or helper and only
+    // update the relevant state map.
+    const entry = presentationEntriesRef.current.find(
+      (e) => (e.kind === "tool" && e.tool.id === id) || (e.kind === "helper" && e.helper.id === id),
+    );
+    if (!entry) return;
+    if (entry.kind === "tool") {
+      setCompletedToolOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
+    } else {
+      setHelperOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
+    }
+  }, []);
+
+  useViewportAutoCollapse({
+    scrollContainer: scrollContainerEl,
+    getIsStuckToBottom,
+    entries: viewportCollapseEntries,
+    wrapperRefs: wrapperRefsMap.current,
+    userManuallyOpenedIds: userManuallyOpenedIds.current,
+    onCollapse: handleViewportCollapse,
+  });
   const lastPresentationRole = presentationEntries.length > 0
     ? getPresentationEntryRole(presentationEntries[presentationEntries.length - 1])
     : null;
@@ -3323,10 +3394,16 @@ export function RuntimeThreadSurface({
 
   const handleCompletedToolOpenChange = useCallback((toolId: string, open: boolean) => {
     setCompletedToolOpen((current) => (current[toolId] === open ? current : { ...current, [toolId]: open }));
+    if (open) {
+      userManuallyOpenedIds.current.add(toolId);
+    }
   }, []);
 
   const handleHelperOpenChange = useCallback((helperId: string, open: boolean) => {
     setHelperOpen((current) => (current[helperId] === open ? current : { ...current, [helperId]: open }));
+    if (open) {
+      userManuallyOpenedIds.current.add(helperId);
+    }
   }, []);
 
   const handlePlanApproval = useCallback(async (
@@ -3613,7 +3690,7 @@ export function RuntimeThreadSurface({
 
               handleCompletedToolOpenChange(tool.id, open);
             }}
-            open={!isCompletedToolState(tool.state) ? true : (completedToolOpen[tool.id] ?? false)}
+            open={!isCompletedToolState(tool.state) ? true : (completedToolOpen[tool.id] ?? true)}
           >
             <CompactCollapsibleHeader
               className={cn(
@@ -3844,6 +3921,8 @@ export function RuntimeThreadSurface({
             className="mx-auto w-full max-w-4xl gap-0 px-6 pt-8"
             style={{ paddingBottom: `${conversationBottomPadding}px` }}
           >
+            {/* Invisible sentinel used to locate the scroll container for viewport auto-collapse */}
+            <div ref={contentSentinelCallback} className="hidden" />
             {hasMoreMessages ? (
               <div className="pb-4">
                 <div className="flex flex-col items-center gap-2">
@@ -3945,6 +4024,7 @@ export function RuntimeThreadSurface({
                         <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
                           <Reasoning
                             className="mb-0 w-full bg-transparent px-0 py-0"
+                            autoClose={false}
                             defaultOpen={message.status === "streaming" || runState === "running"}
                             isStreaming={message.status === "streaming"}
                           >
@@ -4165,12 +4245,23 @@ export function RuntimeThreadSurface({
                   toolUses: helper.totalToolCalls,
                 });
                 return (
-                  <div className={spacingClass} key={entry.key}>
+                  <div
+                    className={spacingClass}
+                    data-timeline-entry-id={helper.id}
+                    key={entry.key}
+                    ref={(node) => {
+                      if (node) {
+                        wrapperRefsMap.current.set(helper.id, node);
+                      } else {
+                        wrapperRefsMap.current.delete(helper.id);
+                      }
+                    }}
+                  >
                     <Message className="max-w-full" from="assistant">
                       <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
                         <CompactCollapsible
                           onOpenChange={(open) => handleHelperOpenChange(helper.id, open)}
-                          open={helperOpen[helper.id] ?? helper.status !== "completed"}
+                          open={helperOpen[helper.id] ?? true}
                         >
                           <CompactCollapsibleHeader
                             className="items-start gap-3 text-left text-app-subtle hover:text-app-foreground"
@@ -4280,7 +4371,18 @@ export function RuntimeThreadSurface({
 
               const { tool } = entry;
               return (
-                <div className={spacingClass} key={entry.key}>
+                <div
+                  className={spacingClass}
+                  data-timeline-entry-id={tool.id}
+                  key={entry.key}
+                  ref={(node) => {
+                    if (node) {
+                      wrapperRefsMap.current.set(tool.id, node);
+                    } else {
+                      wrapperRefsMap.current.delete(tool.id);
+                    }
+                  }}
+                >
                   {renderToolEntry(tool, entry.key)}
                 </div>
               );

--- a/src/shared/hooks/use-viewport-auto-collapse.ts
+++ b/src/shared/hooks/use-viewport-auto-collapse.ts
@@ -1,0 +1,229 @@
+import { useCallback, useEffect, useRef } from "react";
+
+/**
+ * Describes a collapsible timeline entry that this hook may auto-collapse
+ * once it scrolls fully above the visible viewport.
+ */
+export interface ViewportAutoCollapseEntry {
+  /** Stable identifier (e.g. tool id, helper id, reasoning message id). */
+  id: string;
+  /** Whether the entry has finished executing (tool completed, helper completed, reasoning done streaming). */
+  completed: boolean;
+  /** Whether the entry's collapsible is currently open. */
+  currentOpen: boolean;
+}
+
+export interface UseViewportAutoCollapseOptions {
+  /**
+   * The scroll container element (the element with `overflow-y: auto/scroll`).
+   * Pass `null` until the element is available.
+   */
+  scrollContainer: HTMLElement | null;
+  /**
+   * A ref-like getter that returns the current stuck-to-bottom state.
+   * Using a getter (rather than a reactive boolean) avoids re-creating the
+   * IntersectionObserver on every scroll position change.
+   */
+  getIsStuckToBottom: () => boolean;
+  /** Current state of all collapsible timeline entries. */
+  entries: ReadonlyArray<ViewportAutoCollapseEntry>;
+  /**
+   * Map from entry id → the DOM wrapper element.
+   * The hook observes these elements with IntersectionObserver.
+   */
+  wrapperRefs: Map<string, HTMLElement>;
+  /**
+   * Set of entry ids that the user has manually re-opened after an
+   * auto-collapse.  These entries will never be auto-collapsed again.
+   */
+  userManuallyOpenedIds: ReadonlySet<string>;
+  /**
+   * Called when the hook decides to collapse an entry.
+   * The consumer should set the entry's open state to false.
+   */
+  onCollapse: (id: string) => void;
+}
+
+/**
+ * Automatically collapses completed collapsible timeline entries once they
+ * scroll fully above the visible viewport, but only when the scroll container
+ * is stuck to bottom.
+ *
+ * To avoid visible layout shifts, the hook compensates scrollTop in the same
+ * animation frame as the collapse so the viewport content does not move.
+ */
+export function useViewportAutoCollapse({
+  scrollContainer,
+  getIsStuckToBottom,
+  entries,
+  wrapperRefs,
+  userManuallyOpenedIds,
+  onCollapse,
+}: UseViewportAutoCollapseOptions): void {
+  // Keep mutable refs so the IO callback always sees the latest values without
+  // needing to tear down / recreate the observer on every render.
+  const getIsStuckRef = useRef(getIsStuckToBottom);
+  getIsStuckRef.current = getIsStuckToBottom;
+
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+
+  const userManualRef = useRef(userManuallyOpenedIds);
+  userManualRef.current = userManuallyOpenedIds;
+
+  const onCollapseRef = useRef(onCollapse);
+  onCollapseRef.current = onCollapse;
+
+  const scrollContainerRef = useRef(scrollContainer);
+  scrollContainerRef.current = scrollContainer;
+
+  // We keep a single long-lived IntersectionObserver.  The `wrapperRefs` map
+  // is the source of truth for which elements are currently observed.
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const observedElementsRef = useRef<Map<string, HTMLElement>>(new Map());
+
+  // Set of ids that have already been auto-collapsed this session to avoid
+  // redundant work if the IO fires again for the same element.
+  const autoCollapsedRef = useRef<Set<string>>(new Set());
+
+  /**
+   * The IO callback.  For each entry reported as not intersecting *above*
+   * the viewport, trigger a collapse + scrollTop compensation.
+   */
+  const handleIntersection = useCallback(
+    (ioEntries: IntersectionObserverEntry[]) => {
+      if (!getIsStuckRef.current()) return;
+
+      for (const ioEntry of ioEntries) {
+        if (ioEntry.isIntersecting) continue;
+
+        // Ensure the element is above the viewport, not below.
+        const rootTop = ioEntry.rootBounds?.top ?? 0;
+        if (ioEntry.boundingClientRect.bottom >= rootTop) continue;
+
+        // Find the id for this element.
+        const el = ioEntry.target as HTMLElement;
+        const id = el.dataset.timelineEntryId;
+        if (!id) continue;
+
+        // Guard: only collapse completed + open entries that the user hasn't
+        // manually re-opened and that we haven't already collapsed.
+        if (userManualRef.current.has(id)) continue;
+        if (autoCollapsedRef.current.has(id)) continue;
+
+        const entry = entriesRef.current.find((e) => e.id === id);
+        if (!entry || !entry.completed || !entry.currentOpen) continue;
+
+        // --- Collapse with scrollTop compensation ---
+        const oldHeight = el.offsetHeight;
+
+        // Mark first so we don't re-enter.
+        autoCollapsedRef.current.add(id);
+
+        // Notify consumer to set open=false (this triggers a React state
+        // update; the DOM will re-render shortly).
+        onCollapseRef.current(id);
+
+        // Compensate scrollTop in the next animation frame, after React has
+        // committed the DOM change.  We capture `scrollContainerRef` here
+        // because the IO root is the same element.
+        const scrollEl = scrollContainerRef.current;
+        requestAnimationFrame(() => {
+          const newHeight = el.offsetHeight;
+          const delta = oldHeight - newHeight;
+          if (delta > 0 && scrollEl && scrollEl.scrollTop >= delta) {
+            scrollEl.scrollTop -= delta;
+          }
+        });
+      }
+    },
+    [],
+  );
+
+  // Create / recreate the IO when the scroll container element changes.
+  useEffect(() => {
+    if (!scrollContainer) {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      return;
+    }
+
+    // Disconnect previous observer if root changed.
+    observerRef.current?.disconnect();
+    observedElementsRef.current.clear();
+    autoCollapsedRef.current.clear();
+
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: scrollContainer,
+      threshold: 0,
+    });
+    observerRef.current = observer;
+
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+      observedElementsRef.current.clear();
+    };
+  }, [scrollContainer, handleIntersection]);
+
+  // Sync observed elements with `wrapperRefs` on every render.
+  useEffect(() => {
+    const observer = observerRef.current;
+    if (!observer) return;
+
+    const prevObserved = observedElementsRef.current;
+    const nextObserved = new Map<string, HTMLElement>();
+
+    for (const entry of entries) {
+      // Only observe completed + currently open entries (candidates for
+      // auto-collapse).  Skip user-manually-opened entries.
+      if (
+        !entry.completed ||
+        !entry.currentOpen ||
+        userManuallyOpenedIds.has(entry.id) ||
+        autoCollapsedRef.current.has(entry.id)
+      ) {
+        continue;
+      }
+
+      const el = wrapperRefs.get(entry.id);
+      if (!el) continue;
+
+      nextObserved.set(entry.id, el);
+
+      if (!prevObserved.has(entry.id) || prevObserved.get(entry.id) !== el) {
+        observer.observe(el);
+      }
+    }
+
+    // Unobserve elements that are no longer candidates.
+    for (const [id, el] of prevObserved) {
+      if (!nextObserved.has(id) || nextObserved.get(id) !== el) {
+        observer.unobserve(el);
+      }
+    }
+
+    observedElementsRef.current = nextObserved;
+  }, [entries, wrapperRefs, userManuallyOpenedIds]);
+}
+
+/**
+ * Find the nearest scrollable ancestor of the given element.
+ * Useful for locating the scroll container managed by `use-stick-to-bottom`.
+ */
+export function findScrollParent(el: HTMLElement | null): HTMLElement | null {
+  let current = el?.parentElement ?? null;
+  while (current) {
+    const style = getComputedStyle(current);
+    if (
+      style.overflowY === "auto" ||
+      style.overflowY === "scroll" ||
+      style.overflow === "auto" ||
+      style.overflow === "scroll"
+    ) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Add `useViewportAutoCollapse` hook that automatically collapses completed tool/helper entries once they scroll fully above the viewport while stuck-to-bottom, with scrollTop compensation to avoid layout jumps
- Change default open state for completed tools/helpers to `true` (expanded by default), and allow viewport auto-collapse to manage closing
- Add `autoClose` prop to `Reasoning` component; disable auto-close for inline reasoning blocks in favor of explicit control
- Update tiycore dependency from RC (`0.1.11-rc.26042020`) to stable (`0.1.11`)

## Test Plan
- [ ] Verify completed tool entries auto-collapse when scrolling above viewport
- [ ] Verify completed helper entries auto-collapse when scrolling above viewport
- [ ] Verify manually re-opened entries are not auto-collapsed again
- [ ] Verify no visible layout shift / jump when auto-collapse triggers
- [ ] Verify auto-collapse only fires when stuck-to-bottom (not when user has scrolled up)
- [ ] Verify reasoning blocks no longer auto-close on stream end
- [ ] Verify switching threads clears refs and auto-collapse state
- [ ] Verify tiycore stable version works correctly

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)