### PR TITLE
fix(workbench-shell): 🐛 Hide thinking placeholder chevron

### DIFF
--- a/src/components/ai-elements/reasoning.tsx
+++ b/src/components/ai-elements/reasoning.tsx
@@ -156,6 +156,7 @@ export type ReasoningTriggerProps = ComponentProps<
   typeof CollapsibleTrigger
 > & {
   getThinkingMessage?: (isStreaming: boolean, duration?: number) => ReactNode;
+  showChevron?: boolean;
 };
 
 const defaultGetThinkingMessage = (isStreaming: boolean, duration?: number) => {
@@ -173,6 +174,7 @@ export const ReasoningTrigger = memo(
     className,
     children,
     getThinkingMessage = defaultGetThinkingMessage,
+    showChevron = true,
     ...props
   }: ReasoningTriggerProps) => {
     const { isStreaming, isOpen, duration } = useReasoning();
@@ -189,12 +191,14 @@ export const ReasoningTrigger = memo(
           <>
             <BrainIcon className="size-4" />
             {getThinkingMessage(isStreaming, duration)}
-            <ChevronDownIcon
-              className={cn(
-                "size-4 transition-transform",
-                isOpen ? "rotate-180" : "rotate-0"
-              )}
-            />
+            {showChevron ? (
+              <ChevronDownIcon
+                className={cn(
+                  "size-4 transition-transform",
+                  isOpen ? "rotate-180" : "rotate-0"
+                )}
+              />
+            ) : null}
           </>
         )}
       </CollapsibleTrigger>

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -4457,7 +4457,7 @@ export function RuntimeThreadSurface({
                         defaultOpen={false}
                         isStreaming
                       >
-                        <ReasoningTrigger />
+                        <ReasoningTrigger showChevron={false} />
                       </Reasoning>
                     </MessageContent>
                   </Message>


### PR DESCRIPTION
## Summary
- Remove the downward chevron from the thinking placeholder trigger shown while the assistant is still reasoning
- Keep the real reasoning block's expand/collapse chevron and behavior unchanged
- Scope the UI change through an opt-in `showChevron` prop on `ReasoningTrigger`

## Test Plan
- [ ] Confirm the temporary thinking placeholder no longer shows a chevron
- [ ] Confirm real reasoning blocks still expand/collapse and keep their chevron
- [ ] Run `npm run typecheck` after TypeScript tooling is available in the environment

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)