### PR TITLE
fix(shell-output): 🐛 Strip ANSI escape sequences from tool output

### DIFF
--- a/src-tauri/src/core/executors/mod.rs
+++ b/src-tauri/src/core/executors/mod.rs
@@ -1,6 +1,7 @@
 pub mod edit;
 pub mod filesystem;
 pub mod git;
+pub mod output_sanitizer;
 pub mod process;
 pub mod search;
 pub mod terminal;

--- a/src-tauri/src/core/executors/output_sanitizer.rs
+++ b/src-tauri/src/core/executors/output_sanitizer.rs
@@ -120,4 +120,53 @@ mod tests {
 
         assert_eq!(sanitized, "startmidend");
     }
+
+    #[test]
+    fn truncated_bare_esc_at_end() {
+        // Input ending with a bare ESC
+        let sanitized = sanitize_terminal_output("hello\u{1b}");
+        assert_eq!(sanitized, "hello");
+    }
+
+    #[test]
+    fn truncated_csi_at_end() {
+        // ESC [ without a final byte
+        let sanitized = sanitize_terminal_output("hello\u{1b}[31");
+        assert_eq!(sanitized, "hello");
+    }
+
+    #[test]
+    fn truncated_osc_at_end() {
+        // ESC ] without BEL/ST terminator
+        let sanitized = sanitize_terminal_output("hello\u{1b}]0;title");
+        assert_eq!(sanitized, "hello");
+    }
+
+    #[test]
+    fn truncated_dcs_at_end() {
+        // ESC P without ST terminator
+        let sanitized = sanitize_terminal_output("hello\u{1b}Pdata");
+        assert_eq!(sanitized, "hello");
+    }
+
+    #[test]
+    fn strips_apc_sequence() {
+        // APC (ESC _) with ST terminator — used by iTerm2 image protocol
+        let raw = "before\u{1b}_payload\u{1b}\\after";
+        let sanitized = sanitize_terminal_output(raw);
+        assert_eq!(sanitized, "beforeafter");
+    }
+
+    #[test]
+    fn empty_input_returns_empty() {
+        let sanitized = sanitize_terminal_output("");
+        assert_eq!(sanitized, "");
+    }
+
+    #[test]
+    fn pure_printable_passes_through() {
+        let raw = "hello world\nline two\ttabbed";
+        let sanitized = sanitize_terminal_output(raw);
+        assert_eq!(sanitized, raw);
+    }
 }

--- a/src-tauri/src/core/executors/output_sanitizer.rs
+++ b/src-tauri/src/core/executors/output_sanitizer.rs
@@ -1,0 +1,123 @@
+//! Shared sanitization helpers for command and terminal text output.
+//!
+//! These helpers remove ANSI / OSC / DCS style escape sequences and apply a
+//! few terminal control semantics so agent-facing surfaces receive readable
+//! plain text instead of raw control bytes.
+
+/// Strip ANSI-style escape/control sequences from terminal text for agent/UI use.
+///
+/// The sanitizer removes CSI/OSC/DCS/APC-style sequences, applies backspaces,
+/// drops carriage returns, and preserves printable text plus `\n` / `\t`.
+pub fn sanitize_terminal_output(raw: &str) -> String {
+    let chars: Vec<char> = raw.chars().collect();
+    let mut output = String::with_capacity(raw.len());
+    let mut index = 0;
+
+    while index < chars.len() {
+        match chars[index] {
+            '\u{1b}' => {
+                index += 1;
+                if index >= chars.len() {
+                    break;
+                }
+
+                match chars[index] {
+                    '[' => {
+                        index += 1;
+                        while index < chars.len() {
+                            let ch = chars[index];
+                            index += 1;
+                            if ('@'..='~').contains(&ch) {
+                                break;
+                            }
+                        }
+                    }
+                    ']' => {
+                        index += 1;
+                        while index < chars.len() {
+                            match chars[index] {
+                                '\u{7}' => {
+                                    index += 1;
+                                    break;
+                                }
+                                '\u{1b}' if chars.get(index + 1).copied() == Some('\\') => {
+                                    index += 2;
+                                    break;
+                                }
+                                _ => {
+                                    index += 1;
+                                }
+                            }
+                        }
+                    }
+                    'P' | 'X' | '^' | '_' => {
+                        index += 1;
+                        while index < chars.len() {
+                            if chars[index] == '\u{1b}'
+                                && chars.get(index + 1).copied() == Some('\\')
+                            {
+                                index += 2;
+                                break;
+                            }
+                            index += 1;
+                        }
+                    }
+                    '(' | ')' | '*' | '+' | '-' | '.' | '/' => {
+                        index += 2;
+                    }
+                    _ => {
+                        index += 1;
+                    }
+                }
+            }
+            '\u{8}' => {
+                output.pop();
+                index += 1;
+            }
+            '\r' => {
+                index += 1;
+            }
+            ch if ch.is_control() && ch != '\n' && ch != '\t' => {
+                index += 1;
+            }
+            ch => {
+                output.push(ch);
+                index += 1;
+            }
+        }
+    }
+
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_terminal_output;
+
+    #[test]
+    fn strips_ansi_and_osc_sequences() {
+        let raw = "\u{1b}[0m\u{1b}[49mhello\u{1b}[39m\n\u{1b}]1;whoami\u{7}whoami\njorben\r\n";
+
+        let sanitized = sanitize_terminal_output(raw);
+
+        assert_eq!(sanitized, "hello\nwhoami\njorben\n");
+    }
+
+    #[test]
+    fn applies_backspaces() {
+        let raw = "abc\u{8}\u{8}Z\n";
+
+        let sanitized = sanitize_terminal_output(raw);
+
+        assert_eq!(sanitized, "aZ\n");
+    }
+
+    #[test]
+    fn strips_dcs_and_charset_sequences() {
+        let raw = "start\u{1b}P1$r0m\u{1b}\\mid\u{1b}(Bend";
+
+        let sanitized = sanitize_terminal_output(raw);
+
+        assert_eq!(sanitized, "startmidend");
+    }
+}

--- a/src-tauri/src/core/executors/truncation.rs
+++ b/src-tauri/src/core/executors/truncation.rs
@@ -3,6 +3,8 @@
 //! Mirrors pi-mono's `truncate.ts` — provides a single, shared module that all
 //! executors use instead of each implementing its own truncation logic.
 
+use super::output_sanitizer::sanitize_terminal_output;
+
 /// Default limit for file-read style output (~100 KB).
 pub const READ_MAX_BYTES: usize = 100_000;
 /// Default max lines for file-read style output.
@@ -122,10 +124,11 @@ pub fn truncate_tail(content: &str, max_bytes: usize, max_lines: usize) -> (Stri
 }
 
 /// Convenience wrapper that accepts raw bytes (e.g. from process stdout/stderr)
-/// and returns a truncated-tail string.
+/// and returns a truncated-tail string after sanitizing ANSI/control sequences.
 pub fn truncate_tail_bytes(bytes: &[u8], max_bytes: usize, max_lines: usize) -> (String, bool) {
     let s = String::from_utf8_lossy(bytes);
-    truncate_tail(&s, max_bytes, max_lines)
+    let sanitized = sanitize_terminal_output(&s);
+    truncate_tail(&sanitized, max_bytes, max_lines)
 }
 
 // ---------------------------------------------------------------------------
@@ -206,6 +209,36 @@ mod tests {
         assert!(truncated);
         assert!(result.contains("d\ne"));
         assert!(result.contains("[Output truncated"));
+    }
+
+    #[test]
+    fn truncate_tail_bytes_sanitizes_ansi_sequences() {
+        let bytes = b"\x1b[31m-red\x1b[0m\n\x1b[32m+green\x1b[0m\r\n";
+
+        let (result, truncated) = truncate_tail_bytes(bytes, 10_000, 100);
+
+        assert_eq!(result, "-red\n+green\n");
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn truncate_tail_bytes_sanitizes_before_truncating() {
+        let bytes = concat!(
+            "keep\n",
+            "\u{1b}[31mremove-me\u{1b}[0m\n",
+            "\u{1b}]0;title\u{7}",
+            "abc\u{8}Z\n",
+            "tail\n"
+        )
+        .as_bytes();
+
+        let (result, truncated) = truncate_tail_bytes(bytes, 16, 2);
+
+        assert!(truncated);
+        assert!(result.contains("showing last 2 of 4 lines"));
+        assert!(result.contains("abZ\ntail"));
+        assert!(!result.contains("\u{1b}"));
+        assert!(!result.contains("remove-me"));
     }
 
     #[test]

--- a/src-tauri/src/core/terminal_manager.rs
+++ b/src-tauri/src/core/terminal_manager.rs
@@ -10,6 +10,7 @@ use portable_pty::{native_pty_system, ChildKiller, CommandBuilder, MasterPty, Pt
 use sqlx::SqlitePool;
 use tokio::sync::{broadcast, RwLock};
 
+use crate::core::executors::output_sanitizer::sanitize_terminal_output;
 use crate::ipc::frontend_channels::TerminalStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::terminal::{
@@ -521,7 +522,7 @@ impl TerminalManager {
             .await
             .ok_or_else(|| AppError::not_found(ErrorSource::Terminal, "terminal session"))?;
 
-        Ok(sanitize_terminal_output_for_agent(&session.recent_output()))
+        Ok(sanitize_terminal_output(&session.recent_output()))
     }
 
     async fn get_session(&self, thread_id: &str) -> Option<Arc<TerminalSessionRuntime>> {
@@ -591,6 +592,9 @@ impl TerminalManager {
                         let chunk = decode_utf8_chunk(&mut pending_utf8, raw);
                         if !chunk.is_empty() {
                             session.push_output(&chunk);
+                            // Keep raw PTY bytes for the live terminal surface.
+                            // xterm consumes ANSI control sequences directly;
+                            // only agent-facing snapshots/tools are sanitized.
                             let _ = session.broadcaster.send(TerminalStreamEvent::StdoutChunk {
                                 thread_id: session.thread_id.clone(),
                                 data: chunk,
@@ -796,88 +800,6 @@ fn flush_utf8_tail(pending: &mut Vec<u8>) -> Option<String> {
     Some(chunk)
 }
 
-fn sanitize_terminal_output_for_agent(raw: &str) -> String {
-    let chars: Vec<char> = raw.chars().collect();
-    let mut output = String::with_capacity(raw.len());
-    let mut index = 0;
-
-    while index < chars.len() {
-        match chars[index] {
-            '\u{1b}' => {
-                index += 1;
-                if index >= chars.len() {
-                    break;
-                }
-
-                match chars[index] {
-                    '[' => {
-                        index += 1;
-                        while index < chars.len() {
-                            let ch = chars[index];
-                            index += 1;
-                            if ('@'..='~').contains(&ch) {
-                                break;
-                            }
-                        }
-                    }
-                    ']' => {
-                        index += 1;
-                        while index < chars.len() {
-                            match chars[index] {
-                                '\u{7}' => {
-                                    index += 1;
-                                    break;
-                                }
-                                '\u{1b}' if chars.get(index + 1).copied() == Some('\\') => {
-                                    index += 2;
-                                    break;
-                                }
-                                _ => {
-                                    index += 1;
-                                }
-                            }
-                        }
-                    }
-                    'P' | 'X' | '^' | '_' => {
-                        index += 1;
-                        while index < chars.len() {
-                            if chars[index] == '\u{1b}'
-                                && chars.get(index + 1).copied() == Some('\\')
-                            {
-                                index += 2;
-                                break;
-                            }
-                            index += 1;
-                        }
-                    }
-                    '(' | ')' | '*' | '+' | '-' | '.' | '/' => {
-                        index += 2;
-                    }
-                    _ => {
-                        index += 1;
-                    }
-                }
-            }
-            '\u{8}' => {
-                output.pop();
-                index += 1;
-            }
-            '\r' => {
-                index += 1;
-            }
-            ch if ch.is_control() && ch != '\n' && ch != '\t' => {
-                index += 1;
-            }
-            ch => {
-                output.push(ch);
-                index += 1;
-            }
-        }
-    }
-
-    output
-}
-
 fn resolve_shell(override_path: Option<&str>) -> String {
     if let Some(path) = override_path {
         let path = path.trim();
@@ -1065,8 +987,7 @@ pub fn list_available_shells() -> Vec<ShellOption> {
 #[cfg(test)]
 mod tests {
     use super::{
-        decode_utf8_chunk, flush_utf8_tail, sanitize_terminal_output_for_agent,
-        trim_replay_to_last_screen_reset, ReplayBuffer,
+        decode_utf8_chunk, flush_utf8_tail, trim_replay_to_last_screen_reset, ReplayBuffer,
     };
 
     #[test]
@@ -1114,23 +1035,5 @@ mod tests {
 
         assert!(resets_screen);
         assert_eq!(trimmed, "\u{1b}[H\u{1b}[2Jsuffix");
-    }
-
-    #[test]
-    fn sanitize_terminal_output_for_agent_strips_ansi_and_osc_sequences() {
-        let raw = "\u{1b}[0m\u{1b}[49mhello\u{1b}[39m\n\u{1b}]1;whoami\u{7}whoami\njorben\r\n";
-
-        let sanitized = sanitize_terminal_output_for_agent(raw);
-
-        assert_eq!(sanitized, "hello\nwhoami\njorben\n");
-    }
-
-    #[test]
-    fn sanitize_terminal_output_for_agent_applies_backspaces() {
-        let raw = "abc\u{8}\u{8}Z\n";
-
-        let sanitized = sanitize_terminal_output_for_agent(raw);
-
-        assert_eq!(sanitized, "aZ\n");
     }
 }


### PR DESCRIPTION
## Summary
- Extract a shared Rust sanitizer for terminal-style ANSI, OSC, and DCS output sequences.
- Sanitize `shell` tool stdout/stderr before truncation so tool cards no longer show raw escape-code mojibake.
- Reuse the same sanitizer for terminal output snapshots while keeping the live PTY stream raw for xterm rendering.

## Test Plan
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml output_sanitizer -- --nocapture`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml truncation -- --nocapture`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
