### PR TITLE
fix(agent-run-manager): 🐛 Clear stale tool calls on context-reset plan approval

### DIFF
--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -293,6 +293,11 @@ impl AgentRunManager {
             let mut spec = spec;
             if let Some(history_override) = options.history_override {
                 spec.history_messages = history_override;
+                // When history is overridden (e.g. context-reset plan approval),
+                // the old tool calls are no longer relevant — the override
+                // messages have no matching run_ids, so stale tool calls would
+                // otherwise be appended to the LLM context as orphaned entries.
+                spec.history_tool_calls = Vec::new();
             }
             spec.initial_prompt = options.initial_prompt;
 


### PR DESCRIPTION
## Summary
- Fix context-reset plan approval ("清理上下文后按计划实施") leaking stale tool calls into the implementation run
- When `history_override` replaces `spec.history_messages`, `spec.history_tool_calls` was not cleared, causing `convert_history_messages` to append orphaned tool call/result pairs to the LLM context
- Now clears `history_tool_calls` alongside `history_messages` so the reset context contains only the approved plan

## Test Plan
- [x] `cargo test` — all Rust tests pass
- [x] `cargo fmt` — formatted
- [ ] Manual: use update_plan → "清理上下文后按计划实施" and verify the implementation run context contains only the plan, no stale tool calls

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)