### PR TITLE
fix(thread): 🐛 make zombie thread cancellation idempotent

### DIFF
--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -468,7 +468,7 @@ pub async fn thread_compact_context(
 pub async fn thread_cancel_run(
     state: State<'_, AppState>,
     thread_id: String,
-) -> Result<(), AppError> {
+) -> Result<bool, AppError> {
     state.agent_run_manager.cancel_run(&thread_id).await
 }
 

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -74,6 +74,16 @@ struct ContextResetMessageBundle {
     persisted_messages: Vec<MessageRecord>,
 }
 
+async fn mark_thread_run_cancellation_requested(
+    active_runs: &Mutex<HashMap<String, ActiveRun>>,
+    thread_id: &str,
+) -> Option<String> {
+    let mut runs = active_runs.lock().await;
+    let run = runs.values_mut().find(|run| run.thread_id == thread_id)?;
+    run.cancellation_requested = true;
+    Some(run.run_id.clone())
+}
+
 pub struct AgentRunManager {
     pool: SqlitePool,
     app_handle: AppHandle,
@@ -621,27 +631,15 @@ impl AgentRunManager {
         Ok(Some((run.run_id.clone(), run.frontend_tx.subscribe())))
     }
 
-    pub async fn cancel_run(&self, thread_id: &str) -> Result<(), AppError> {
-        if self.cancel_run_if_active(thread_id).await? {
-            return Ok(());
-        }
-
-        Err(AppError::recoverable(
-            ErrorSource::Thread,
-            "thread.run.not_active",
-            "No active run for this thread",
-        ))
+    pub async fn cancel_run(&self, thread_id: &str) -> Result<bool, AppError> {
+        self.cancel_run_if_active(thread_id).await
     }
 
     pub async fn cancel_run_if_active(&self, thread_id: &str) -> Result<bool, AppError> {
-        let run_id = {
-            let mut runs = self.active_runs.lock().await;
-            let run = runs.values_mut().find(|run| run.thread_id == thread_id);
-            let Some(run) = run else {
-                return Ok(false);
-            };
-            run.cancellation_requested = true;
-            run.run_id.clone()
+        let Some(run_id) =
+            mark_thread_run_cancellation_requested(&self.active_runs, thread_id).await
+        else {
+            return Ok(false);
         };
 
         run_repo::update_status(&self.pool, &run_id, "cancelling").await?;
@@ -2140,16 +2138,53 @@ mod tests {
         append_compact_instructions, build_compact_summary_messages,
         build_compact_summary_system_prompt, build_implementation_handoff_prompt,
         build_title_prompt, collapse_whitespace, extract_context_summary_block,
-        normalize_compact_summary, normalize_generated_title, should_complete_reasoning_for_event,
-        truncate_chars,
+        mark_thread_run_cancellation_requested, normalize_compact_summary,
+        normalize_generated_title, should_complete_reasoning_for_event, truncate_chars, ActiveRun,
     };
     use crate::core::agent_session::ProfileResponseStyle;
     use crate::core::plan_checkpoint::{
         build_plan_artifact_from_tool_input, build_plan_message_metadata, PlanApprovalAction,
     };
     use crate::ipc::frontend_channels::ThreadStreamEvent;
+    use std::collections::HashMap;
     use tiycore::agent::AgentMessage;
     use tiycore::types::{Message as TiyMessage, UserMessage};
+    use tokio::sync::{broadcast, Mutex};
+
+    #[tokio::test]
+    async fn mark_thread_run_cancellation_requested_returns_falsey_none_when_thread_is_inactive() {
+        let active_runs = Mutex::new(HashMap::<String, ActiveRun>::new());
+
+        let run_id = mark_thread_run_cancellation_requested(&active_runs, "thread-missing").await;
+
+        assert_eq!(run_id, None);
+    }
+
+    #[tokio::test]
+    async fn mark_thread_run_cancellation_requested_marks_matching_run_and_returns_run_id() {
+        let (frontend_tx, _) = broadcast::channel::<ThreadStreamEvent>(1);
+        let active_runs = Mutex::new(HashMap::from([(
+            "run-1".to_string(),
+            ActiveRun {
+                run_id: "run-1".to_string(),
+                thread_id: "thread-1".to_string(),
+                profile_id: None,
+                frontend_tx,
+                lightweight_model_role: None,
+                streaming_message_id: None,
+                reasoning_message_id: None,
+                cancellation_requested: false,
+            },
+        )]));
+
+        let run_id = mark_thread_run_cancellation_requested(&active_runs, "thread-1").await;
+
+        assert_eq!(run_id.as_deref(), Some("run-1"));
+        let runs = active_runs.lock().await;
+        assert!(runs
+            .get("run-1")
+            .is_some_and(|run| run.cancellation_requested));
+    }
 
     #[test]
     fn normalize_generated_title_strips_prefixes_and_wrappers() {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -4555,7 +4555,16 @@ export function RuntimeThreadSurface({
                 return;
               }
 
-              void streamRef.current?.cancelRun(threadId).then(() => {
+              void streamRef.current?.cancelRun(threadId).then((didCancel) => {
+                if (!didCancel) {
+                  // The backend no longer has an active run for this thread.
+                  // Reload the snapshot to reconcile the stale UI state with
+                  // the actual persisted terminal state without surfacing a
+                  // technical error to the user.
+                  void loadSnapshot();
+                  return;
+                }
+
                 // Optimistic UI update: immediately reflect the cancellation in
                 // the UI so the user sees instant feedback. The backend has
                 // accepted the cancel request but `RunCancelled` may arrive late
@@ -4576,10 +4585,9 @@ export function RuntimeThreadSurface({
                 // correct state and this timer becomes a harmless no-op.
                 return () => clearTimeout(timer);
               }).catch(() => {
-                // The cancel request failed — most likely the run already
-                // finished on the backend but the terminal event was lost or
-                // hasn't arrived yet.  Reload the snapshot to reconcile the
-                // UI with the actual backend state.
+                // The cancel request failed due to a real backend/runtime error.
+                // Reload the snapshot to reconcile the UI after surfacing that
+                // failure through the normal stream error path.
                 void loadSnapshot();
               });
             }}

--- a/src/services/bridge/agent-commands.ts
+++ b/src/services/bridge/agent-commands.ts
@@ -472,9 +472,9 @@ export async function threadCompactContext(
   });
 }
 
-export async function threadCancelRun(threadId: string): Promise<void> {
+export async function threadCancelRun(threadId: string): Promise<boolean> {
   requireTauri("thread_cancel_run");
-  return invoke("thread_cancel_run", { threadId });
+  return invoke<boolean>("thread_cancel_run", { threadId });
 }
 
 export async function toolApprovalRespond(

--- a/src/services/thread-stream/thread-stream.test.ts
+++ b/src/services/thread-stream/thread-stream.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  threadCancelRunMock,
+} = vi.hoisted(() => ({
+  threadCancelRunMock: vi.fn<(...args: unknown[]) => Promise<boolean>>(),
+}));
+
+vi.mock("@/services/bridge", () => ({
+  threadCancelRun: threadCancelRunMock,
+  threadExecuteApprovedPlan: vi.fn(),
+  threadStartRun: vi.fn(),
+  threadSubscribeRun: vi.fn(),
+  toolApprovalRespond: vi.fn(),
+  toolClarifyRespond: vi.fn(),
+}));
+
+import { ThreadStream } from "@/services/thread-stream/thread-stream";
+
+describe("ThreadStream.cancelRun", () => {
+  beforeEach(() => {
+    threadCancelRunMock.mockReset();
+  });
+
+  it("透传后端的幂等取消结果，不触发错误回调", async () => {
+    const stream = new ThreadStream();
+    const onError = vi.fn();
+    stream.onError = onError;
+
+    threadCancelRunMock.mockResolvedValueOnce(false);
+
+    await expect(stream.cancelRun("thread-1")).resolves.toBe(false);
+    expect(threadCancelRunMock).toHaveBeenCalledWith("thread-1");
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("在真实取消失败时仍然上报错误并抛出异常", async () => {
+    const stream = new ThreadStream();
+    const onError = vi.fn();
+    stream.onError = onError;
+
+    threadCancelRunMock.mockRejectedValueOnce(new Error("cancel failed"));
+
+    await expect(stream.cancelRun("thread-2")).rejects.toThrow("cancel failed");
+    expect(onError).toHaveBeenCalledWith("cancel failed", "");
+  });
+});

--- a/src/services/thread-stream/thread-stream.ts
+++ b/src/services/thread-stream/thread-stream.ts
@@ -244,9 +244,9 @@ export class ThreadStream {
   /**
    * Cancel the currently active run.
    */
-  async cancelRun(threadId: string): Promise<void> {
+  async cancelRun(threadId: string): Promise<boolean> {
     try {
-      await threadCancelRun(threadId);
+      return await threadCancelRun(threadId);
     } catch (error) {
       const message = extractErrorMessage(error);
       this.onError?.(message, this.currentRunId ?? "");


### PR DESCRIPTION
## Summary
- Make thread run cancellation idempotent when a thread no longer has an active run.
- Return a boolean cancel result from the Rust/Tauri/TypeScript cancellation path instead of surfacing `thread.run.not_active` to users.
- Refresh the workbench snapshot for stale zombie-thread stop attempts and add regression tests for the new behavior.

## Test Plan
- [x] Run `npm run typecheck`
- [x] Run `npm run test:unit -- src/services/thread-stream/thread-stream.test.ts`
- [x] Run `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml mark_thread_run_cancellation_requested`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml --test m1_5_agent_run`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
