### PR TITLE
fix(core): 🐛 Prevent context overflow with auto-compression

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6126,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a44567663b35149de0ac89670585850d03ebd7482126b08c1c9b0d0af2ded6"
+checksum = "1afb2b0b10a7a616941f30c3f1960a4772ccd65f247913b335ac21ed1fcf74c5"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,7 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
-tiycore = "0.1.12"
+tiycore = "0.1.13"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -20,7 +20,7 @@ use crate::core::agent_session::{
     normalize_profile_response_style, trim_history_to_current_context, ProfileResponseStyle,
     ResolvedModelRole,
 };
-use crate::core::built_in_agent_runtime::BuiltInAgentRuntime;
+use crate::core::built_in_agent_runtime::{BuiltInAgentRuntime, RuntimeSessionFinishState};
 use crate::core::plan_checkpoint::{
     ApprovalPromptMetadata, PlanApprovalAction, PlanMessageMetadata,
     IMPLEMENTATION_PLAN_APPROVAL_KIND, IMPLEMENTATION_PLAN_APPROVED_STATE,
@@ -85,6 +85,51 @@ async fn mark_thread_run_cancellation_requested(
     let run = runs.values_mut().find(|run| run.thread_id == thread_id)?;
     run.cancellation_requested = true;
     Some(run.run_id.clone())
+}
+
+fn build_orphaned_run_terminal_event(
+    run_id: &str,
+    cancellation_requested: bool,
+) -> ThreadStreamEvent {
+    if cancellation_requested {
+        ThreadStreamEvent::RunCancelled {
+            run_id: run_id.to_string(),
+        }
+    } else {
+        ThreadStreamEvent::RunInterrupted {
+            run_id: run_id.to_string(),
+        }
+    }
+}
+
+fn terminal_event_status(
+    event: &ThreadStreamEvent,
+    cancellation_requested: bool,
+) -> Option<&'static str> {
+    match event {
+        ThreadStreamEvent::RunCompleted { .. } => Some("completed"),
+        ThreadStreamEvent::RunLimitReached { .. } => Some("limit_reached"),
+        ThreadStreamEvent::RunFailed { .. } => Some("failed"),
+        ThreadStreamEvent::RunCancelled { .. } => Some("cancelled"),
+        ThreadStreamEvent::RunInterrupted { .. } => Some(if cancellation_requested {
+            "cancelled"
+        } else {
+            "interrupted"
+        }),
+        _ => None,
+    }
+}
+
+fn is_terminal_runtime_event(event: &ThreadStreamEvent) -> bool {
+    matches!(
+        event,
+        ThreadStreamEvent::RunCheckpointed { .. }
+            | ThreadStreamEvent::RunCompleted { .. }
+            | ThreadStreamEvent::RunLimitReached { .. }
+            | ThreadStreamEvent::RunFailed { .. }
+            | ThreadStreamEvent::RunCancelled { .. }
+            | ThreadStreamEvent::RunInterrupted { .. }
+    )
 }
 
 pub struct AgentRunManager {
@@ -255,8 +300,9 @@ impl AgentRunManager {
             }
 
             let (runtime_tx, runtime_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-            self.runtime.start_session(spec, runtime_tx).await?;
+            let runtime_finish_rx = self.runtime.start_session(spec, runtime_tx).await?;
             self.spawn_runtime_event_loop(run_id.clone(), runtime_rx);
+            self.spawn_runtime_finish_watchdog(run_id.clone(), runtime_finish_rx);
 
             Ok::<(), AppError>(())
         }
@@ -824,7 +870,31 @@ impl AgentRunManager {
         };
 
         run_repo::update_status(&self.pool, &run_id, "cancelling").await?;
-        self.runtime.cancel_session(&run_id).await?;
+        let cancel_delivered = self.runtime.cancel_session(&run_id).await?;
+
+        if !cancel_delivered {
+            tracing::warn!(
+                run_id = %run_id,
+                "runtime session missing during cancel; forcing cancelled cleanup"
+            );
+            self.handle_runtime_event(&run_id, build_orphaned_run_terminal_event(&run_id, true))
+                .await?;
+            return Ok(true);
+        }
+
+        if matches!(
+            self.runtime.session_finish_state(&run_id).await,
+            Some(RuntimeSessionFinishState::Panicked | RuntimeSessionFinishState::Cancelled)
+        ) {
+            tracing::warn!(
+                run_id = %run_id,
+                "runtime session was already finished when cancel was requested; forcing cancelled cleanup"
+            );
+            self.handle_runtime_event(&run_id, build_orphaned_run_terminal_event(&run_id, true))
+                .await?;
+            return Ok(true);
+        }
+
         tracing::info!(run_id = %run_id, "run cancel requested");
         Ok(true)
     }
@@ -1006,7 +1076,92 @@ impl AgentRunManager {
                     tracing::error!(run_id = %run_id, error = %error, "failed to handle runtime event");
                 }
             }
+
+            if let Err(error) = manager.handle_runtime_channel_closed(&run_id).await {
+                tracing::error!(
+                    run_id = %run_id,
+                    error = %error,
+                    "failed to reconcile run after runtime event channel closed"
+                );
+            }
         });
+    }
+
+    pub(crate) fn spawn_runtime_finish_watchdog(
+        self: &Arc<Self>,
+        run_id: String,
+        mut finish_rx: tokio::sync::watch::Receiver<RuntimeSessionFinishState>,
+    ) {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            if finish_rx.changed().await.is_err() {
+                return;
+            }
+
+            let finish_state = *finish_rx.borrow();
+            if !manager.has_active_run(&run_id).await {
+                return;
+            }
+
+            let event = match finish_state {
+                RuntimeSessionFinishState::Running | RuntimeSessionFinishState::Completed => return,
+                RuntimeSessionFinishState::Panicked => ThreadStreamEvent::RunInterrupted {
+                    run_id: run_id.clone(),
+                },
+                RuntimeSessionFinishState::Cancelled => {
+                    build_orphaned_run_terminal_event(&run_id, true)
+                }
+            };
+
+            if let Err(error) = manager.handle_runtime_event(&run_id, event).await {
+                tracing::error!(
+                    run_id = %run_id,
+                    error = %error,
+                    finish_state = ?finish_state,
+                    "failed to reconcile run after runtime task finished"
+                );
+            }
+        });
+    }
+
+    async fn handle_runtime_channel_closed(&self, run_id: &str) -> Result<(), AppError> {
+        if !self.has_active_run(run_id).await {
+            return Ok(());
+        }
+
+        let runtime_state = self.runtime.session_state(run_id).await;
+        let runtime_finish_state = self.runtime.session_finish_state(run_id).await;
+        let cancellation_requested = self.was_cancel_requested(run_id).await;
+
+        let Some(terminal_event) = (match runtime_finish_state {
+            Some(RuntimeSessionFinishState::Completed) => None,
+            Some(RuntimeSessionFinishState::Panicked) => Some(ThreadStreamEvent::RunInterrupted {
+                run_id: run_id.to_string(),
+            }),
+            Some(RuntimeSessionFinishState::Cancelled) => {
+                Some(build_orphaned_run_terminal_event(run_id, true))
+            }
+            Some(RuntimeSessionFinishState::Running) | None => Some(
+                build_orphaned_run_terminal_event(run_id, cancellation_requested),
+            ),
+        }) else {
+            tracing::debug!(
+                run_id = %run_id,
+                runtime_state = ?runtime_state,
+                "runtime event channel closed after session completed; skipping forced cleanup"
+            );
+            return Ok(());
+        };
+
+        tracing::warn!(
+            run_id = %run_id,
+            cancellation_requested,
+            runtime_state = ?runtime_state,
+            runtime_finish_state = ?runtime_finish_state,
+            "runtime event channel closed before a terminal event; forcing run cleanup"
+        );
+
+        self.handle_runtime_event(run_id, terminal_event).await
     }
 
     async fn handle_runtime_event(
@@ -1014,6 +1169,15 @@ impl AgentRunManager {
         run_id: &str,
         event: ThreadStreamEvent,
     ) -> Result<(), AppError> {
+        if is_terminal_runtime_event(&event) && !self.has_active_run(run_id).await {
+            tracing::debug!(
+                run_id = %run_id,
+                event = ?event,
+                "ignoring duplicate terminal runtime event after run cleanup"
+            );
+            return Ok(());
+        }
+
         if should_complete_reasoning_for_event(&event) {
             self.complete_active_reasoning_message(run_id, "completed")
                 .await?;
@@ -1163,14 +1327,8 @@ impl AgentRunManager {
             | ThreadStreamEvent::RunCancelled { .. }
             | ThreadStreamEvent::RunInterrupted { .. } => {
                 let thread_id = self.get_thread_id(run_id).await;
-                let status = match &event {
-                    ThreadStreamEvent::RunCompleted { .. } => "completed",
-                    ThreadStreamEvent::RunLimitReached { .. } => "limit_reached",
-                    ThreadStreamEvent::RunFailed { .. } => "failed",
-                    ThreadStreamEvent::RunCancelled { .. } => "cancelled",
-                    ThreadStreamEvent::RunInterrupted { .. } => "interrupted",
-                    _ => unreachable!(),
-                };
+                let status = terminal_event_status(&event, self.was_cancel_requested(run_id).await)
+                    .expect("terminal run event should resolve to a status");
                 let _ = self.app_handle.emit(
                     app_events::THREAD_RUN_FINISHED,
                     ThreadRunFinishedPayload {
@@ -1183,15 +1341,7 @@ impl AgentRunManager {
             _ => {}
         }
 
-        if matches!(
-            event,
-            ThreadStreamEvent::RunCheckpointed { .. }
-                | ThreadStreamEvent::RunCompleted { .. }
-                | ThreadStreamEvent::RunLimitReached { .. }
-                | ThreadStreamEvent::RunFailed { .. }
-                | ThreadStreamEvent::RunCancelled { .. }
-                | ThreadStreamEvent::RunInterrupted { .. }
-        ) {
+        if is_terminal_runtime_event(&event) {
             self.runtime.remove_session(run_id).await;
             self.remove_active_run(run_id).await;
         }
@@ -1468,6 +1618,11 @@ impl AgentRunManager {
         runs.get(run_id)
             .map(|run| run.thread_id.clone())
             .unwrap_or_default()
+    }
+
+    async fn has_active_run(&self, run_id: &str) -> bool {
+        let runs = self.active_runs.lock().await;
+        runs.contains_key(run_id)
     }
 
     async fn was_cancel_requested(&self, run_id: &str) -> bool {
@@ -2628,12 +2783,13 @@ mod tests {
     use super::{
         append_compact_instructions, await_summary_with_abort, build_compact_summary_messages,
         build_compact_summary_system_prompt, build_implementation_handoff_prompt,
-        build_merge_summary_messages, build_merge_summary_system_prompt, build_title_prompt,
-        collapse_whitespace, detect_prior_summary, extract_context_summary_block,
+        build_merge_summary_messages, build_merge_summary_system_prompt,
+        build_orphaned_run_terminal_event, build_title_prompt, collapse_whitespace,
+        detect_prior_summary, extract_context_summary_block,
         mark_thread_run_cancellation_requested, normalize_compact_summary,
         normalize_generated_title, render_compact_summary_history,
-        should_complete_reasoning_for_event, summary_history_char_budget, truncate_chars,
-        truncate_chars_keep_tail, truncate_tool_result_head_tail, ActiveRun,
+        should_complete_reasoning_for_event, summary_history_char_budget, terminal_event_status,
+        truncate_chars, truncate_chars_keep_tail, truncate_tool_result_head_tail, ActiveRun,
         SUMMARY_HISTORY_MIN_CHARS, SUMMARY_TOOL_RESULT_MAX_CHARS,
     };
     use crate::core::agent_session::{ProfileResponseStyle, ResolvedModelRole};
@@ -2707,6 +2863,38 @@ mod tests {
             reasoning_message_id: None,
             cancellation_requested: false,
         }
+    }
+
+    #[test]
+    fn orphaned_run_terminal_event_uses_cancelled_when_user_requested_stop() {
+        let cancelled = build_orphaned_run_terminal_event("run-1", true);
+        let interrupted = build_orphaned_run_terminal_event("run-2", false);
+
+        assert!(matches!(
+            cancelled,
+            ThreadStreamEvent::RunCancelled { ref run_id } if run_id == "run-1"
+        ));
+        assert!(matches!(
+            interrupted,
+            ThreadStreamEvent::RunInterrupted { ref run_id } if run_id == "run-2"
+        ));
+    }
+
+    #[test]
+    fn terminal_event_status_maps_interrupted_to_cancelled_when_cancel_was_requested() {
+        let interrupted = ThreadStreamEvent::RunInterrupted {
+            run_id: "run-1".to_string(),
+        };
+        let cancelled = ThreadStreamEvent::RunCancelled {
+            run_id: "run-1".to_string(),
+        };
+
+        assert_eq!(terminal_event_status(&interrupted, true), Some("cancelled"));
+        assert_eq!(
+            terminal_event_status(&interrupted, false),
+            Some("interrupted")
+        );
+        assert_eq!(terminal_event_status(&cancelled, false), Some("cancelled"));
     }
 
     /// Mirrors the check in `compact_thread_context` (and `start_run`): a

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -15,6 +15,7 @@ use tiycore::types::{
 };
 use tokio::sync::mpsc;
 
+use crate::core::context_compression::ContextTokenCalibration;
 use crate::core::plan_checkpoint::{
     approval_prompt_markdown, build_approval_prompt_metadata, build_plan_artifact_from_tool_input,
     build_plan_message_metadata, parse_plan_message_metadata, plan_markdown, write_plan_file,
@@ -33,8 +34,10 @@ use crate::extensions::ExtensionsManager;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::provider::AgentProfileRecord;
-use crate::model::thread::{MessageAttachmentDto, MessageRecord, RunUsageDto, ToolCallDto};
-use crate::persistence::repo::{message_repo, provider_repo, tool_call_repo};
+use crate::model::thread::{
+    MessageAttachmentDto, MessageRecord, RunSummaryDto, RunUsageDto, ToolCallDto,
+};
+use crate::persistence::repo::{message_repo, provider_repo, run_repo, tool_call_repo};
 
 /// Deprecated: previously used as the hard limit for `message_repo::list_recent` in
 /// `build_session_spec`.  Replaced by `message_repo::list_since_last_reset()` which
@@ -137,6 +140,7 @@ pub struct AgentSessionSpec {
     pub history_tool_calls: Vec<ToolCallDto>,
     pub model_plan: ResolvedRuntimeModelPlan,
     pub initial_prompt: Option<String>,
+    pub initial_context_calibration: ContextTokenCalibration,
 }
 
 pub async fn build_session_spec(
@@ -168,11 +172,20 @@ pub async fn build_session_spec(
         .into_iter()
         .collect();
     let history_tool_calls = tool_call_repo::list_by_run_ids(pool, &history_run_ids).await?;
+    let latest_historical_run =
+        run_repo::find_latest_with_input_usage_by_thread_excluding_run(pool, thread_id, run_id)
+            .await?;
 
     let system_prompt = build_system_prompt(pool, &raw_plan, workspace_path, run_mode).await?;
     let extension_tools = ExtensionsManager::new(pool.clone())
         .list_runtime_agent_tools(Some(workspace_path))
         .await?;
+    let initial_context_calibration = build_initial_context_token_calibration(
+        latest_historical_run.as_ref(),
+        &history_messages,
+        &history_tool_calls,
+        &resolved_plan.primary,
+    );
 
     Ok(AgentSessionSpec {
         run_id: run_id.to_string(),
@@ -189,6 +202,7 @@ pub async fn build_session_spec(
         history_tool_calls,
         model_plan: resolved_plan,
         initial_prompt: None,
+        initial_context_calibration,
     })
 }
 
@@ -206,6 +220,105 @@ pub(crate) fn trim_history_to_current_context(messages: &[MessageRecord]) -> Vec
         .collect()
 }
 
+#[derive(Debug, Default)]
+struct ContextCompressionRuntimeState {
+    calibration: ContextTokenCalibration,
+    pending_prompt_estimate: Option<u32>,
+}
+
+impl ContextCompressionRuntimeState {
+    fn new(initial_calibration: ContextTokenCalibration) -> Self {
+        Self {
+            calibration: initial_calibration,
+            pending_prompt_estimate: None,
+        }
+    }
+
+    fn calibration(&self) -> ContextTokenCalibration {
+        self.calibration
+    }
+
+    fn record_pending_prompt_estimate(&mut self, estimated_tokens: u32) {
+        self.pending_prompt_estimate = Some(estimated_tokens);
+    }
+
+    fn observe_input_usage(&mut self, actual_input_tokens: u64) {
+        let Some(estimated_tokens) = self.pending_prompt_estimate.take() else {
+            return;
+        };
+
+        self.calibration = self
+            .calibration
+            .observe(estimated_tokens, actual_input_tokens);
+    }
+}
+
+fn current_context_token_calibration(
+    state: &StdMutex<ContextCompressionRuntimeState>,
+) -> ContextTokenCalibration {
+    state
+        .lock()
+        .map(|state| state.calibration())
+        .unwrap_or_default()
+}
+
+fn record_pending_prompt_estimate(
+    state: &StdMutex<ContextCompressionRuntimeState>,
+    estimated_tokens: u32,
+) {
+    if let Ok(mut state) = state.lock() {
+        state.record_pending_prompt_estimate(estimated_tokens);
+    }
+}
+
+fn observe_context_usage_calibration(
+    state: &StdMutex<ContextCompressionRuntimeState>,
+    usage: &Usage,
+) {
+    if usage.input == 0 {
+        return;
+    }
+
+    if let Ok(mut state) = state.lock() {
+        state.observe_input_usage(usage.input);
+    }
+}
+
+fn build_initial_context_token_calibration(
+    latest_historical_run: Option<&RunSummaryDto>,
+    history_messages: &[MessageRecord],
+    history_tool_calls: &[ToolCallDto],
+    primary_model: &ResolvedModelRole,
+) -> ContextTokenCalibration {
+    let Some(latest_historical_run) = latest_historical_run else {
+        return ContextTokenCalibration::default();
+    };
+
+    if latest_historical_run.usage.input_tokens == 0
+        || !run_summary_matches_primary_model(latest_historical_run, primary_model)
+    {
+        return ContextTokenCalibration::default();
+    }
+
+    let history =
+        convert_history_messages(history_messages, history_tool_calls, &primary_model.model);
+    let estimated_tokens = crate::core::context_compression::estimate_total_tokens(&history);
+
+    ContextTokenCalibration::from_observation(
+        estimated_tokens,
+        latest_historical_run.usage.input_tokens,
+    )
+    .unwrap_or_default()
+}
+
+fn run_summary_matches_primary_model(
+    run_summary: &RunSummaryDto,
+    primary_model: &ResolvedModelRole,
+) -> bool {
+    run_summary.model_id.as_deref() == Some(primary_model.model_id.as_str())
+        || run_summary.model_id.as_deref() == Some(primary_model.model.id.as_str())
+}
+
 pub struct AgentSession {
     spec: AgentSessionSpec,
     pool: SqlitePool,
@@ -216,6 +329,7 @@ pub struct AgentSession {
     cancel_requested: Arc<AtomicBool>,
     checkpoint_requested: AtomicBool,
     abort_signal: tiycore::agent::AbortSignal,
+    context_compression_state: Arc<StdMutex<ContextCompressionRuntimeState>>,
 }
 
 impl AgentSession {
@@ -229,8 +343,16 @@ impl AgentSession {
     ) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| {
             let agent = Arc::new(Agent::with_model(spec.model_plan.primary.model.clone()));
+            let context_compression_state = Arc::new(StdMutex::new(
+                ContextCompressionRuntimeState::new(spec.initial_context_calibration),
+            ));
             agent.set_max_turns(max_turns);
-            configure_agent(&agent, &spec, weak_self.clone());
+            configure_agent(
+                &agent,
+                &spec,
+                weak_self.clone(),
+                Arc::clone(&context_compression_state),
+            );
 
             Self {
                 spec,
@@ -242,6 +364,7 @@ impl AgentSession {
                 cancel_requested: Arc::new(AtomicBool::new(false)),
                 checkpoint_requested: AtomicBool::new(false),
                 abort_signal: tiycore::agent::AbortSignal::new(),
+                context_compression_state,
             }
         })
     }
@@ -281,6 +404,7 @@ impl AgentSession {
         let reasoning_message_id_ref = Arc::clone(&current_reasoning_message_id);
         let last_usage_ref = Arc::clone(&last_usage);
         let reasoning_ref = Arc::clone(&reasoning_buffer);
+        let context_compression_state_ref = Arc::clone(&self.context_compression_state);
         let unsubscribe = self.agent.subscribe(move |event| {
             handle_agent_event(
                 &run_id,
@@ -289,6 +413,7 @@ impl AgentSession {
                 &last_completed_message_id_ref,
                 &reasoning_message_id_ref,
                 &last_usage_ref,
+                &context_compression_state_ref,
                 &reasoning_ref,
                 &context_window,
                 &model_display_name,
@@ -1021,7 +1146,12 @@ impl AgentSession {
     }
 }
 
-fn configure_agent(agent: &Arc<Agent>, spec: &AgentSessionSpec, weak_self: Weak<AgentSession>) {
+fn configure_agent(
+    agent: &Arc<Agent>,
+    spec: &AgentSessionSpec,
+    weak_self: Weak<AgentSession>,
+    context_compression_state: Arc<StdMutex<ContextCompressionRuntimeState>>,
+) {
     agent.set_system_prompt(spec.system_prompt.clone());
     agent.replace_messages(convert_history_messages(
         &spec.history_messages,
@@ -1062,14 +1192,25 @@ fn configure_agent(agent: &Arc<Agent>, spec: &AgentSessionSpec, weak_self: Weak<
     let compression_weak_self = weak_self.clone();
     let compression_thread_id = spec.thread_id.clone();
     let compression_run_id = spec.run_id.clone();
+    let compression_state = Arc::clone(&context_compression_state);
     agent.set_transform_context(move |messages| {
         // Cheap pass-through check first: only clone the heavy captured state
         // (ResolvedModelRole, String ids, Weak) when compression will actually
         // run. For long sessions with many turns this avoids per-turn heap
         // allocations when the thread is still well under budget.
         let settings = compression_settings.clone();
-        let needs_compression =
-            crate::core::context_compression::should_compress(&messages, &settings);
+        let raw_estimated_tokens =
+            crate::core::context_compression::estimate_total_tokens(&messages);
+        let calibration = current_context_token_calibration(&compression_state);
+        let calibrated_total_tokens = crate::core::context_compression::calibrate_total_tokens(
+            raw_estimated_tokens,
+            Some(calibration),
+        );
+        let needs_compression = !messages.is_empty()
+            && crate::core::context_compression::should_compress_total_tokens(
+                calibrated_total_tokens,
+                &settings,
+            );
 
         let model_role = if needs_compression {
             Some(primary_model_role.clone())
@@ -1091,23 +1232,29 @@ fn configure_agent(agent: &Arc<Agent>, spec: &AgentSessionSpec, weak_self: Weak<
         } else {
             None
         };
+        let compression_state = Arc::clone(&compression_state);
 
         async move {
-            if !needs_compression {
-                return messages;
-            }
-            // Unwraps are sound: all `Some(_)` are populated together under
-            // `needs_compression`, so either all four are `Some` (compression
-            // path) or we returned above.
-            run_auto_compression(
-                messages,
-                settings,
-                model_role.expect("model_role populated when compressing"),
-                weak.expect("weak populated when compressing"),
-                thread_id.expect("thread_id populated when compressing"),
-                run_id.expect("run_id populated when compressing"),
-            )
-            .await
+            let transformed_messages = if !needs_compression {
+                messages
+            } else {
+                // Unwraps are sound: all `Some(_)` are populated together under
+                // `needs_compression`, so either all four are `Some` (compression
+                // path) or we returned above.
+                run_auto_compression(
+                    messages,
+                    settings,
+                    model_role.expect("model_role populated when compressing"),
+                    weak.expect("weak populated when compressing"),
+                    thread_id.expect("thread_id populated when compressing"),
+                    run_id.expect("run_id populated when compressing"),
+                )
+                .await
+            };
+            let sent_estimated_tokens =
+                crate::core::context_compression::estimate_total_tokens(&transformed_messages);
+            record_pending_prompt_estimate(&compression_state, sent_estimated_tokens);
+            transformed_messages
         }
     });
 
@@ -1155,6 +1302,7 @@ fn handle_agent_event(
     last_completed_message_id: &StdMutex<Option<String>>,
     current_reasoning_message_id: &StdMutex<Option<String>>,
     last_usage: &StdMutex<Option<Usage>>,
+    context_compression_state: &StdMutex<ContextCompressionRuntimeState>,
     reasoning_buffer: &StdMutex<String>,
     context_window: &str,
     model_display_name: &str,
@@ -1231,6 +1379,7 @@ fn handle_agent_event(
                     run_id,
                     event_tx,
                     last_usage,
+                    context_compression_state,
                     &partial.usage,
                     context_window,
                     model_display_name,
@@ -1245,6 +1394,7 @@ fn handle_agent_event(
                         run_id,
                         event_tx,
                         last_usage,
+                        context_compression_state,
                         &assistant.usage,
                         context_window,
                         model_display_name,
@@ -1258,6 +1408,7 @@ fn handle_agent_event(
                     run_id,
                     event_tx,
                     last_usage,
+                    context_compression_state,
                     &assistant.usage,
                     context_window,
                     model_display_name,
@@ -1290,6 +1441,7 @@ fn emit_usage_update_if_changed(
     run_id: &str,
     event_tx: &mpsc::UnboundedSender<ThreadStreamEvent>,
     last_usage: &StdMutex<Option<Usage>>,
+    context_compression_state: &StdMutex<ContextCompressionRuntimeState>,
     usage: &Usage,
     context_window: &str,
     model_display_name: &str,
@@ -1321,6 +1473,8 @@ fn emit_usage_update_if_changed(
     if !should_emit {
         return;
     }
+
+    observe_context_usage_calibration(context_compression_state, usage);
 
     let _ = event_tx.send(ThreadStreamEvent::ThreadUsageUpdated {
         run_id: run_id.to_string(),
@@ -3309,14 +3463,15 @@ fn merge_json_value(base: &mut serde_json::Value, patch: &serde_json::Value) {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_profile_response_prompt_parts, build_system_prompt, convert_history_messages,
+        build_initial_context_token_calibration, build_profile_response_prompt_parts,
+        build_system_prompt, convert_history_messages, current_context_token_calibration,
         handle_agent_event, main_agent_security_config, normalize_profile_response_language,
         normalize_profile_response_style, plan_mode_missing_checkpoint_error,
-        resolve_helper_model_role, resolve_helper_profile, response_style_system_instruction,
-        runtime_security_config, runtime_tools_for_profile,
+        record_pending_prompt_estimate, resolve_helper_model_role, resolve_helper_profile,
+        response_style_system_instruction, runtime_security_config, runtime_tools_for_profile,
         runtime_tools_for_profile_with_extensions, standard_tool_timeout,
-        trim_history_to_current_context, ProfileResponseStyle, ResolvedModelRole,
-        ResolvedRuntimeModelPlan, RuntimeModelPlan, DEFAULT_FULL_TOOL_PROFILE,
+        trim_history_to_current_context, ContextCompressionRuntimeState, ProfileResponseStyle,
+        ResolvedModelRole, ResolvedRuntimeModelPlan, RuntimeModelPlan, DEFAULT_FULL_TOOL_PROFILE,
         MAIN_AGENT_TOOL_TIMEOUT_SECS, PLAN_MODE_MISSING_CHECKPOINT_ERROR,
         PLAN_READ_ONLY_TOOL_PROFILE, STANDARD_TOOL_TIMEOUT_SECS, SUBAGENT_TOOL_TIMEOUT_SECS,
     };
@@ -3338,7 +3493,7 @@ mod tests {
     use crate::core::subagent::{RuntimeOrchestrationTool, SubagentProfile};
     use crate::ipc::frontend_channels::ThreadStreamEvent;
     use crate::model::provider::AgentProfileRecord;
-    use crate::model::thread::MessageRecord;
+    use crate::model::thread::{MessageRecord, RunSummaryDto, RunUsageDto};
     use crate::persistence::init_database;
 
     const TEST_CONTEXT_WINDOW: &str = "128000";
@@ -3421,6 +3576,42 @@ mod tests {
         }
     }
 
+    fn make_history_message(id: &str, run_id: &str, role: &str, content: &str) -> MessageRecord {
+        MessageRecord {
+            id: id.to_string(),
+            thread_id: "thread-1".to_string(),
+            run_id: Some(run_id.to_string()),
+            role: role.to_string(),
+            content_markdown: content.to_string(),
+            message_type: "plain_message".to_string(),
+            status: "completed".to_string(),
+            metadata_json: None,
+            attachments_json: None,
+            created_at: "2026-01-01T00:00:00.000Z".to_string(),
+        }
+    }
+
+    fn make_run_summary(model_id: &str, input_tokens: u64) -> RunSummaryDto {
+        RunSummaryDto {
+            id: "run-prev".to_string(),
+            thread_id: "thread-1".to_string(),
+            run_mode: "default".to_string(),
+            status: "completed".to_string(),
+            model_id: Some(model_id.to_string()),
+            model_display_name: Some(model_id.to_string()),
+            context_window: Some(TEST_CONTEXT_WINDOW.to_string()),
+            error_message: None,
+            started_at: "2026-01-01T00:00:00.000Z".to_string(),
+            usage: RunUsageDto {
+                input_tokens,
+                output_tokens: 128,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                total_tokens: input_tokens + 128,
+            },
+        }
+    }
+
     fn message_text(message: &AgentMessage) -> String {
         match message {
             AgentMessage::User(user) => match &user.content {
@@ -3458,6 +3649,29 @@ mod tests {
         reasoning_buffer: &StdMutex<String>,
         event: &AgentEvent,
     ) {
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        handle_test_agent_event_with_context_state(
+            run_id,
+            event_tx,
+            current_message_id,
+            current_reasoning_message_id,
+            last_usage,
+            &context_compression_state,
+            reasoning_buffer,
+            event,
+        );
+    }
+
+    fn handle_test_agent_event_with_context_state(
+        run_id: &str,
+        event_tx: &mpsc::UnboundedSender<ThreadStreamEvent>,
+        current_message_id: &StdMutex<Option<String>>,
+        current_reasoning_message_id: &StdMutex<Option<String>>,
+        last_usage: &StdMutex<Option<tiycore::types::Usage>>,
+        context_compression_state: &StdMutex<ContextCompressionRuntimeState>,
+        reasoning_buffer: &StdMutex<String>,
+        event: &AgentEvent,
+    ) {
         let last_completed_message_id = StdMutex::new(None::<String>);
         handle_agent_event(
             run_id,
@@ -3466,6 +3680,7 @@ mod tests {
             &last_completed_message_id,
             current_reasoning_message_id,
             last_usage,
+            context_compression_state,
             reasoning_buffer,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
@@ -3968,12 +4183,121 @@ Used for prompt assembly coverage.
     }
 
     #[test]
+    fn message_end_usage_updates_consume_pending_prompt_estimate_once() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let current_message_id = StdMutex::new(None::<String>);
+        let current_reasoning_message_id = StdMutex::new(None::<String>);
+        let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        let reasoning_buffer = StdMutex::new(String::new());
+        let assistant = AssistantMessage::builder()
+            .api(Api::OpenAICompletions)
+            .provider(Provider::OpenAI)
+            .model("gpt-test")
+            .usage(tiycore::types::Usage::from_tokens(1_500, 32))
+            .build()
+            .expect("assistant message with usage");
+
+        record_pending_prompt_estimate(&context_compression_state, 1_000);
+        handle_test_agent_event_with_context_state(
+            "run-usage-calibration",
+            &event_tx,
+            &current_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &AgentEvent::MessageEnd {
+                message: AgentMessage::Assistant(assistant.clone()),
+            },
+        );
+        handle_test_agent_event_with_context_state(
+            "run-usage-calibration",
+            &event_tx,
+            &current_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &AgentEvent::MessageEnd {
+                message: AgentMessage::Assistant(assistant),
+            },
+        );
+
+        let usage_events = std::iter::from_fn(|| event_rx.try_recv().ok())
+            .filter(|event| matches!(event, ThreadStreamEvent::ThreadUsageUpdated { .. }))
+            .count();
+        let calibration = current_context_token_calibration(&context_compression_state);
+
+        assert_eq!(usage_events, 1);
+        assert_eq!(calibration.ratio_basis_points(), 15_000);
+        assert!(context_compression_state
+            .lock()
+            .expect("context compression state")
+            .pending_prompt_estimate
+            .is_none());
+    }
+
+    #[test]
+    fn build_initial_context_token_calibration_seeds_from_matching_historical_run() {
+        let primary_model = sample_resolved_model_role("primary-model");
+        let history_messages = vec![
+            make_history_message("msg-1", "run-prev", "user", &"x".repeat(600)),
+            make_history_message("msg-2", "run-prev", "assistant", &"y".repeat(600)),
+        ];
+        let history = convert_history_messages(&history_messages, &[], &primary_model.model);
+        let estimated_tokens = crate::core::context_compression::estimate_total_tokens(&history);
+        let run_summary = make_run_summary("primary-model", (estimated_tokens as u64) * 2);
+
+        let calibration = build_initial_context_token_calibration(
+            Some(&run_summary),
+            &history_messages,
+            &[],
+            &primary_model,
+        );
+
+        assert_eq!(calibration.ratio_basis_points(), 20_000);
+        assert_eq!(
+            calibration.apply_to_estimate(estimated_tokens),
+            estimated_tokens * 2
+        );
+    }
+
+    #[test]
+    fn build_initial_context_token_calibration_ignores_mismatched_models_and_zero_usage() {
+        let primary_model = sample_resolved_model_role("primary-model");
+        let history_messages = vec![make_history_message(
+            "msg-1",
+            "run-prev",
+            "user",
+            &"x".repeat(400),
+        )];
+
+        let mismatched = build_initial_context_token_calibration(
+            Some(&make_run_summary("other-model", 4_096)),
+            &history_messages,
+            &[],
+            &primary_model,
+        );
+        let zero_usage = build_initial_context_token_calibration(
+            Some(&make_run_summary("primary-model", 0)),
+            &history_messages,
+            &[],
+            &primary_model,
+        );
+
+        assert_eq!(mismatched.ratio_basis_points(), 10_000);
+        assert_eq!(zero_usage.ratio_basis_points(), 10_000);
+    }
+
+    #[test]
     fn turn_retrying_event_emits_runtime_retry_notice() {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let current_message_id = StdMutex::new(None::<String>);
         let last_completed_message_id = StdMutex::new(None::<String>);
         let current_reasoning_message_id = StdMutex::new(None::<String>);
         let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
 
         handle_agent_event(
@@ -3983,6 +4307,7 @@ Used for prompt assembly coverage.
             &last_completed_message_id,
             &current_reasoning_message_id,
             &last_usage,
+            &context_compression_state,
             &reasoning_buffer,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
@@ -4014,6 +4339,7 @@ Used for prompt assembly coverage.
         let last_completed_message_id = StdMutex::new(None::<String>);
         let current_reasoning_message_id = StdMutex::new(None::<String>);
         let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let assistant = sample_partial_assistant_message();
 
@@ -4024,6 +4350,7 @@ Used for prompt assembly coverage.
             &last_completed_message_id,
             &current_reasoning_message_id,
             &last_usage,
+            &context_compression_state,
             &reasoning_buffer,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
@@ -4038,6 +4365,7 @@ Used for prompt assembly coverage.
             &last_completed_message_id,
             &current_reasoning_message_id,
             &last_usage,
+            &context_compression_state,
             &reasoning_buffer,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -369,10 +369,10 @@ impl AgentSession {
         })
     }
 
-    pub fn start(self: Arc<Self>) {
+    pub fn start(self: Arc<Self>) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             self.run().await;
-        });
+        })
     }
 
     pub async fn cancel(&self) {

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -173,7 +173,7 @@ pub async fn build_session_spec(
         .collect();
     let history_tool_calls = tool_call_repo::list_by_run_ids(pool, &history_run_ids).await?;
     let latest_historical_run =
-        run_repo::find_latest_with_input_usage_by_thread_excluding_run(pool, thread_id, run_id)
+        run_repo::find_latest_with_prompt_usage_by_thread_excluding_run(pool, thread_id, run_id)
             .await?;
 
     let system_prompt = build_system_prompt(pool, &raw_plan, workspace_path, run_mode).await?;
@@ -220,6 +220,10 @@ pub(crate) fn trim_history_to_current_context(messages: &[MessageRecord]) -> Vec
         .collect()
 }
 
+fn effective_prompt_tokens(input_tokens: u64, cache_read_tokens: u64) -> u64 {
+    input_tokens.saturating_add(cache_read_tokens)
+}
+
 #[derive(Debug, Default)]
 struct ContextCompressionRuntimeState {
     calibration: ContextTokenCalibration,
@@ -242,14 +246,14 @@ impl ContextCompressionRuntimeState {
         self.pending_prompt_estimate = Some(estimated_tokens);
     }
 
-    fn observe_input_usage(&mut self, actual_input_tokens: u64) {
+    fn observe_prompt_usage(&mut self, actual_prompt_tokens: u64) {
         let Some(estimated_tokens) = self.pending_prompt_estimate.take() else {
             return;
         };
 
         self.calibration = self
             .calibration
-            .observe(estimated_tokens, actual_input_tokens);
+            .observe(estimated_tokens, actual_prompt_tokens);
     }
 }
 
@@ -275,12 +279,13 @@ fn observe_context_usage_calibration(
     state: &StdMutex<ContextCompressionRuntimeState>,
     usage: &Usage,
 ) {
-    if usage.input == 0 {
+    let actual_prompt_tokens = effective_prompt_tokens(usage.input, usage.cache_read);
+    if actual_prompt_tokens == 0 {
         return;
     }
 
     if let Ok(mut state) = state.lock() {
-        state.observe_input_usage(usage.input);
+        state.observe_prompt_usage(actual_prompt_tokens);
     }
 }
 
@@ -294,7 +299,11 @@ fn build_initial_context_token_calibration(
         return ContextTokenCalibration::default();
     };
 
-    if latest_historical_run.usage.input_tokens == 0
+    let historical_prompt_tokens = effective_prompt_tokens(
+        latest_historical_run.usage.input_tokens,
+        latest_historical_run.usage.cache_read_tokens,
+    );
+    if historical_prompt_tokens == 0
         || !run_summary_matches_primary_model(latest_historical_run, primary_model)
     {
         return ContextTokenCalibration::default();
@@ -304,11 +313,8 @@ fn build_initial_context_token_calibration(
         convert_history_messages(history_messages, history_tool_calls, &primary_model.model);
     let estimated_tokens = crate::core::context_compression::estimate_total_tokens(&history);
 
-    ContextTokenCalibration::from_observation(
-        estimated_tokens,
-        latest_historical_run.usage.input_tokens,
-    )
-    .unwrap_or_default()
+    ContextTokenCalibration::from_observation(estimated_tokens, historical_prompt_tokens)
+        .unwrap_or_default()
 }
 
 fn run_summary_matches_primary_model(
@@ -3603,6 +3609,14 @@ mod tests {
     }
 
     fn make_run_summary(model_id: &str, input_tokens: u64) -> RunSummaryDto {
+        make_run_summary_with_cache(model_id, input_tokens, 0)
+    }
+
+    fn make_run_summary_with_cache(
+        model_id: &str,
+        input_tokens: u64,
+        cache_read_tokens: u64,
+    ) -> RunSummaryDto {
         RunSummaryDto {
             id: "run-prev".to_string(),
             thread_id: "thread-1".to_string(),
@@ -3616,9 +3630,9 @@ mod tests {
             usage: RunUsageDto {
                 input_tokens,
                 output_tokens: 128,
-                cache_read_tokens: 0,
+                cache_read_tokens,
                 cache_write_tokens: 0,
-                total_tokens: input_tokens + 128,
+                total_tokens: input_tokens + cache_read_tokens + 128,
             },
         }
     }
@@ -4250,6 +4264,61 @@ Used for prompt assembly coverage.
     }
 
     #[test]
+    fn usage_calibration_counts_cache_read_when_input_is_zero() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let current_message_id = StdMutex::new(None::<String>);
+        let last_completed_message_id = StdMutex::new(None::<String>);
+        let current_reasoning_message_id = StdMutex::new(None::<String>);
+        let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        let reasoning_buffer = StdMutex::new(String::new());
+        let assistant = AssistantMessage::builder()
+            .api(Api::OpenAICompletions)
+            .provider(Provider::OpenAI)
+            .model("gpt-test")
+            .usage(tiycore::types::Usage {
+                input: 0,
+                output: 32,
+                cache_read: 1_500,
+                cache_write: 0,
+                total_tokens: 1_532,
+                cost: tiycore::types::UsageCost::default(),
+            })
+            .build()
+            .expect("assistant message with cache-read usage");
+
+        record_pending_prompt_estimate(&context_compression_state, 1_000);
+        handle_agent_event(
+            "run-cache-read-calibration",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &AgentEvent::MessageEnd {
+                message: AgentMessage::Assistant(assistant),
+            },
+        );
+
+        let usage_events = std::iter::from_fn(|| event_rx.try_recv().ok())
+            .filter(|event| matches!(event, ThreadStreamEvent::ThreadUsageUpdated { .. }))
+            .count();
+        let calibration = current_context_token_calibration(&context_compression_state);
+
+        assert_eq!(usage_events, 1);
+        assert_eq!(calibration.ratio_basis_points(), 15_000);
+        assert!(context_compression_state
+            .lock()
+            .expect("context compression state")
+            .pending_prompt_estimate
+            .is_none());
+    }
+
+    #[test]
     fn build_initial_context_token_calibration_seeds_from_matching_historical_run() {
         let primary_model = sample_resolved_model_role("primary-model");
         let history_messages = vec![
@@ -4259,6 +4328,35 @@ Used for prompt assembly coverage.
         let history = convert_history_messages(&history_messages, &[], &primary_model.model);
         let estimated_tokens = crate::core::context_compression::estimate_total_tokens(&history);
         let run_summary = make_run_summary("primary-model", (estimated_tokens as u64) * 2);
+
+        let calibration = build_initial_context_token_calibration(
+            Some(&run_summary),
+            &history_messages,
+            &[],
+            &primary_model,
+        );
+
+        assert_eq!(calibration.ratio_basis_points(), 20_000);
+        assert_eq!(
+            calibration.apply_to_estimate(estimated_tokens),
+            estimated_tokens * 2
+        );
+    }
+
+    #[test]
+    fn build_initial_context_token_calibration_counts_cache_read_tokens() {
+        let primary_model = sample_resolved_model_role("primary-model");
+        let history_messages = vec![
+            make_history_message("msg-1", "run-prev", "user", &"x".repeat(600)),
+            make_history_message("msg-2", "run-prev", "assistant", &"y".repeat(600)),
+        ];
+        let history = convert_history_messages(&history_messages, &[], &primary_model.model);
+        let estimated_tokens = crate::core::context_compression::estimate_total_tokens(&history);
+        let run_summary = make_run_summary_with_cache(
+            "primary-model",
+            estimated_tokens as u64 / 2,
+            estimated_tokens as u64 * 3 / 2,
+        );
 
         let calibration = build_initial_context_token_calibration(
             Some(&run_summary),

--- a/src-tauri/src/core/built_in_agent_runtime.rs
+++ b/src-tauri/src/core/built_in_agent_runtime.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use sqlx::SqlitePool;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 
 use crate::core::agent_session::{AgentSession, AgentSessionSpec};
 use crate::core::subagent::HelperAgentOrchestrator;
@@ -10,11 +10,31 @@ use crate::core::tool_gateway::ToolGateway;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::AppError;
 
+struct RuntimeSessionEntry {
+    session: Arc<AgentSession>,
+    finish_state_rx: watch::Receiver<RuntimeSessionFinishState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeSessionState {
+    Missing,
+    Running,
+    Finished,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RuntimeSessionFinishState {
+    Running,
+    Completed,
+    Panicked,
+    Cancelled,
+}
+
 pub struct BuiltInAgentRuntime {
     pool: SqlitePool,
     tool_gateway: Arc<ToolGateway>,
     helper_orchestrator: Arc<HelperAgentOrchestrator>,
-    sessions: Arc<Mutex<HashMap<String, Arc<AgentSession>>>>,
+    sessions: Arc<Mutex<HashMap<String, RuntimeSessionEntry>>>,
 }
 
 impl BuiltInAgentRuntime {
@@ -30,11 +50,11 @@ impl BuiltInAgentRuntime {
         }
     }
 
-    pub async fn start_session(
+    pub(crate) async fn start_session(
         &self,
         spec: AgentSessionSpec,
         event_tx: mpsc::UnboundedSender<ThreadStreamEvent>,
-    ) -> Result<(), AppError> {
+    ) -> Result<watch::Receiver<RuntimeSessionFinishState>, AppError> {
         let max_turns =
             crate::core::agent_runtime_limits::desktop_agent_max_turns(&self.pool).await;
         let session = AgentSession::new(
@@ -45,20 +65,34 @@ impl BuiltInAgentRuntime {
             spec.clone(),
             max_turns,
         );
+        let run_task = Arc::clone(&session).start();
+        let (finish_state_tx, finish_state_rx) = watch::channel(RuntimeSessionFinishState::Running);
 
-        {
-            let mut sessions = self.sessions.lock().await;
-            sessions.insert(spec.run_id.clone(), Arc::clone(&session));
-        }
+        tokio::spawn(async move {
+            let finish_state = match run_task.await {
+                Ok(()) => RuntimeSessionFinishState::Completed,
+                Err(error) if error.is_cancelled() => RuntimeSessionFinishState::Cancelled,
+                Err(_) => RuntimeSessionFinishState::Panicked,
+            };
+            let _ = finish_state_tx.send(finish_state);
+        });
 
-        session.start();
-        Ok(())
+        let mut sessions = self.sessions.lock().await;
+        sessions.insert(
+            spec.run_id.clone(),
+            RuntimeSessionEntry {
+                session,
+                finish_state_rx: finish_state_rx.clone(),
+            },
+        );
+
+        Ok(finish_state_rx)
     }
 
     pub async fn cancel_session(&self, run_id: &str) -> Result<bool, AppError> {
         let session = {
             let sessions = self.sessions.lock().await;
-            sessions.get(run_id).cloned()
+            sessions.get(run_id).map(|entry| Arc::clone(&entry.session))
         };
 
         if let Some(session) = session {
@@ -67,6 +101,28 @@ impl BuiltInAgentRuntime {
         } else {
             Ok(false)
         }
+    }
+
+    pub(crate) async fn session_state(&self, run_id: &str) -> RuntimeSessionState {
+        match self.session_finish_state(run_id).await {
+            None => RuntimeSessionState::Missing,
+            Some(RuntimeSessionFinishState::Running) => RuntimeSessionState::Running,
+            Some(
+                RuntimeSessionFinishState::Completed
+                | RuntimeSessionFinishState::Panicked
+                | RuntimeSessionFinishState::Cancelled,
+            ) => RuntimeSessionState::Finished,
+        }
+    }
+
+    pub(crate) async fn session_finish_state(
+        &self,
+        run_id: &str,
+    ) -> Option<RuntimeSessionFinishState> {
+        let sessions = self.sessions.lock().await;
+        sessions
+            .get(run_id)
+            .map(|entry| *entry.finish_state_rx.borrow())
     }
 
     pub async fn remove_session(&self, run_id: &str) {

--- a/src-tauri/src/core/context_compression.rs
+++ b/src-tauri/src/core/context_compression.rs
@@ -46,12 +46,13 @@ const MIN_MESSAGES_TO_KEEP: usize = 4;
 const CALIBRATION_SCALE_BASIS_POINTS: u32 = 10_000;
 
 /// Conservative calibration for message-token estimates derived from real
-/// provider `usage.input` samples.
+/// provider prompt-token samples.
 ///
 /// The heuristic estimator only counts the message payload. Real provider
-/// usage also reflects system prompt, tool schema, and model-specific
-/// tokenisation differences. We therefore track the highest observed
-/// underestimate ratio and apply it to future heuristic totals.
+/// prompt usage also reflects system prompt, tool schema, model-specific
+/// tokenisation differences, and provider-side prompt caching reads. We
+/// therefore track the highest observed underestimate ratio and apply it to
+/// future heuristic totals.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ContextTokenCalibration {
     ratio_basis_points: u32,
@@ -66,23 +67,23 @@ impl Default for ContextTokenCalibration {
 }
 
 impl ContextTokenCalibration {
-    /// Build a calibration sample from one heuristic-vs-real observation.
-    pub fn from_observation(estimated_tokens: u32, actual_input_tokens: u64) -> Option<Self> {
-        if estimated_tokens == 0 || actual_input_tokens == 0 {
+    /// Build a calibration sample from one heuristic-vs-real prompt-token observation.
+    pub fn from_observation(estimated_tokens: u32, actual_prompt_tokens: u64) -> Option<Self> {
+        if estimated_tokens == 0 || actual_prompt_tokens == 0 {
             return None;
         }
 
-        Some(Self::default().observe(estimated_tokens, actual_input_tokens))
+        Some(Self::default().observe(estimated_tokens, actual_prompt_tokens))
     }
 
     /// Fold a new observation into the calibration, keeping the most
     /// conservative underestimate ratio seen so far.
-    pub fn observe(self, estimated_tokens: u32, actual_input_tokens: u64) -> Self {
-        if estimated_tokens == 0 || actual_input_tokens == 0 {
+    pub fn observe(self, estimated_tokens: u32, actual_prompt_tokens: u64) -> Self {
+        if estimated_tokens == 0 || actual_prompt_tokens == 0 {
             return self;
         }
 
-        let observed_ratio = (((actual_input_tokens as u128)
+        let observed_ratio = (((actual_prompt_tokens as u128)
             * (CALIBRATION_SCALE_BASIS_POINTS as u128))
             .saturating_add((estimated_tokens as u128).saturating_sub(1)))
             / (estimated_tokens as u128);
@@ -828,6 +829,15 @@ mod tests {
         // Should equal sum of individual estimates
         let sum: u32 = messages.iter().map(estimate_message_tokens).sum();
         assert_eq!(total, sum);
+    }
+
+    #[test]
+    fn context_token_calibration_from_observation_uses_prompt_token_observation() {
+        let calibration = ContextTokenCalibration::from_observation(1_000, 1_750)
+            .expect("non-zero prompt-token observation should produce calibration");
+
+        assert_eq!(calibration.ratio_basis_points(), 17_500);
+        assert_eq!(calibration.apply_to_estimate(2_000), 3_500);
     }
 
     #[test]

--- a/src-tauri/src/core/context_compression.rs
+++ b/src-tauri/src/core/context_compression.rs
@@ -841,6 +841,21 @@ mod tests {
     }
 
     #[test]
+    fn context_token_calibration_observe_ignores_zero_values() {
+        let baseline = ContextTokenCalibration::default();
+
+        assert_eq!(baseline.observe(0, 1_500), baseline);
+        assert_eq!(baseline.observe(1_000, 0), baseline);
+    }
+
+    #[test]
+    fn context_token_calibration_apply_to_zero_estimate_returns_zero() {
+        let calibration = ContextTokenCalibration::default().observe(1_000, 1_500);
+
+        assert_eq!(calibration.apply_to_estimate(0), 0);
+    }
+
+    #[test]
     fn should_compress_with_calibration_triggers_when_raw_estimate_is_under_budget() {
         let mut messages = Vec::new();
         for i in 0..4 {

--- a/src-tauri/src/core/context_compression.rs
+++ b/src-tauri/src/core/context_compression.rs
@@ -9,8 +9,10 @@
 //!
 //! ## Strategy
 //!
-//! 1. **Token estimation**: `chars / 4` heuristic (matches pi-mono).
-//! 2. **Threshold check**: Compress when `estimated_tokens > context_window - reserve_tokens`.
+//! 1. **Token estimation**: heuristic message token estimation, with optional
+//!    calibration from real provider `usage.input` samples.
+//! 2. **Threshold check**: Compress when the calibrated input estimate exceeds
+//!    `context_window - reserve_tokens`.
 //! 3. **Cut-point detection**: Walk backwards from newest message, keep `keep_recent_tokens`
 //!    worth of recent messages. Never cut in the middle of an assistant+tool_result pair.
 //! 4. **Summary injection**: Old messages before the cut-point are replaced with a single
@@ -40,6 +42,75 @@ const OLD_TOOL_RESULT_MAX_CHARS: usize = 800;
 
 /// Minimum number of messages to keep (never compress below this).
 const MIN_MESSAGES_TO_KEEP: usize = 4;
+
+const CALIBRATION_SCALE_BASIS_POINTS: u32 = 10_000;
+
+/// Conservative calibration for message-token estimates derived from real
+/// provider `usage.input` samples.
+///
+/// The heuristic estimator only counts the message payload. Real provider
+/// usage also reflects system prompt, tool schema, and model-specific
+/// tokenisation differences. We therefore track the highest observed
+/// underestimate ratio and apply it to future heuristic totals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextTokenCalibration {
+    ratio_basis_points: u32,
+}
+
+impl Default for ContextTokenCalibration {
+    fn default() -> Self {
+        Self {
+            ratio_basis_points: CALIBRATION_SCALE_BASIS_POINTS,
+        }
+    }
+}
+
+impl ContextTokenCalibration {
+    /// Build a calibration sample from one heuristic-vs-real observation.
+    pub fn from_observation(estimated_tokens: u32, actual_input_tokens: u64) -> Option<Self> {
+        if estimated_tokens == 0 || actual_input_tokens == 0 {
+            return None;
+        }
+
+        Some(Self::default().observe(estimated_tokens, actual_input_tokens))
+    }
+
+    /// Fold a new observation into the calibration, keeping the most
+    /// conservative underestimate ratio seen so far.
+    pub fn observe(self, estimated_tokens: u32, actual_input_tokens: u64) -> Self {
+        if estimated_tokens == 0 || actual_input_tokens == 0 {
+            return self;
+        }
+
+        let observed_ratio = (((actual_input_tokens as u128)
+            * (CALIBRATION_SCALE_BASIS_POINTS as u128))
+            .saturating_add((estimated_tokens as u128).saturating_sub(1)))
+            / (estimated_tokens as u128);
+        let observed_ratio = observed_ratio
+            .max(CALIBRATION_SCALE_BASIS_POINTS as u128)
+            .min(u32::MAX as u128) as u32;
+
+        Self {
+            ratio_basis_points: self.ratio_basis_points.max(observed_ratio),
+        }
+    }
+
+    /// Apply the conservative calibration ratio to a heuristic token total.
+    pub fn apply_to_estimate(self, estimated_tokens: u32) -> u32 {
+        if estimated_tokens == 0 {
+            return 0;
+        }
+
+        ((((estimated_tokens as u128) * (self.ratio_basis_points as u128))
+            .saturating_add((CALIBRATION_SCALE_BASIS_POINTS as u128).saturating_sub(1)))
+            / (CALIBRATION_SCALE_BASIS_POINTS as u128))
+            .min(u32::MAX as u128) as u32
+    }
+
+    pub fn ratio_basis_points(self) -> u32 {
+        self.ratio_basis_points
+    }
+}
 
 /// Estimate the number of tokens for a string.
 ///
@@ -181,13 +252,43 @@ pub fn estimate_total_tokens(messages: &[AgentMessage]) -> u32 {
     messages.iter().map(estimate_message_tokens).sum()
 }
 
-/// Check whether compression is needed for the given messages and settings.
-pub fn should_compress(messages: &[AgentMessage], settings: &CompressionSettings) -> bool {
+/// Apply an optional conservative calibration to a heuristic token estimate.
+pub(crate) fn calibrate_total_tokens(
+    total_tokens: u32,
+    calibration: Option<ContextTokenCalibration>,
+) -> u32 {
+    calibration
+        .unwrap_or_default()
+        .apply_to_estimate(total_tokens)
+}
+
+/// Check whether a token total exceeds the compression input budget.
+pub(crate) fn should_compress_total_tokens(
+    total_tokens: u32,
+    settings: &CompressionSettings,
+) -> bool {
+    total_tokens > settings.budget()
+}
+
+/// Check whether compression is needed for the given messages and settings,
+/// applying an optional conservative calibration derived from real provider
+/// `usage.input` samples.
+pub fn should_compress_with_calibration(
+    messages: &[AgentMessage],
+    settings: &CompressionSettings,
+    calibration: Option<ContextTokenCalibration>,
+) -> bool {
     if messages.is_empty() {
         return false;
     }
     let total_tokens = estimate_total_tokens(messages);
-    total_tokens > settings.budget()
+    let calibrated_total_tokens = calibrate_total_tokens(total_tokens, calibration);
+    should_compress_total_tokens(calibrated_total_tokens, settings)
+}
+
+/// Check whether compression is needed for the given messages and settings.
+pub fn should_compress(messages: &[AgentMessage], settings: &CompressionSettings) -> bool {
+    should_compress_with_calibration(messages, settings, None)
 }
 
 /// Find the cut-point index: messages before this index are "old" (to be
@@ -727,6 +828,47 @@ mod tests {
         // Should equal sum of individual estimates
         let sum: u32 = messages.iter().map(estimate_message_tokens).sum();
         assert_eq!(total, sum);
+    }
+
+    #[test]
+    fn context_token_calibration_keeps_the_most_conservative_ratio() {
+        let calibration = ContextTokenCalibration::default()
+            .observe(1_000, 1_500)
+            .observe(1_000, 1_200);
+
+        assert_eq!(calibration.ratio_basis_points(), 15_000);
+        assert_eq!(calibration.apply_to_estimate(2_000), 3_000);
+    }
+
+    #[test]
+    fn should_compress_with_calibration_triggers_when_raw_estimate_is_under_budget() {
+        let mut messages = Vec::new();
+        for i in 0..4 {
+            messages.push(make_user(&format!("Question {}: {}", i, "x".repeat(400))));
+            messages.push(make_assistant(&format!(
+                "Answer {}: {}",
+                i,
+                "y".repeat(400)
+            )));
+        }
+
+        let settings = CompressionSettings {
+            context_window: 4_000,
+            reserve_tokens: 2_000,
+            keep_recent_tokens: 500,
+        };
+        let raw_total = estimate_total_tokens(&messages);
+        assert!(raw_total < settings.budget());
+
+        let calibration = ContextTokenCalibration::from_observation(raw_total, 2_500)
+            .expect("non-zero observation should produce calibration");
+
+        assert!(!should_compress(&messages, &settings));
+        assert!(should_compress_with_calibration(
+            &messages,
+            &settings,
+            Some(calibration),
+        ));
     }
 
     #[test]

--- a/src-tauri/src/core/executors/edit.rs
+++ b/src-tauri/src/core/executors/edit.rs
@@ -423,12 +423,19 @@ pub(super) fn generate_diff(path: &Path, old_content: &str, new_content: &str) -
     let old_changed_end = old_lines.len() - common_suffix;
     let new_changed_start = common_prefix;
     let new_changed_end = new_lines.len() - common_suffix;
+    let old_changed_len = old_changed_end - old_changed_start;
+    let new_changed_len = new_changed_end - new_changed_start;
 
     // Context lines around the change (3 lines, matching standard unified diff)
     let context = 3;
     let display_start = old_changed_start.saturating_sub(context);
     let display_old_end = (old_changed_end + context).min(old_lines.len());
     let display_new_end = (new_changed_end + context).min(new_lines.len());
+    let context_before_len = old_changed_start - display_start;
+    let old_context_after_len = display_old_end - old_changed_end;
+    let new_context_after_len = display_new_end - new_changed_end;
+    let old_hunk_len = context_before_len + old_changed_len + old_context_after_len;
+    let new_hunk_len = context_before_len + new_changed_len + new_context_after_len;
 
     let mut diff = String::new();
     diff.push_str(&format!("--- {path_str}\n"));
@@ -436,10 +443,9 @@ pub(super) fn generate_diff(path: &Path, old_content: &str, new_content: &str) -
     diff.push_str(&format!(
         "@@ -{},{} +{},{} @@\n",
         display_start + 1,
-        display_old_end - display_start,
+        old_hunk_len,
         display_start + 1,
-        display_new_end - display_start - (old_changed_end - old_changed_start)
-            + (new_changed_end - new_changed_start),
+        new_hunk_len,
     ));
 
     // Context before
@@ -646,5 +652,18 @@ mod tests {
 
         assert_eq!(lines_added, 1);
         assert_eq!(lines_removed, 1);
+    }
+
+    #[test]
+    fn test_generate_diff_handles_line_deletions_without_underflow() {
+        let path = PathBuf::from("/test/file.rs");
+        let old = "line1\nline2\nline3";
+        let new = "line1";
+        let diff = generate_diff(&path, old, new);
+
+        assert!(diff.contains("@@ -1,3 +1,1 @@"));
+        assert!(diff.contains(" line1"));
+        assert!(diff.contains("-line2"));
+        assert!(diff.contains("-line3"));
     }
 }

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -173,6 +173,33 @@ pub async fn find_latest_by_thread(
     Ok(row.map(map_run_summary))
 }
 
+/// Find the latest historical run for a thread that has non-zero input usage,
+/// excluding the currently created run. This is used to seed conservative
+/// context-token calibration for the next run on the same thread.
+pub async fn find_latest_with_input_usage_by_thread_excluding_run(
+    pool: &SqlitePool,
+    thread_id: &str,
+    excluded_run_id: &str,
+) -> Result<Option<RunSummaryDto>, AppError> {
+    let row = sqlx::query_as::<_, RunRow>(
+        "SELECT id, thread_id, run_mode, status, model_id, effective_model_plan_json,
+                error_message, started_at, input_tokens, output_tokens,
+                cache_read_tokens, cache_write_tokens, total_tokens
+         FROM thread_runs
+         WHERE thread_id = ?
+           AND id != ?
+           AND input_tokens > 0
+         ORDER BY started_at DESC
+         LIMIT 1",
+    )
+    .bind(thread_id)
+    .bind(excluded_run_id)
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map(map_run_summary))
+}
+
 pub async fn list_thread_ids_with_active_runs(pool: &SqlitePool) -> Result<Vec<String>, AppError> {
     let rows = sqlx::query_scalar::<_, String>(
         "SELECT DISTINCT thread_id

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -173,10 +173,11 @@ pub async fn find_latest_by_thread(
     Ok(row.map(map_run_summary))
 }
 
-/// Find the latest historical run for a thread that has non-zero input usage,
-/// excluding the currently created run. This is used to seed conservative
-/// context-token calibration for the next run on the same thread.
-pub async fn find_latest_with_input_usage_by_thread_excluding_run(
+/// Find the latest historical run for a thread that has non-zero prompt usage
+/// (`input_tokens + cache_read_tokens`), excluding the currently created run.
+/// This is used to seed conservative context-token calibration for the next
+/// run on the same thread.
+pub async fn find_latest_with_prompt_usage_by_thread_excluding_run(
     pool: &SqlitePool,
     thread_id: &str,
     excluded_run_id: &str,
@@ -188,7 +189,7 @@ pub async fn find_latest_with_input_usage_by_thread_excluding_run(
          FROM thread_runs
          WHERE thread_id = ?
            AND id != ?
-           AND input_tokens > 0
+           AND (input_tokens > 0 OR cache_read_tokens > 0)
          ORDER BY started_at DESC
          LIMIT 1",
     )
@@ -350,30 +351,42 @@ mod tests {
         started_at: &str,
         input_tokens: i64,
     ) {
+        insert_run_with_usage(pool, id, thread_id, started_at, input_tokens, 0).await;
+    }
+
+    async fn insert_run_with_usage(
+        pool: &SqlitePool,
+        id: &str,
+        thread_id: &str,
+        started_at: &str,
+        input_tokens: i64,
+        cache_read_tokens: i64,
+    ) {
         sqlx::query(
             "INSERT INTO thread_runs (
                 id, thread_id, profile_id, run_mode, provider_id, model_id,
                 effective_model_plan_json, status, started_at, input_tokens,
                 output_tokens, cache_read_tokens, cache_write_tokens, total_tokens
              )
-             VALUES (?, ?, NULL, 'default', NULL, NULL, NULL, 'completed', ?, ?, 0, 0, 0, ?)",
+             VALUES (?, ?, NULL, 'default', NULL, NULL, NULL, 'completed', ?, ?, 0, ?, 0, ?)",
         )
         .bind(id)
         .bind(thread_id)
         .bind(started_at)
         .bind(input_tokens)
-        .bind(input_tokens)
+        .bind(cache_read_tokens)
+        .bind(input_tokens.saturating_add(cache_read_tokens))
         .execute(pool)
         .await
         .expect("seed run");
     }
 
     #[tokio::test]
-    async fn find_latest_with_input_usage_returns_none_when_no_matching_history_exists() {
+    async fn find_latest_with_prompt_usage_returns_none_when_no_matching_history_exists() {
         let pool = setup_test_pool().await;
 
         assert!(
-            find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+            find_latest_with_prompt_usage_by_thread_excluding_run(&pool, "t1", "run-x")
                 .await
                 .unwrap()
                 .is_none()
@@ -382,7 +395,7 @@ mod tests {
         insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
 
         assert!(
-            find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+            find_latest_with_prompt_usage_by_thread_excluding_run(&pool, "t1", "run-x")
                 .await
                 .unwrap()
                 .is_none()
@@ -390,7 +403,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn find_latest_with_input_usage_filters_thread_zero_usage_and_excluded_run() {
+    async fn find_latest_with_prompt_usage_filters_thread_zero_usage_and_excluded_run() {
         let pool = setup_test_pool().await;
 
         insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 10).await;
@@ -398,7 +411,7 @@ mod tests {
         insert_run_with_started_at(&pool, "run-3", "t1", "2026-04-22T09:10:00Z", 50).await;
         insert_run_with_started_at(&pool, "run-4", "t2", "2026-04-22T09:20:00Z", 999).await;
 
-        let latest = find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+        let latest = find_latest_with_prompt_usage_by_thread_excluding_run(&pool, "t1", "run-x")
             .await
             .unwrap()
             .expect("latest matching run for t1");
@@ -406,11 +419,28 @@ mod tests {
         assert_eq!(latest.thread_id, "t1");
         assert_eq!(latest.usage.input_tokens, 50);
 
-        let excluded = find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-3")
+        let excluded = find_latest_with_prompt_usage_by_thread_excluding_run(&pool, "t1", "run-3")
             .await
             .unwrap()
             .expect("previous matching run after exclusion");
         assert_eq!(excluded.id, "run-1");
         assert_eq!(excluded.usage.input_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn find_latest_with_prompt_usage_includes_cache_read_only_runs() {
+        let pool = setup_test_pool().await;
+
+        insert_run_with_usage(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 10, 0).await;
+        insert_run_with_usage(&pool, "run-2", "t1", "2026-04-22T09:05:00Z", 0, 64).await;
+        insert_run_with_usage(&pool, "run-3", "t1", "2026-04-22T09:10:00Z", 0, 0).await;
+
+        let latest = find_latest_with_prompt_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+            .await
+            .unwrap()
+            .expect("cache-read-only run should qualify as prompt usage");
+        assert_eq!(latest.id, "run-2");
+        assert_eq!(latest.usage.input_tokens, 0);
+        assert_eq!(latest.usage.cache_read_tokens, 64);
     }
 }

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -285,3 +285,132 @@ fn extract_primary_model_details(
 
     (model_display_name, context_window)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use std::str::FromStr;
+
+    async fn setup_test_pool() -> SqlitePool {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("invalid sqlite options")
+            .foreign_keys(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to create in-memory pool");
+
+        crate::persistence::sqlite::run_migrations(&pool)
+            .await
+            .expect("migrations failed");
+
+        sqlx::query(
+            "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
+                    is_default, is_git, auto_work_tree, status, created_at, updated_at)
+             VALUES ('ws-1', 'ws', '/tmp', '/tmp', '/tmp', 0, 0, 0, 'ready',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed workspace");
+
+        sqlx::query(
+            "INSERT INTO threads (id, workspace_id, title, status, created_at, updated_at, last_active_at)
+             VALUES ('t1', 'ws-1', 't', 'idle',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed thread t1");
+
+        sqlx::query(
+            "INSERT INTO threads (id, workspace_id, title, status, created_at, updated_at, last_active_at)
+             VALUES ('t2', 'ws-1', 't2', 'idle',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed thread t2");
+
+        pool
+    }
+
+    async fn insert_run_with_started_at(
+        pool: &SqlitePool,
+        id: &str,
+        thread_id: &str,
+        started_at: &str,
+        input_tokens: i64,
+    ) {
+        sqlx::query(
+            "INSERT INTO thread_runs (
+                id, thread_id, profile_id, run_mode, provider_id, model_id,
+                effective_model_plan_json, status, started_at, input_tokens,
+                output_tokens, cache_read_tokens, cache_write_tokens, total_tokens
+             )
+             VALUES (?, ?, NULL, 'default', NULL, NULL, NULL, 'completed', ?, ?, 0, 0, 0, ?)",
+        )
+        .bind(id)
+        .bind(thread_id)
+        .bind(started_at)
+        .bind(input_tokens)
+        .bind(input_tokens)
+        .execute(pool)
+        .await
+        .expect("seed run");
+    }
+
+    #[tokio::test]
+    async fn find_latest_with_input_usage_returns_none_when_no_matching_history_exists() {
+        let pool = setup_test_pool().await;
+
+        assert!(
+            find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+
+        assert!(
+            find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn find_latest_with_input_usage_filters_thread_zero_usage_and_excluded_run() {
+        let pool = setup_test_pool().await;
+
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 10).await;
+        insert_run_with_started_at(&pool, "run-2", "t1", "2026-04-22T09:05:00Z", 0).await;
+        insert_run_with_started_at(&pool, "run-3", "t1", "2026-04-22T09:10:00Z", 50).await;
+        insert_run_with_started_at(&pool, "run-4", "t2", "2026-04-22T09:20:00Z", 999).await;
+
+        let latest = find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-x")
+            .await
+            .unwrap()
+            .expect("latest matching run for t1");
+        assert_eq!(latest.id, "run-3");
+        assert_eq!(latest.thread_id, "t1");
+        assert_eq!(latest.usage.input_tokens, 50);
+
+        let excluded = find_latest_with_input_usage_by_thread_excluding_run(&pool, "t1", "run-3")
+            .await
+            .unwrap()
+            .expect("previous matching run after exclusion");
+        assert_eq!(excluded.id, "run-1");
+        assert_eq!(excluded.usage.input_tokens, 10);
+    }
+}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { mapSnapshotToRunState } from "./runtime-thread-surface";
+import type { RunStatus, ThreadSnapshotDto } from "@/shared/types/api";
+
+function makeSnapshot(activeStatus: RunStatus | null): ThreadSnapshotDto {
+  return {
+    thread: {
+      id: "thread-1",
+      workspaceId: "workspace-1",
+      profileId: null,
+      title: "Test thread",
+      status: activeStatus ? "running" : "idle",
+      lastActiveAt: "2026-04-22T00:00:00Z",
+      createdAt: "2026-04-22T00:00:00Z",
+    },
+    messages: [],
+    hasMoreMessages: false,
+    activeRun: activeStatus
+      ? {
+          id: "run-1",
+          threadId: "thread-1",
+          runMode: "default",
+          status: activeStatus,
+          modelId: null,
+          modelDisplayName: null,
+          contextWindow: null,
+          errorMessage: null,
+          startedAt: "2026-04-22T00:00:00Z",
+          usage: {
+            inputTokens: 0,
+            outputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            totalTokens: 0,
+          },
+        }
+      : null,
+    latestRun: null,
+    toolCalls: [],
+    helpers: [],
+    taskBoards: [],
+    activeTaskBoardId: null,
+  };
+}
+
+describe("mapSnapshotToRunState", () => {
+  it("treats cancelling snapshots as cancelled instead of running", () => {
+    expect(mapSnapshotToRunState(makeSnapshot("cancelling"))).toBe("cancelled");
+  });
+
+  it("still keeps waiting_tool_result snapshots in running state", () => {
+    expect(mapSnapshotToRunState(makeSnapshot("waiting_tool_result"))).toBe("running");
+  });
+
+  it("maps approval and reply states directly from the active run", () => {
+    expect(mapSnapshotToRunState(makeSnapshot("waiting_approval"))).toBe("waiting_approval");
+    expect(mapSnapshotToRunState(makeSnapshot("needs_reply"))).toBe("needs_reply");
+  });
+
+  it("maps failed, interrupted, and limit states from the active run", () => {
+    expect(mapSnapshotToRunState(makeSnapshot("failed"))).toBe("failed");
+    expect(mapSnapshotToRunState(makeSnapshot("interrupted"))).toBe("interrupted");
+    expect(mapSnapshotToRunState(makeSnapshot("limit_reached"))).toBe("limit_reached");
+  });
+
+  it("falls back to completed when there is no active run", () => {
+    expect(mapSnapshotToRunState(makeSnapshot(null))).toBe("completed");
+  });
+});

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -727,7 +727,7 @@ function mapSnapshotHelper(
   };
 }
 
-function mapSnapshotToRunState(snapshot: ThreadSnapshotDto): RunState {
+export function mapSnapshotToRunState(snapshot: ThreadSnapshotDto): RunState {
   if (snapshot.activeRun) {
     switch (snapshot.activeRun.status) {
       case "waiting_approval":
@@ -738,8 +738,9 @@ function mapSnapshotToRunState(snapshot: ThreadSnapshotDto): RunState {
       case "dispatching":
       case "running":
       case "waiting_tool_result":
-      case "cancelling":
         return "running";
+      case "cancelling":
+        return "cancelled";
       case "failed":
       case "denied":
         return "failed";


### PR DESCRIPTION
## Summary
This PR improves long-running thread resilience in two complementary areas:
1. It prevents provider context overflow by auto-compressing conversation history before requests are sent.
2. It hardens thread-run recovery when the runtime panics or terminal events become orphaned, so stuck runs can be stopped and the UI no longer bounces from cancelled back to running.

## Changes
### Context compression
- Add runtime calibration state in `src-tauri/src/core/agent_session.rs` to compare heuristic prompt estimates with real `usage.input` values.
- Seed calibration from the latest historical run with input usage and apply calibrated totals before deciding whether to compress.
- Record pending prompt estimates before requests and update calibration when usage events arrive.

### Runtime recovery and stop behavior
- Return a `JoinHandle` from `AgentSession::start` and track runtime session finish state in `src-tauri/src/core/built_in_agent_runtime.rs`.
- Add a runtime finish watchdog plus orphaned terminal-event reconciliation in `src-tauri/src/core/agent_run_manager.rs` so panic/aborted runs are forced through terminal cleanup.
- Force cleanup when cancel delivery fails or the runtime has already terminated, and ignore duplicate terminal events after cleanup.
- Map `cancelling` snapshots to `cancelled` in `src/modules/workbench-shell/ui/runtime-thread-surface.tsx` so the workbench UI does not flip back to `running` after stop.
- Add Vitest coverage for runtime thread-surface run-state mapping and Rust unit coverage for orphaned terminal event/status mapping.

### Token estimation and fallback
- Add `ContextTokenCalibration` and calibrated budget checks in `src-tauri/src/core/context_compression.rs`.
- Improve token heuristics for CJK-heavy content and add regression coverage for conservative compression triggers.
- Preserve a heuristic `<context_summary>` fallback path when LLM-based compression is unavailable.

### Edit executor
- Fix unified diff hunk length calculation in `src-tauri/src/core/executors/edit.rs` so deletion-only edits do not underflow.
- Add a regression test covering deleted-line hunks.

### Persistence
- Add `find_latest_with_input_usage_by_thread_excluding_run` in `src-tauri/src/persistence/repo/run_repo.rs` to warm-start calibration from prior runs.

## Motivation
Long threads could exceed provider input limits before compression triggered because raw heuristics underestimated real input usage, especially once prompt and tool overhead accumulated. Separately, a runtime panic could leave a thread stuck in `running`/`cancelling`, with stop unable to complete and the UI later snapping back to `running` from snapshot reload.

This change makes compression more conservative and also ensures panic/orphaned runs are driven to a terminal state so users can recover without restarting the app.

## Testing
- [x] Run `cargo fmt --manifest-path src-tauri/Cargo.toml`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] Run `npm run typecheck`
- [x] Run `npm run test:unit`
- [ ] Verify long English threads auto-compress before hitting provider limits
- [ ] Verify CJK-heavy threads auto-compress before hitting provider limits
- [ ] Verify runtime panic/orphaned thread runs can be stopped and do not return to `running`

## Screenshots
Not applicable. This PR changes backend/runtime behavior and thread-state recovery logic.

## Breaking Changes
None.

## Related Issues
None specified.

## Checklist
- [x] Code follows project style guidelines
- [x] Tests have been added or updated where needed
- [x] No new compile/type-check failures were introduced by this PR
- [ ] Documentation has been updated if needed

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
