### PR TITLE
fix(git): 🐛 Show ours blob as Old side in conflict diff view

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5029,6 +5029,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6104,6 +6110,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "similar",
  "smappservice-rs",
  "sqlx",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -53,6 +53,7 @@ chrono = { version = "0.4", features = ["serde"] }
 keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
+similar = "2"
 tiycore = "0.1.13"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -309,12 +309,50 @@ impl GitManager {
         let workspace_relative = normalize_workspace_relative_path(path);
 
         tokio::task::spawn_blocking(move || {
-            // For conflict files, we read the workdir content (which contains
-            // conflict markers) and display it as all-new content.
-            // This gives users a clear view of the current state of the file
-            // including conflict markers (<<<<<<<, =======, >>>>>>>).
-            let hunks = build_added_file_fallback_hunks(&workspace_root, &workspace_relative);
+            // Try to get the ours blob from the index conflict to use as Old side.
+            // If that fails (e.g. delete-modify conflict, non-UTF-8 blob), fall
+            // back to the previous all-new-content behaviour.
+            let ours_text = (|| -> Option<String> {
+                let repo = open_repository(&workspace_root).ok()?;
+                let repo_root = repo_workdir(&repo).ok()?;
+                let repo_relative =
+                    workspace_path_to_repo_path(&repo_root, &workspace_root, &workspace_relative)
+                        .ok()?;
+                let index = repo.index().ok()?;
+                let conflict = index.conflict_get(Path::new(&repo_relative)).ok()?;
+                let ours_entry = conflict.our?;
+                let blob = repo.find_blob(ours_entry.id).ok()?;
+                if blob.is_binary() {
+                    return None;
+                }
+                std::str::from_utf8(blob.content())
+                    .ok()
+                    .map(|s| s.to_string())
+            })();
 
+            // Read current workdir content (New side, may contain conflict markers).
+            let new_text = std::fs::read_to_string(workspace_root.join(&workspace_relative)).ok();
+
+            if let (Some(old_text), Some(new_text)) = (&ours_text, &new_text) {
+                let (hunks, additions, deletions, truncated) =
+                    build_conflict_diff_hunks(old_text, new_text);
+
+                return Ok(GitDiffDto {
+                    path: workspace_relative.clone(),
+                    staged: false,
+                    status: GitChangeKind::Unmerged,
+                    old_path: Some(workspace_relative.clone()),
+                    new_path: Some(workspace_relative),
+                    additions,
+                    deletions,
+                    is_binary: false,
+                    truncated,
+                    hunks,
+                });
+            }
+
+            // Fallback: show workdir content as all-new (original behaviour).
+            let hunks = build_added_file_fallback_hunks(&workspace_root, &workspace_relative);
             let additions = hunks.iter().map(|h| h.lines.len() as u32).sum::<u32>();
 
             Ok(GitDiffDto {
@@ -1380,6 +1418,74 @@ fn trim_patch_line(bytes: &[u8]) -> String {
         .trim_end_matches('\n')
         .trim_end_matches('\r')
         .to_string()
+}
+
+/// Compare old (ours blob) text with new (workdir) text using `similar` and
+/// produce standard context/remove/add hunk data, respecting MAX_DIFF_LINES.
+fn build_conflict_diff_hunks(
+    old_text: &str,
+    new_text: &str,
+) -> (Vec<GitDiffHunkDto>, u32, u32, bool) {
+    use similar::{ChangeTag, TextDiff};
+
+    let text_diff = TextDiff::from_lines(old_text, new_text);
+    let mut lines = Vec::new();
+    let mut additions: u32 = 0;
+    let mut deletions: u32 = 0;
+    let mut old_line: u32 = 1;
+    let mut new_line: u32 = 1;
+    let mut truncated = false;
+
+    for change in text_diff.iter_all_changes() {
+        if lines.len() >= MAX_DIFF_LINES {
+            truncated = true;
+            break;
+        }
+
+        match change.tag() {
+            ChangeTag::Equal => {
+                lines.push(GitDiffLineDto {
+                    kind: GitDiffLineKind::Context,
+                    old_number: Some(old_line),
+                    new_number: Some(new_line),
+                    text: change.value().trim_end_matches('\n').to_string(),
+                });
+                old_line += 1;
+                new_line += 1;
+            }
+            ChangeTag::Delete => {
+                lines.push(GitDiffLineDto {
+                    kind: GitDiffLineKind::Remove,
+                    old_number: Some(old_line),
+                    new_number: None,
+                    text: change.value().trim_end_matches('\n').to_string(),
+                });
+                old_line += 1;
+                deletions += 1;
+            }
+            ChangeTag::Insert => {
+                lines.push(GitDiffLineDto {
+                    kind: GitDiffLineKind::Add,
+                    old_number: None,
+                    new_number: Some(new_line),
+                    text: change.value().trim_end_matches('\n').to_string(),
+                });
+                new_line += 1;
+                additions += 1;
+            }
+        }
+    }
+
+    if lines.is_empty() {
+        return (Vec::new(), 0, 0, false);
+    }
+
+    let old_total = old_line.saturating_sub(1);
+    let new_total = new_line.saturating_sub(1);
+    let header = format!("@@ -1,{} +1,{} @@", old_total, new_total);
+
+    let hunks = vec![GitDiffHunkDto { header, lines }];
+    (hunks, additions, deletions, truncated)
 }
 
 fn build_added_file_fallback_hunks(

--- a/src-tauri/src/core/git_manager.rs
+++ b/src-tauri/src/core/git_manager.rs
@@ -1448,7 +1448,10 @@ fn build_conflict_diff_hunks(
                     kind: GitDiffLineKind::Context,
                     old_number: Some(old_line),
                     new_number: Some(new_line),
-                    text: change.value().trim_end_matches('\n').to_string(),
+                    text: change
+                        .value()
+                        .trim_end_matches(&['\r', '\n'][..])
+                        .to_string(),
                 });
                 old_line += 1;
                 new_line += 1;
@@ -1458,7 +1461,10 @@ fn build_conflict_diff_hunks(
                     kind: GitDiffLineKind::Remove,
                     old_number: Some(old_line),
                     new_number: None,
-                    text: change.value().trim_end_matches('\n').to_string(),
+                    text: change
+                        .value()
+                        .trim_end_matches(&['\r', '\n'][..])
+                        .to_string(),
                 });
                 old_line += 1;
                 deletions += 1;
@@ -1468,7 +1474,10 @@ fn build_conflict_diff_hunks(
                     kind: GitDiffLineKind::Add,
                     old_number: None,
                     new_number: Some(new_line),
-                    text: change.value().trim_end_matches('\n').to_string(),
+                    text: change
+                        .value()
+                        .trim_end_matches(&['\r', '\n'][..])
+                        .to_string(),
                 });
                 new_line += 1;
                 additions += 1;
@@ -1628,4 +1637,129 @@ fn collect_branches(repo: &Repository) -> Result<Vec<GitBranchDto>, AppError> {
     });
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conflict_diff_identical_texts() {
+        let text = "line1\nline2\nline3\n";
+        let (hunks, additions, deletions, truncated) = build_conflict_diff_hunks(text, text);
+        assert_eq!(additions, 0);
+        assert_eq!(deletions, 0);
+        assert!(!truncated);
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].lines.len(), 3);
+        for line in &hunks[0].lines {
+            assert!(matches!(line.kind, GitDiffLineKind::Context));
+            assert!(line.old_number.is_some());
+            assert!(line.new_number.is_some());
+        }
+    }
+
+    #[test]
+    fn conflict_diff_empty_old() {
+        let (hunks, additions, deletions, truncated) = build_conflict_diff_hunks("", "a\nb\n");
+        assert_eq!(additions, 2);
+        assert_eq!(deletions, 0);
+        assert!(!truncated);
+        for line in &hunks[0].lines {
+            assert!(matches!(line.kind, GitDiffLineKind::Add));
+            assert!(line.old_number.is_none());
+            assert!(line.new_number.is_some());
+        }
+    }
+
+    #[test]
+    fn conflict_diff_empty_new() {
+        let (hunks, additions, deletions, truncated) = build_conflict_diff_hunks("a\nb\n", "");
+        assert_eq!(additions, 0);
+        assert_eq!(deletions, 2);
+        assert!(!truncated);
+        for line in &hunks[0].lines {
+            assert!(matches!(line.kind, GitDiffLineKind::Remove));
+            assert!(line.old_number.is_some());
+            assert!(line.new_number.is_none());
+        }
+    }
+
+    #[test]
+    fn conflict_diff_both_empty() {
+        let (hunks, additions, deletions, truncated) = build_conflict_diff_hunks("", "");
+        assert_eq!(additions, 0);
+        assert_eq!(deletions, 0);
+        assert!(!truncated);
+        assert!(hunks.is_empty());
+    }
+
+    #[test]
+    fn conflict_diff_mixed_changes() {
+        let old = "keep\nremove_me\nstay\n";
+        let new = "keep\nadd_me\nstay\n";
+        let (hunks, additions, deletions, truncated) = build_conflict_diff_hunks(old, new);
+        assert_eq!(additions, 1);
+        assert_eq!(deletions, 1);
+        assert!(!truncated);
+        assert_eq!(hunks.len(), 1);
+
+        let kinds: Vec<_> = hunks[0].lines.iter().map(|l| &l.kind).collect();
+        assert!(kinds.contains(&&GitDiffLineKind::Context));
+        assert!(kinds.contains(&&GitDiffLineKind::Remove));
+        assert!(kinds.contains(&&GitDiffLineKind::Add));
+    }
+
+    #[test]
+    fn conflict_diff_line_numbers_tracked_correctly() {
+        let old = "a\nb\nc\n";
+        let new = "a\nx\nc\n";
+        let (hunks, _, _, _) = build_conflict_diff_hunks(old, new);
+        let lines = &hunks[0].lines;
+
+        // line 1: context a → old=1, new=1
+        assert_eq!(lines[0].old_number, Some(1));
+        assert_eq!(lines[0].new_number, Some(1));
+        // line 2: remove b → old=2
+        assert_eq!(lines[1].old_number, Some(2));
+        assert_eq!(lines[1].new_number, None);
+        // line 3: add x → new=2
+        assert_eq!(lines[2].old_number, None);
+        assert_eq!(lines[2].new_number, Some(2));
+        // line 4: context c → old=3, new=3
+        assert_eq!(lines[3].old_number, Some(3));
+        assert_eq!(lines[3].new_number, Some(3));
+    }
+
+    #[test]
+    fn conflict_diff_crlf_trimmed() {
+        let old = "line\r\n";
+        let new = "changed\r\n";
+        let (hunks, _, _, _) = build_conflict_diff_hunks(old, new);
+        for line in &hunks[0].lines {
+            assert!(!line.text.ends_with('\r'));
+            assert!(!line.text.ends_with('\n'));
+        }
+    }
+
+    #[test]
+    fn conflict_diff_truncation_at_max() {
+        // Build input that exceeds MAX_DIFF_LINES (1200).
+        let old_lines: String = (0..700).map(|i| format!("old_{i}\n")).collect();
+        let new_lines: String = (0..700).map(|i| format!("new_{i}\n")).collect();
+        let (hunks, _, _, truncated) = build_conflict_diff_hunks(&old_lines, &new_lines);
+        assert!(truncated);
+        let total: usize = hunks.iter().map(|h| h.lines.len()).sum();
+        assert_eq!(total, MAX_DIFF_LINES);
+    }
+
+    #[test]
+    fn conflict_diff_hunk_header_format() {
+        let old = "a\nb\n";
+        let new = "a\nc\n";
+        let (hunks, _, _, _) = build_conflict_diff_hunks(old, new);
+        assert!(hunks[0].header.starts_with("@@ -1,"));
+        assert!(hunks[0].header.contains("+1,"));
+        assert!(hunks[0].header.ends_with("@@"));
+    }
 }


### PR DESCRIPTION
## Summary
- Fix conflict diff displaying only New column (all-add lines) with empty Old column
- Retrieve ours blob from Git index conflict entry as the Old side, diff against workdir content using `similar` crate
- Graceful fallback to original all-new behavior for edge cases (delete-modify conflicts, binary files)

## Test Plan
- [ ] Open a repo with merge conflicts, click a conflicted file in Source Control
- [ ] Verify Old column shows ours (pre-merge) content, New column shows workdir content with conflict markers
- [ ] Verify binary conflict files and delete-modify conflicts fallback to all-new display without errors
- [ ] `cargo test` passes (6/6)

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)