### PR TITLE
feat(title): ✨ Add thread title fallback and context handling

### DIFF
--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -7,20 +7,29 @@ use tiycore::types::{
 };
 
 use crate::core::agent_run_manager::{
-    build_provider_options_payload_hook, normalize_generated_title, truncate_chars,
-    TITLE_CONTEXT_MAX_CHARS, TITLE_GENERATION_MAX_TOKENS, TITLE_GENERATION_MAX_TOKENS_REASONING,
+    build_provider_options_payload_hook, build_title_prompt_from_messages,
+    normalize_generated_title, TITLE_GENERATION_MAX_TOKENS, TITLE_GENERATION_MAX_TOKENS_REASONING,
     TITLE_GENERATION_TIMEOUT,
 };
+#[cfg(test)]
+use crate::core::agent_run_manager::{truncate_chars, TITLE_CONTEXT_MAX_CHARS};
+#[cfg(test)]
+use crate::core::agent_session::ProfileResponseStyle;
 use crate::core::agent_session::{
     normalize_profile_response_language, normalize_profile_response_style,
-    resolve_runtime_model_role, ProfileResponseStyle, RuntimeModelPlan, RuntimeModelRole,
+    resolve_runtime_model_role, RuntimeModelPlan, RuntimeModelRole,
 };
 use crate::core::app_state::AppState;
 use crate::core::tiycode_default_headers;
 use crate::core::tiycode_url_policy;
 use crate::model::errors::{AppError, ErrorSource};
-use crate::model::thread::{AddMessageInput, MessageDto, ThreadSnapshotDto, ThreadSummaryDto};
+use crate::model::thread::{
+    AddMessageInput, MessageDto, MessageRecord, ThreadSnapshotDto, ThreadSummaryDto,
+};
 use crate::persistence::repo::{message_repo, profile_repo};
+
+const MANUAL_TITLE_CONTEXT_MESSAGE_LIMIT: usize = 128;
+const MANUAL_TITLE_RELEVANT_MESSAGE_LIMIT: usize = 24;
 
 #[tauri::command]
 pub async fn thread_list(
@@ -123,12 +132,16 @@ pub async fn thread_regenerate_title(
             format!("Invalid model plan for title generation: {e}"),
         )
     })?;
-    let selected_model = select_title_model_role(&raw_plan)?;
-    let mut model_role = resolve_runtime_model_role(&state.pool, selected_model).await?;
 
-    // Disable reasoning for lightweight title generation.
-    let was_reasoning = model_role.model.reasoning;
-    model_role.model.reasoning = false;
+    // Build deduplicated candidates: lightweight → auxiliary → primary.
+    let candidates = select_title_model_roles(&raw_plan);
+    if candidates.is_empty() {
+        return Err(AppError::recoverable(
+            ErrorSource::Settings,
+            "settings.title.model_missing",
+            "Select an enabled lightweight, auxiliary, or primary model in the current profile before generating a title.",
+        ));
+    }
 
     // Load the profile to resolve language/style preferences.
     let profile = match raw_plan.profile_id {
@@ -142,19 +155,18 @@ pub async fn thread_regenerate_title(
         profile.as_ref().and_then(|p| p.response_style.as_deref()),
     );
 
-    // Load the most recent 5 plain messages for context.
-    // `list_recent` returns messages in reverse-chronological order (newest first).
-    // We filter and take 5, then reverse in the prompt to show chronological order.
-    let messages = message_repo::list_recent(&state.pool, &thread_id, None, 10).await?;
-    let relevant: Vec<_> = messages
-        .iter()
-        .filter(|m| {
-            m.message_type == "plain_message" && (m.role == "user" || m.role == "assistant")
-        })
-        .take(5)
-        .collect();
+    // Load the current context using the DB-backed reset boundary semantics,
+    // then restrict manual regeneration to the last 128 messages and finally
+    // the last 24 user/assistant plain messages.
+    let context_messages = message_repo::list_since_last_reset(&state.pool, &thread_id).await?;
+    let recent_context_messages =
+        collect_recent_messages(&context_messages, MANUAL_TITLE_CONTEXT_MESSAGE_LIMIT);
+    let recent_relevant = collect_recent_title_context_messages(
+        recent_context_messages,
+        MANUAL_TITLE_RELEVANT_MESSAGE_LIMIT,
+    );
 
-    if relevant.is_empty() {
+    if recent_relevant.is_empty() {
         return Err(AppError::recoverable(
             ErrorSource::Thread,
             "thread.regenerate_title.no_messages",
@@ -162,91 +174,169 @@ pub async fn thread_regenerate_title(
         ));
     }
 
-    let prompt =
-        build_regenerate_title_prompt(&relevant, response_language.as_deref(), response_style);
+    let prompt = build_title_prompt_from_messages(
+        &recent_relevant,
+        response_language.as_deref(),
+        response_style,
+    );
 
-    let provider = get_provider(&model_role.model.provider).ok_or_else(|| {
-        AppError::recoverable(
-            ErrorSource::Settings,
-            "settings.title.provider_missing",
-            format!(
-                "Provider type '{:?}' is not registered for title generation.",
-                model_role.model.provider
-            ),
-        )
-    })?;
+    // Try each candidate in order; skip duplicates.
+    let mut tried_model_ids = std::collections::HashSet::new();
+    let mut last_error: Option<AppError> = None;
 
-    let context = TiyContext {
-        system_prompt: Some(
-            "You write concise conversation titles. Return only the title text.".to_string(),
-        ),
-        messages: vec![TiyMessage::User(UserMessage::text(prompt))],
-        tools: None,
-    };
+    for candidate in &candidates {
+        let mut model_role = match resolve_runtime_model_role(&state.pool, candidate.clone()).await
+        {
+            Ok(role) => role,
+            Err(e) => {
+                tracing::warn!(
+                    thread_id = %thread_id,
+                    model_id = %candidate.model_id,
+                    error = %e,
+                    "failed to resolve title model role"
+                );
+                last_error = Some(e);
+                continue;
+            }
+        };
 
-    let options = TiyStreamOptions {
-        api_key: model_role.api_key.clone(),
-        max_tokens: Some(if was_reasoning {
-            TITLE_GENERATION_MAX_TOKENS_REASONING
-        } else {
-            TITLE_GENERATION_MAX_TOKENS
-        }),
-        headers: Some(tiycode_default_headers()),
-        on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
-        security: Some(tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy())),
-        ..TiyStreamOptions::default()
-    };
-
-    let completion = provider
-        .stream(&model_role.model, &context, options)
-        .try_result(TITLE_GENERATION_TIMEOUT)
-        .await;
-
-    let message = match completion {
-        Some(msg) => msg,
-        None => {
-            return Err(AppError::recoverable(
-                ErrorSource::Thread,
-                "thread.regenerate_title.timeout",
-                "Title generation timed out or returned no result.",
-            ))
+        if !tried_model_ids.insert(model_role.model_id.clone()) {
+            continue;
         }
-    };
 
-    if message.stop_reason == tiycore::types::StopReason::Error {
-        return Err(AppError::recoverable(
-            ErrorSource::Thread,
-            "thread.regenerate_title.model_error",
-            "The model returned an error during title generation.",
-        ));
-    }
+        // Disable reasoning for lightweight title generation.
+        let was_reasoning = model_role.model.reasoning;
+        model_role.model.reasoning = false;
 
-    let title = normalize_generated_title(&message.text_content()).ok_or_else(|| {
-        AppError::recoverable(
+        let provider = match get_provider(&model_role.model.provider) {
+            Some(p) => p,
+            None => {
+                last_error = Some(AppError::recoverable(
+                    ErrorSource::Settings,
+                    "settings.title.provider_missing",
+                    format!(
+                        "Provider type '{:?}' is not registered for title generation.",
+                        model_role.model.provider
+                    ),
+                ));
+                continue;
+            }
+        };
+
+        let context = TiyContext {
+            system_prompt: Some(
+                "You write concise conversation titles. Return only the title text.".to_string(),
+            ),
+            messages: vec![TiyMessage::User(UserMessage::text(prompt.clone()))],
+            tools: None,
+        };
+
+        let options = TiyStreamOptions {
+            api_key: model_role.api_key.clone(),
+            max_tokens: Some(if was_reasoning {
+                TITLE_GENERATION_MAX_TOKENS_REASONING
+            } else {
+                TITLE_GENERATION_MAX_TOKENS
+            }),
+            headers: Some(tiycode_default_headers()),
+            on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
+            security: Some(
+                tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy()),
+            ),
+            ..TiyStreamOptions::default()
+        };
+
+        let completion = provider
+            .stream(&model_role.model, &context, options)
+            .try_result(TITLE_GENERATION_TIMEOUT)
+            .await;
+
+        let message = match completion {
+            Some(msg) => msg,
+            None => {
+                last_error = Some(AppError::recoverable(
+                    ErrorSource::Thread,
+                    "thread.regenerate_title.timeout",
+                    "Title generation timed out or returned no result.",
+                ));
+                continue;
+            }
+        };
+
+        if message.stop_reason == tiycore::types::StopReason::Error {
+            last_error = Some(AppError::recoverable(
+                ErrorSource::Thread,
+                "thread.regenerate_title.model_error",
+                "The model returned an error during title generation.",
+            ));
+            continue;
+        }
+
+        if let Some(title) = normalize_generated_title(&message.text_content()) {
+            return Ok(title);
+        }
+
+        last_error = Some(AppError::recoverable(
             ErrorSource::Thread,
             "thread.regenerate_title.empty",
             "The model returned an empty or unusable title.",
+        ));
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        AppError::recoverable(
+            ErrorSource::Thread,
+            "thread.regenerate_title.failed",
+            "All title generation candidates failed.",
         )
-    })?;
-
-    Ok(title)
+    }))
 }
 
-fn select_title_model_role(raw_plan: &RuntimeModelPlan) -> Result<RuntimeModelRole, AppError> {
-    raw_plan
-        .lightweight
-        .clone()
-        .or_else(|| raw_plan.auxiliary.clone())
-        .or_else(|| raw_plan.primary.clone())
-        .ok_or_else(|| {
-            AppError::recoverable(
-                ErrorSource::Settings,
-                "settings.title.model_missing",
-                "Select an enabled lightweight, auxiliary, or primary model in the current profile before generating a title.",
-            )
+fn collect_recent_messages(messages: &[MessageRecord], limit: usize) -> &[MessageRecord] {
+    let start = messages.len().saturating_sub(limit);
+    &messages[start..]
+}
+
+fn collect_recent_title_context_messages(
+    messages: &[MessageRecord],
+    limit: usize,
+) -> Vec<MessageRecord> {
+    let relevant: Vec<&MessageRecord> = messages
+        .iter()
+        .filter(|message| {
+            message.message_type == "plain_message"
+                && (message.role == "user" || message.role == "assistant")
         })
+        .collect();
+    let start = relevant.len().saturating_sub(limit);
+    relevant[start..]
+        .iter()
+        .map(|message| (*message).clone())
+        .collect()
 }
 
+/// Select title model candidates with fallback and deduplication.
+/// Fallback order: lightweight → auxiliary → primary.
+/// Skips candidates whose model_id matches an already-selected one.
+fn select_title_model_roles(raw_plan: &RuntimeModelPlan) -> Vec<RuntimeModelRole> {
+    let mut result = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for candidate in [
+        raw_plan.lightweight.as_ref(),
+        raw_plan.auxiliary.as_ref(),
+        raw_plan.primary.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if seen.insert(candidate.model_id.clone()) {
+            result.push(candidate.clone());
+        }
+    }
+    result
+}
+
+#[cfg(test)]
 fn build_regenerate_title_prompt(
     messages: &[&crate::model::thread::MessageRecord],
     response_language: Option<&str>,
@@ -325,7 +415,7 @@ mod tests {
             run_id: None,
             role: role.into(),
             content_markdown: content.into(),
-            message_type: "message".into(),
+            message_type: "plain_message".into(),
             status: "completed".into(),
             metadata_json: None,
             attachments_json: None,
@@ -334,46 +424,121 @@ mod tests {
     }
 
     #[test]
-    fn select_title_model_role_prefers_lightweight() {
+    fn collect_recent_title_context_messages_keeps_tail_in_chronological_order() {
+        let messages = vec![
+            dummy_message("user", "m1"),
+            dummy_message("assistant", "m2"),
+            MessageRecord {
+                id: "marker".into(),
+                thread_id: "t1".into(),
+                run_id: None,
+                role: "system".into(),
+                content_markdown: "summary".into(),
+                message_type: "summary_marker".into(),
+                status: "completed".into(),
+                metadata_json: Some(serde_json::json!({ "kind": "context_summary" }).to_string()),
+                attachments_json: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+            dummy_message("user", "m3"),
+            dummy_message("assistant", "m4"),
+        ];
+
+        let recent = collect_recent_title_context_messages(&messages, 3);
+        let contents: Vec<&str> = recent
+            .iter()
+            .map(|message| message.content_markdown.as_str())
+            .collect();
+
+        assert_eq!(contents, vec!["m2", "m3", "m4"]);
+    }
+
+    #[test]
+    fn collect_recent_title_context_messages_ignores_non_user_assistant_messages() {
+        let messages = vec![
+            dummy_message("user", "u1"),
+            MessageRecord {
+                id: "tool".into(),
+                thread_id: "t1".into(),
+                run_id: None,
+                role: "tool".into(),
+                content_markdown: "tool output".into(),
+                message_type: "plain_message".into(),
+                status: "completed".into(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: "2026-01-01T00:00:00Z".into(),
+            },
+            dummy_message("assistant", "a1"),
+        ];
+
+        let recent = collect_recent_title_context_messages(&messages, 24);
+        let roles: Vec<&str> = recent.iter().map(|message| message.role.as_str()).collect();
+
+        assert_eq!(roles, vec!["user", "assistant"]);
+    }
+
+    #[test]
+    fn select_title_model_roles_prefers_lightweight() {
         let plan = RuntimeModelPlan {
             lightweight: Some(dummy_model_role("lite")),
             auxiliary: Some(dummy_model_role("aux")),
             primary: Some(dummy_model_role("primary")),
             ..Default::default()
         };
-        let role = select_title_model_role(&plan).unwrap();
-        assert_eq!(role.model, "lite");
+        let roles = select_title_model_roles(&plan);
+        assert_eq!(roles.len(), 3);
+        assert_eq!(roles[0].model, "lite");
+        assert_eq!(roles[1].model, "aux");
+        assert_eq!(roles[2].model, "primary");
     }
 
     #[test]
-    fn select_title_model_role_falls_back_to_auxiliary() {
+    fn select_title_model_roles_falls_back_to_auxiliary() {
         let plan = RuntimeModelPlan {
             lightweight: None,
             auxiliary: Some(dummy_model_role("aux")),
             primary: Some(dummy_model_role("primary")),
             ..Default::default()
         };
-        let role = select_title_model_role(&plan).unwrap();
-        assert_eq!(role.model, "aux");
+        let roles = select_title_model_roles(&plan);
+        assert_eq!(roles.len(), 2);
+        assert_eq!(roles[0].model, "aux");
+        assert_eq!(roles[1].model, "primary");
     }
 
     #[test]
-    fn select_title_model_role_falls_back_to_primary() {
+    fn select_title_model_roles_falls_back_to_primary() {
         let plan = RuntimeModelPlan {
             lightweight: None,
             auxiliary: None,
             primary: Some(dummy_model_role("primary")),
             ..Default::default()
         };
-        let role = select_title_model_role(&plan).unwrap();
-        assert_eq!(role.model, "primary");
+        let roles = select_title_model_roles(&plan);
+        assert_eq!(roles.len(), 1);
+        assert_eq!(roles[0].model, "primary");
     }
 
     #[test]
-    fn select_title_model_role_errors_when_all_missing() {
+    fn select_title_model_roles_returns_empty_when_all_missing() {
         let plan = RuntimeModelPlan::default();
-        let result = select_title_model_role(&plan);
-        assert!(result.is_err());
+        let roles = select_title_model_roles(&plan);
+        assert!(roles.is_empty());
+    }
+
+    #[test]
+    fn select_title_model_roles_skips_duplicate_model_ids() {
+        let plan = RuntimeModelPlan {
+            lightweight: Some(dummy_model_role("shared")),
+            auxiliary: Some(dummy_model_role("shared")),
+            primary: Some(dummy_model_role("unique")),
+            ..Default::default()
+        };
+        let roles = select_title_model_roles(&plan);
+        assert_eq!(roles.len(), 2);
+        assert_eq!(roles[0].model, "shared");
+        assert_eq!(roles[1].model, "unique");
     }
 
     #[test]

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -40,7 +40,7 @@ use crate::persistence::repo::{
     message_repo, profile_repo, run_repo, thread_repo, tool_call_repo, workspace_repo,
 };
 
-pub(crate) const TITLE_GENERATION_TIMEOUT: Duration = Duration::from_secs(60);
+pub(crate) const TITLE_GENERATION_TIMEOUT: Duration = Duration::from_secs(90);
 pub(crate) const TITLE_GENERATION_MAX_TOKENS: u32 = 512;
 pub(crate) const TITLE_GENERATION_MAX_TOKENS_REASONING: u32 = 2048;
 const PRIMARY_SUMMARY_MAX_TOKENS: u32 = 8192;
@@ -60,6 +60,8 @@ struct ActiveRun {
     profile_id: Option<String>,
     frontend_tx: broadcast::Sender<ThreadStreamEvent>,
     lightweight_model_role: Option<ResolvedModelRole>,
+    auxiliary_model_role: Option<ResolvedModelRole>,
+    primary_model_role: Option<ResolvedModelRole>,
     streaming_message_id: Option<String>,
     reasoning_message_id: Option<String>,
     cancellation_requested: bool,
@@ -189,6 +191,8 @@ impl AgentRunManager {
                     profile_id: profile_id.clone(),
                     frontend_tx: frontend_tx.clone(),
                     lightweight_model_role: None,
+                    auxiliary_model_role: None,
+                    primary_model_role: None,
                     streaming_message_id: None,
                     reasoning_message_id: None,
                     cancellation_requested: false,
@@ -251,6 +255,8 @@ impl AgentRunManager {
                 let mut runs = self.active_runs.lock().await;
                 if let Some(run) = runs.get_mut(&run_id) {
                     run.lightweight_model_role = spec.model_plan.lightweight.clone();
+                    run.auxiliary_model_role = spec.model_plan.auxiliary.clone();
+                    run.primary_model_role = Some(spec.model_plan.primary.clone());
                 }
             }
 
@@ -556,6 +562,8 @@ impl AgentRunManager {
                     profile_id: None,
                     frontend_tx: frontend_tx.clone(),
                     lightweight_model_role: None,
+                    auxiliary_model_role: None,
+                    primary_model_role: None,
                     streaming_message_id: None,
                     reasoning_message_id: None,
                     cancellation_requested: false,
@@ -1354,6 +1362,8 @@ impl AgentRunManager {
             profile_id,
             frontend_tx,
             lightweight_model_role,
+            auxiliary_model_role,
+            primary_model_role,
             streaming_message_id,
             reasoning_message_id,
         ) = {
@@ -1366,6 +1376,8 @@ impl AgentRunManager {
                 run.profile_id.clone(),
                 run.frontend_tx.clone(),
                 run.lightweight_model_role.clone(),
+                run.auxiliary_model_role.clone(),
+                run.primary_model_role.clone(),
                 run.streaming_message_id.clone(),
                 run.reasoning_message_id.clone(),
             )
@@ -1415,6 +1427,8 @@ impl AgentRunManager {
                 profile_id,
                 frontend_tx,
                 lightweight_model_role,
+                auxiliary_model_role,
+                primary_model_role,
                 self.app_handle.clone(),
             );
         }
@@ -1429,16 +1443,23 @@ impl AgentRunManager {
         profile_id: Option<String>,
         frontend_tx: broadcast::Sender<ThreadStreamEvent>,
         lightweight_model_role: Option<ResolvedModelRole>,
+        auxiliary_model_role: Option<ResolvedModelRole>,
+        primary_model_role: Option<ResolvedModelRole>,
         app_handle: AppHandle,
     ) {
-        let Some(model_role) = lightweight_model_role else {
+        let candidates = build_title_model_candidates(
+            lightweight_model_role.as_ref(),
+            auxiliary_model_role.as_ref(),
+            primary_model_role.as_ref(),
+        );
+        if candidates.is_empty() {
             tracing::debug!(
                 run_id = %run_id,
                 thread_id = %thread_id,
-                "skipping thread title generation: no lightweight model configured"
+                "skipping thread title generation: no title model configured"
             );
             return;
-        };
+        }
 
         let pool = self.pool.clone();
         tokio::spawn(async move {
@@ -1447,7 +1468,7 @@ impl AgentRunManager {
                 &run_id,
                 &thread_id,
                 profile_id,
-                model_role,
+                &candidates,
                 frontend_tx,
                 app_handle,
             )
@@ -2278,12 +2299,30 @@ fn append_compact_instructions(base_summary: String, instructions: Option<&str>)
     )
 }
 
+/// Build a deduplicated list of title model candidates in priority order:
+/// lightweight → auxiliary → primary.
+/// Skips candidates whose model_id is identical to an already-included one.
+fn build_title_model_candidates(
+    lightweight: Option<&ResolvedModelRole>,
+    auxiliary: Option<&ResolvedModelRole>,
+    primary: Option<&ResolvedModelRole>,
+) -> Vec<ResolvedModelRole> {
+    let mut result = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for candidate in [lightweight, auxiliary, primary].into_iter().flatten() {
+        if seen.insert(candidate.model_id.clone()) {
+            result.push(candidate.clone());
+        }
+    }
+    result
+}
+
 async fn maybe_generate_thread_title(
     pool: &SqlitePool,
     run_id: &str,
     thread_id: &str,
     profile_id: Option<String>,
-    model_role: ResolvedModelRole,
+    candidates: &[ResolvedModelRole],
     frontend_tx: broadcast::Sender<ThreadStreamEvent>,
     app_handle: AppHandle,
 ) -> Result<(), AppError> {
@@ -2296,16 +2335,15 @@ async fn maybe_generate_thread_title(
         return Ok(());
     }
 
-    let Some((user_message, assistant_message)) =
-        load_initial_title_context(pool, thread_id).await?
-    else {
+    let context_messages = load_title_context_messages(pool, thread_id).await?;
+    if context_messages.is_empty() {
         tracing::debug!(
             run_id = %run_id,
             thread_id = %thread_id,
-            "skipping thread title generation: could not load initial title context"
+            "skipping thread title generation: no user/assistant messages in current context"
         );
         return Ok(());
-    };
+    }
 
     let profile = match profile_id {
         Some(profile_id) => profile_repo::find_by_id(pool, &profile_id).await?,
@@ -2320,93 +2358,103 @@ async fn maybe_generate_thread_title(
             .and_then(|profile| profile.response_style.as_deref()),
     );
 
-    let Some(title) = generate_thread_title(
-        &model_role,
-        &user_message,
-        &assistant_message,
-        response_language.as_deref(),
-        response_style,
-    )
-    .await?
-    else {
-        tracing::warn!(
-            run_id = %run_id,
-            thread_id = %thread_id,
-            "thread title generation returned empty result (timeout or empty response)"
-        );
-        return Ok(());
-    };
+    let mut last_error: Option<AppError> = None;
+    for model_role in candidates {
+        match generate_thread_title(
+            model_role,
+            &context_messages,
+            response_language.as_deref(),
+            response_style,
+        )
+        .await
+        {
+            Ok(Some(title)) => {
+                thread_repo::update_title(pool, thread_id, &title).await?;
 
-    thread_repo::update_title(pool, thread_id, &title).await?;
+                tracing::info!(
+                    run_id = %run_id,
+                    thread_id = %thread_id,
+                    title = %title,
+                    "generated thread title, sending to frontend"
+                );
 
-    tracing::info!(
-        run_id = %run_id,
-        thread_id = %thread_id,
-        title = %title,
-        "generated thread title, sending to frontend"
-    );
+                // Broadcast a global event so the sidebar can pick up the new title even
+                // when no per-run stream subscription exists (e.g. inactive threads).
+                let _ = app_handle.emit(
+                    app_events::THREAD_TITLE_UPDATED,
+                    ThreadTitleUpdatedPayload {
+                        thread_id: thread_id.to_string(),
+                        title: title.clone(),
+                    },
+                );
 
-    // Broadcast a global event so the sidebar can pick up the new title even
-    // when no per-run stream subscription exists (e.g. inactive threads).
-    let _ = app_handle.emit(
-        app_events::THREAD_TITLE_UPDATED,
-        ThreadTitleUpdatedPayload {
-            thread_id: thread_id.to_string(),
-            title: title.clone(),
-        },
-    );
+                if frontend_tx
+                    .send(ThreadStreamEvent::ThreadTitleUpdated {
+                        run_id: run_id.to_string(),
+                        thread_id: thread_id.to_string(),
+                        title,
+                    })
+                    .is_err()
+                {
+                    tracing::warn!(
+                        run_id = %run_id,
+                        thread_id = %thread_id,
+                        "failed to send ThreadTitleUpdated event: frontend channel closed"
+                    );
+                }
 
-    if frontend_tx
-        .send(ThreadStreamEvent::ThreadTitleUpdated {
-            run_id: run_id.to_string(),
-            thread_id: thread_id.to_string(),
-            title,
-        })
-        .is_err()
-    {
-        tracing::warn!(
-            run_id = %run_id,
-            thread_id = %thread_id,
-            "failed to send ThreadTitleUpdated event: frontend channel closed"
-        );
+                return Ok(());
+            }
+            Ok(None) => {
+                tracing::warn!(
+                    run_id = %run_id,
+                    thread_id = %thread_id,
+                    model_id = %model_role.model_id,
+                    "title generation returned empty result (timeout or empty response)"
+                );
+                last_error = Some(AppError::recoverable(
+                    ErrorSource::Thread,
+                    "thread.regenerate_title.empty",
+                    "Title generation returned empty or timed out.",
+                ));
+            }
+            Err(e) => {
+                tracing::warn!(
+                    run_id = %run_id,
+                    thread_id = %thread_id,
+                    model_id = %model_role.model_id,
+                    error = %e,
+                    "title generation failed"
+                );
+                last_error = Some(e);
+            }
+        }
+    }
+
+    if let Some(e) = last_error {
+        return Err(e);
     }
 
     Ok(())
 }
 
-async fn load_initial_title_context(
+async fn load_title_context_messages(
     pool: &SqlitePool,
     thread_id: &str,
-) -> Result<Option<(String, String)>, AppError> {
-    let messages = message_repo::list_recent(pool, thread_id, None, 12).await?;
-    let first_user_message = messages
-        .iter()
-        .find(|message| message.role == "user" && message.message_type == "plain_message")
-        .map(|message| message.content_markdown.trim())
-        .filter(|content| !content.is_empty());
-    let first_assistant_message = messages
-        .iter()
-        .find(|message| {
-            message.role == "assistant"
-                && message.message_type == "plain_message"
-                && message.status == "completed"
+) -> Result<Vec<MessageRecord>, AppError> {
+    let messages = message_repo::list_since_last_reset(pool, thread_id).await?;
+    let filtered: Vec<MessageRecord> = messages
+        .into_iter()
+        .filter(|m| {
+            m.message_type == "plain_message" && (m.role == "user" || m.role == "assistant")
         })
-        .map(|message| message.content_markdown.trim())
-        .filter(|content| !content.is_empty());
-
-    match (first_user_message, first_assistant_message) {
-        (Some(user_message), Some(assistant_message)) => Ok(Some((
-            truncate_chars(user_message, TITLE_CONTEXT_MAX_CHARS),
-            truncate_chars(assistant_message, TITLE_CONTEXT_MAX_CHARS),
-        ))),
-        _ => Ok(None),
-    }
+        .collect();
+    Ok(filtered)
 }
 
 async fn generate_thread_title(
     model_role: &ResolvedModelRole,
-    user_message: &str,
-    assistant_message: &str,
+    messages: &[MessageRecord],
     response_language: Option<&str>,
     response_style: ProfileResponseStyle,
 ) -> Result<Option<String>, AppError> {
@@ -2437,12 +2485,7 @@ async fn generate_thread_title(
         )
     })?;
 
-    let prompt = build_title_prompt(
-        user_message,
-        assistant_message,
-        response_language,
-        response_style,
-    );
+    let prompt = build_title_prompt_from_messages(messages, response_language, response_style);
     let context = TiyContext {
         system_prompt: Some(
             "You write concise conversation titles. Return only the title text.".to_string(),
@@ -2489,6 +2532,54 @@ async fn generate_thread_title(
     Ok(normalize_generated_title(&message.text_content()))
 }
 
+pub(crate) fn build_title_prompt_from_messages(
+    messages: &[MessageRecord],
+    response_language: Option<&str>,
+    response_style: ProfileResponseStyle,
+) -> String {
+    let language_rule = match response_language {
+        Some(language) => format!("- Write the title in {language}."),
+        None => "- Match the conversation language.".to_string(),
+    };
+    let style_rule = match response_style {
+        ProfileResponseStyle::Balanced => {
+            "- Keep the title clear and natural, with enough specificity to scan quickly."
+        }
+        ProfileResponseStyle::Concise => {
+            "- Keep the title especially terse, direct, and low-friction."
+        }
+        ProfileResponseStyle::Guide => {
+            "- Prefer a title that signals the user's goal or decision focus clearly."
+        }
+    };
+
+    let mut conversation = String::new();
+    // Messages are in chronological order (oldest first); iterate in reverse
+    // so the newest messages appear first in the prompt.
+    for msg in messages.iter().rev() {
+        let role_label = if msg.role == "user" {
+            "User"
+        } else {
+            "Assistant"
+        };
+        let content = truncate_chars(msg.content_markdown.trim(), TITLE_CONTEXT_MAX_CHARS);
+        conversation.push_str(&format!("{role_label}:\n{content}\n\n"));
+    }
+
+    format!(
+        "Create a short thread title for this conversation.\n\
+Rules:\n\
+{language_rule}\n\
+{style_rule}\n\
+- Prefer concrete nouns and actions.\n\
+- Max 18 Chinese characters or 7 English words.\n\
+- No quotes, no markdown, no prefixes.\n\
+\n\
+Conversation:\n{conversation}"
+    )
+}
+
+#[cfg(test)]
 pub(crate) fn build_title_prompt(
     user_message: &str,
     assistant_message: &str,
@@ -2629,9 +2720,9 @@ mod tests {
         append_compact_instructions, await_summary_with_abort, build_compact_summary_messages,
         build_compact_summary_system_prompt, build_implementation_handoff_prompt,
         build_merge_summary_messages, build_merge_summary_system_prompt, build_title_prompt,
-        collapse_whitespace, detect_prior_summary, extract_context_summary_block,
-        mark_thread_run_cancellation_requested, normalize_compact_summary,
-        normalize_generated_title, render_compact_summary_history,
+        build_title_prompt_from_messages, collapse_whitespace, detect_prior_summary,
+        extract_context_summary_block, mark_thread_run_cancellation_requested,
+        normalize_compact_summary, normalize_generated_title, render_compact_summary_history,
         should_complete_reasoning_for_event, summary_history_char_budget, truncate_chars,
         truncate_chars_keep_tail, truncate_tool_result_head_tail, ActiveRun,
         SUMMARY_HISTORY_MIN_CHARS, SUMMARY_TOOL_RESULT_MAX_CHARS,
@@ -2641,6 +2732,7 @@ mod tests {
         build_plan_artifact_from_tool_input, build_plan_message_metadata, PlanApprovalAction,
     };
     use crate::ipc::frontend_channels::ThreadStreamEvent;
+    use crate::model::thread::MessageRecord;
     use std::collections::HashMap;
     use tiycore::agent::AgentMessage;
     use tiycore::types::{Message as TiyMessage, UserMessage};
@@ -2666,6 +2758,8 @@ mod tests {
                 profile_id: None,
                 frontend_tx,
                 lightweight_model_role: None,
+                auxiliary_model_role: None,
+                primary_model_role: None,
                 streaming_message_id: None,
                 reasoning_message_id: None,
                 cancellation_requested: false,
@@ -2703,6 +2797,8 @@ mod tests {
             profile_id: None,
             frontend_tx,
             lightweight_model_role: None,
+            auxiliary_model_role: None,
+            primary_model_role: None,
             streaming_message_id: None,
             reasoning_message_id: None,
             cancellation_requested: false,
@@ -2954,6 +3050,68 @@ mod tests {
 
         assert!(prompt.contains("Write the title in Japanese."));
         assert!(prompt.contains("signals the user's goal or decision focus clearly"));
+    }
+
+    #[test]
+    fn title_prompt_from_messages_renders_newest_messages_first() {
+        let messages = vec![
+            MessageRecord {
+                id: "msg-1".into(),
+                thread_id: "thread-1".into(),
+                run_id: None,
+                role: "user".into(),
+                content_markdown: "oldest user message".into(),
+                message_type: "plain_message".into(),
+                status: "completed".into(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: String::new(),
+            },
+            MessageRecord {
+                id: "msg-2".into(),
+                thread_id: "thread-1".into(),
+                run_id: None,
+                role: "assistant".into(),
+                content_markdown: "newer assistant reply".into(),
+                message_type: "plain_message".into(),
+                status: "completed".into(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: String::new(),
+            },
+            MessageRecord {
+                id: "msg-3".into(),
+                thread_id: "thread-1".into(),
+                run_id: None,
+                role: "user".into(),
+                content_markdown: "newest user follow-up".into(),
+                message_type: "plain_message".into(),
+                status: "completed".into(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: String::new(),
+            },
+        ];
+
+        let prompt = build_title_prompt_from_messages(
+            &messages,
+            Some("English"),
+            ProfileResponseStyle::Balanced,
+        );
+
+        let newest_idx = prompt
+            .find("User:\nnewest user follow-up")
+            .expect("newest message should be present");
+        let older_idx = prompt
+            .find("Assistant:\nnewer assistant reply")
+            .expect("older assistant message should be present");
+        let oldest_idx = prompt
+            .find("User:\noldest user message")
+            .expect("oldest message should be present");
+
+        assert!(newest_idx < older_idx);
+        assert!(older_idx < oldest_idx);
+        assert!(prompt.contains("Write the title in English."));
     }
 
     #[test]

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -2719,10 +2719,11 @@ mod tests {
     use super::{
         append_compact_instructions, await_summary_with_abort, build_compact_summary_messages,
         build_compact_summary_system_prompt, build_implementation_handoff_prompt,
-        build_merge_summary_messages, build_merge_summary_system_prompt, build_title_prompt,
-        build_title_prompt_from_messages, collapse_whitespace, detect_prior_summary,
-        extract_context_summary_block, mark_thread_run_cancellation_requested,
-        normalize_compact_summary, normalize_generated_title, render_compact_summary_history,
+        build_merge_summary_messages, build_merge_summary_system_prompt,
+        build_title_model_candidates, build_title_prompt, build_title_prompt_from_messages,
+        collapse_whitespace, detect_prior_summary, extract_context_summary_block,
+        mark_thread_run_cancellation_requested, normalize_compact_summary,
+        normalize_generated_title, render_compact_summary_history,
         should_complete_reasoning_for_event, summary_history_char_budget, truncate_chars,
         truncate_chars_keep_tail, truncate_tool_result_head_tail, ActiveRun,
         SUMMARY_HISTORY_MIN_CHARS, SUMMARY_TOOL_RESULT_MAX_CHARS,
@@ -3660,6 +3661,149 @@ mod tests {
             provider_options: None,
             model,
         }
+    }
+
+    fn model_role_with_id(model_id: &str) -> ResolvedModelRole {
+        let mut role = model_role_with(128_000, false);
+        role.model_id = model_id.to_string();
+        role.model_name = model_id.to_string();
+        role.model = tiycore::types::Model::builder()
+            .id(model_id)
+            .name(model_id)
+            .provider(tiycore::types::Provider::OpenAI)
+            .base_url("https://api.openai.com/v1")
+            .context_window(128_000)
+            .max_tokens(32_000)
+            .input(vec![tiycore::types::InputType::Text])
+            .cost(tiycore::types::Cost::default())
+            .reasoning(false)
+            .build()
+            .expect("sample model with custom id");
+        role
+    }
+
+    #[test]
+    fn build_title_model_candidates_prefers_priority_order() {
+        let lightweight = model_role_with_id("lite");
+        let auxiliary = model_role_with_id("aux");
+        let primary = model_role_with_id("primary");
+
+        let candidates =
+            build_title_model_candidates(Some(&lightweight), Some(&auxiliary), Some(&primary));
+
+        let ids: Vec<&str> = candidates
+            .iter()
+            .map(|role| role.model_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["lite", "aux", "primary"]);
+    }
+
+    #[test]
+    fn build_title_model_candidates_skips_missing_entries() {
+        let auxiliary = model_role_with_id("aux");
+        let primary = model_role_with_id("primary");
+
+        let candidates = build_title_model_candidates(None, Some(&auxiliary), Some(&primary));
+
+        let ids: Vec<&str> = candidates
+            .iter()
+            .map(|role| role.model_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["aux", "primary"]);
+    }
+
+    #[test]
+    fn build_title_model_candidates_returns_empty_when_all_missing() {
+        let candidates = build_title_model_candidates(None, None, None);
+        assert!(candidates.is_empty());
+    }
+
+    #[test]
+    fn build_title_model_candidates_deduplicates_same_model_id() {
+        let lightweight = model_role_with_id("shared");
+        let auxiliary = model_role_with_id("shared");
+        let primary = model_role_with_id("primary");
+
+        let candidates =
+            build_title_model_candidates(Some(&lightweight), Some(&auxiliary), Some(&primary));
+
+        let ids: Vec<&str> = candidates
+            .iter()
+            .map(|role| role.model_id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["shared", "primary"]);
+    }
+
+    #[test]
+    fn title_prompt_from_messages_matches_conversation_language_when_none() {
+        let messages = vec![MessageRecord {
+            id: "msg-1".into(),
+            thread_id: "thread-1".into(),
+            run_id: None,
+            role: "user".into(),
+            content_markdown: "请帮我分析标题生成策略".into(),
+            message_type: "plain_message".into(),
+            status: "completed".into(),
+            metadata_json: None,
+            attachments_json: None,
+            created_at: String::new(),
+        }];
+
+        let prompt =
+            build_title_prompt_from_messages(&messages, None, ProfileResponseStyle::Balanced);
+
+        assert!(prompt.contains("Match the conversation language."));
+        assert!(prompt.contains("Keep the title clear and natural"));
+    }
+
+    #[test]
+    fn title_prompt_from_messages_includes_concise_style_rule() {
+        let messages = vec![MessageRecord {
+            id: "msg-1".into(),
+            thread_id: "thread-1".into(),
+            run_id: None,
+            role: "user".into(),
+            content_markdown: "Need a short title".into(),
+            message_type: "plain_message".into(),
+            status: "completed".into(),
+            metadata_json: None,
+            attachments_json: None,
+            created_at: String::new(),
+        }];
+
+        let prompt = build_title_prompt_from_messages(
+            &messages,
+            Some("English"),
+            ProfileResponseStyle::Concise,
+        );
+
+        assert!(prompt.contains("Write the title in English."));
+        assert!(prompt.contains("especially terse, direct, and low-friction"));
+    }
+
+    #[test]
+    fn title_prompt_from_messages_includes_guide_style_rule() {
+        let messages = vec![MessageRecord {
+            id: "msg-1".into(),
+            thread_id: "thread-1".into(),
+            run_id: None,
+            role: "assistant".into(),
+            content_markdown: "Let's decide whether to keep fallback behavior.".into(),
+            message_type: "plain_message".into(),
+            status: "completed".into(),
+            metadata_json: None,
+            attachments_json: None,
+            created_at: String::new(),
+        }];
+
+        let prompt = build_title_prompt_from_messages(
+            &messages,
+            Some("English"),
+            ProfileResponseStyle::Guide,
+        );
+
+        assert!(prompt.contains("Write the title in English."));
+        assert!(prompt.contains("signals the user's goal or decision focus clearly"));
     }
 
     #[test]

--- a/src-tauri/src/persistence/repo/message_repo.rs
+++ b/src-tauri/src/persistence/repo/message_repo.rs
@@ -527,6 +527,71 @@ mod tests {
         assert_eq!(ids, vec!["50", "60"]);
     }
 
+    #[tokio::test]
+    async fn list_since_last_reset_supports_manual_title_tail_windowing_after_boundary() {
+        let pool = setup_test_pool().await;
+
+        for index in 0..140 {
+            let id = format!("{:03}", index + 1);
+            let role = if index % 2 == 0 { "user" } else { "assistant" };
+            insert(&pool, &msg(&id, role, &format!("message-{index}")))
+                .await
+                .unwrap();
+        }
+
+        insert(
+            &pool,
+            &reset_marker(
+                "200",
+                serde_json::json!({
+                    "kind": "context_reset",
+                    "source": "auto",
+                    "boundaryMessageId": "050",
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+        insert(
+            &pool,
+            &MessageRecord {
+                id: "201".to_string(),
+                thread_id: "t1".to_string(),
+                run_id: None,
+                role: "system".to_string(),
+                content_markdown: "<context_summary>state</context_summary>".to_string(),
+                message_type: "summary_marker".to_string(),
+                status: "completed".to_string(),
+                metadata_json: Some(serde_json::json!({"kind": "context_summary"}).to_string()),
+                attachments_json: None,
+                created_at: String::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let messages = list_since_last_reset(&pool, "t1").await.unwrap();
+        let tail_start = messages.len().saturating_sub(128);
+        let recent_tail = &messages[tail_start..];
+        let relevant: Vec<&MessageRecord> = recent_tail
+            .iter()
+            .filter(|message| {
+                message.message_type == "plain_message"
+                    && (message.role == "user" || message.role == "assistant")
+            })
+            .collect();
+        let relevant_start = relevant.len().saturating_sub(24);
+        let recent_relevant: Vec<&MessageRecord> = relevant[relevant_start..].to_vec();
+        let ids: Vec<&str> = recent_relevant
+            .iter()
+            .map(|message| message.id.as_str())
+            .collect();
+
+        assert_eq!(ids.len(), 24);
+        assert_eq!(ids.first().copied(), Some("117"));
+        assert_eq!(ids.last().copied(), Some("140"));
+    }
+
     #[test]
     fn extract_boundary_message_id_is_tolerant_of_malformed_metadata() {
         assert_eq!(extract_boundary_message_id(None), None);


### PR DESCRIPTION
## Summary
- Add multi-model thread title fallback across lightweight, auxiliary, and primary candidates while skipping duplicate model IDs.
- Align auto and manual title generation with current-context boundaries, including reset-marker and boundaryMessageId semantics.
- Limit manual title context to the latest 128 context messages and the latest 24 user/assistant messages, and add regression tests for prompt ordering and boundary windowing.

## Test Plan
- [x] Run `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml -- title`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml list_since_last_reset_supports_manual_title_tail_windowing_after_boundary`
- [x] Run `cargo test --manifest-path src-tauri/Cargo.toml`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
