### PR TITLE
fix(workbench): 🐛 Fix scroll jump when sending messages in existing threads

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -3213,7 +3213,7 @@ export function RuntimeThreadSurface({
 
     if (submission.kind === "command" && submission.command?.behavior === "clear") {
       appendOptimisticUserMessage(submission.displayText, submission.metadata ?? null, [], false);
-      conversationContextRef.current?.scrollToBottom();
+      conversationContextRef.current?.scrollToBottom("instant");
       try {
         preserveContextUsageOnNextEmptySnapshotRef.current = false;
         onContextUsageChange?.(null);
@@ -3227,7 +3227,7 @@ export function RuntimeThreadSurface({
 
     if (submission.kind === "command" && submission.command?.behavior === "compact") {
       appendOptimisticUserMessage(submission.displayText, submission.metadata ?? null, [], false);
-      conversationContextRef.current?.scrollToBottom();
+      conversationContextRef.current?.scrollToBottom("instant");
       try {
         preserveContextUsageOnNextEmptySnapshotRef.current = false;
         onContextUsageChange?.(null);
@@ -3259,7 +3259,7 @@ export function RuntimeThreadSurface({
 
     // Scroll to bottom when sending a new message to ensure the conversation
     // follows the new content even if the user had scrolled up previously.
-    conversationContextRef.current?.scrollToBottom();
+    conversationContextRef.current?.scrollToBottom("instant");
 
     try {
       await streamRef.current?.startRun(
@@ -3294,7 +3294,7 @@ export function RuntimeThreadSurface({
     setRuntimeError(null);
     setQueueArtifact(null);
     appendOptimisticUserMessage(displayText, null, []);
-    conversationContextRef.current?.scrollToBottom();
+    conversationContextRef.current?.scrollToBottom("instant");
 
     try {
       await streamRef.current.respondToClarify(tool.id, response);
@@ -3403,9 +3403,13 @@ export function RuntimeThreadSurface({
   }, []);
 
   useEffect(() => {
+    if (!snapshotReady) {
+      setScrollContainerEl(null);
+      return;
+    }
     const scrollEl = conversationContextRef.current?.scrollRef?.current ?? null;
     setScrollContainerEl(scrollEl);
-  }, []);
+  }, [snapshotReady]);
 
   const getIsStuckToBottom = useCallback(
     () => conversationContextRef.current?.isAtBottom ?? true,
@@ -4145,6 +4149,7 @@ export function RuntimeThreadSurface({
           className="size-full"
           contextRef={conversationContextRef}
           initialBehavior="instant"
+          resizeBehavior="instant"
         >
           <ConversationContent
             className="mx-auto w-full max-w-4xl gap-0 px-6 pt-8"

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2245,6 +2245,7 @@ export function RuntimeThreadSurface({
   const thinkingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const preserveContextUsageOnNextEmptySnapshotRef = useRef(false);
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
+  const lastOptimisticUserIdRef = useRef<string | null>(null);
 
   // --- Viewport auto-collapse infrastructure ---
   const [scrollContainerEl, setScrollContainerEl] = useState<HTMLElement | null>(null);
@@ -2336,6 +2337,7 @@ export function RuntimeThreadSurface({
   ) => {
     const userCreatedAt = new Date().toISOString();
     const localUserMessageId = `local-user-${Date.now()}`;
+    lastOptimisticUserIdRef.current = localUserMessageId;
 
     setMessages((current) => {
       const withoutStaleLocal = current.filter(
@@ -2428,9 +2430,31 @@ export function RuntimeThreadSurface({
         for (const localMsg of currentMessages) {
           const snapshotIdx = merged.findIndex((m) => m.id === localMsg.id);
           if (snapshotIdx === -1) {
-            // Message exists locally but not in snapshot — keep it when it
-            // has meaningful content (streaming or completed assistant reply).
+            // Message exists locally but not in snapshot.
             if (
+              localMsg.id.startsWith("local-user-") && localMsg.role === "user"
+              && lastOptimisticUserIdRef.current === localMsg.id
+            ) {
+              // Optimistic user message — check if snapshot contains its
+              // persisted counterpart (same role + content, new to this snapshot).
+              const persistedIdx = merged.findIndex(
+                (m) =>
+                  m.role === "user"
+                  && m.content === localMsg.content
+                  && !currentMessages.some((c) => c.id === m.id),
+              );
+              if (persistedIdx !== -1) {
+                // Backend has persisted the message. Replace the snapshot
+                // entry's id with the optimistic id so the React key stays
+                // stable and no DOM remount / scroll jump occurs.
+                merged[persistedIdx] = { ...merged[persistedIdx], id: localMsg.id };
+                lastOptimisticUserIdRef.current = null;
+              } else {
+                // DB write hasn't landed yet — keep the optimistic message
+                // so it doesn't vanish from the list mid-frame.
+                merged.push(localMsg);
+              }
+            } else if (
               localMsg.role === "assistant"
               && (localMsg.status === "streaming" || localMsg.status === "completed")
               && localMsg.content.length > 0
@@ -2611,6 +2635,7 @@ export function RuntimeThreadSurface({
     setRunState("idle");
     setSnapshotReady(false);
     setSnapshotThreadId(null);
+    lastOptimisticUserIdRef.current = null;
     clearScheduledThinkingPhase();
     setThinkingPlaceholder(null);
     setTools([]);

--- a/src/shared/hooks/use-viewport-auto-collapse.ts
+++ b/src/shared/hooks/use-viewport-auto-collapse.ts
@@ -86,25 +86,41 @@ export function useViewportAutoCollapse({
   // redundant work if the IO fires again for the same element.
   const autoCollapsedRef = useRef<Set<string>>(new Set());
 
+  // Track entry ids that have been observed as intersecting (visible) at least
+  // once.  We only auto-collapse entries that were previously visible and then
+  // scrolled out — never entries that were already above the viewport when
+  // first observed (e.g. a reasoning block that completed while off-screen).
+  const seenIntersectingRef = useRef<Set<string>>(new Set());
+
   /**
    * The IO callback.  For each entry reported as not intersecting *above*
    * the viewport, trigger a collapse + scrollTop compensation.
    */
   const handleIntersection = useCallback(
     (ioEntries: IntersectionObserverEntry[]) => {
-      if (!getIsStuckRef.current()) return;
-
       for (const ioEntry of ioEntries) {
-        if (ioEntry.isIntersecting) continue;
+        const el = ioEntry.target as HTMLElement;
+        const id = el.dataset.timelineEntryId;
+        if (!id) continue;
+
+        // Always track visibility so we know which entries have been on-screen.
+        if (ioEntry.isIntersecting) {
+          seenIntersectingRef.current.add(id);
+          continue;
+        }
+
+        // Only collapse when the scroll container is stuck to bottom.
+        if (!getIsStuckRef.current()) continue;
+
+        // Only collapse entries that were previously visible in the viewport.
+        // This prevents collapsing entries that were already above the viewport
+        // when first observed (e.g. a reasoning block pushed off-screen by
+        // tool calls during streaming, then completing while still off-screen).
+        if (!seenIntersectingRef.current.has(id)) continue;
 
         // Ensure the element is above the viewport, not below.
         const rootTop = ioEntry.rootBounds?.top ?? 0;
         if (ioEntry.boundingClientRect.bottom >= rootTop) continue;
-
-        // Find the id for this element.
-        const el = ioEntry.target as HTMLElement;
-        const id = el.dataset.timelineEntryId;
-        if (!id) continue;
 
         // Guard: only collapse completed + open entries that the user hasn't
         // manually re-opened and that we haven't already collapsed.
@@ -152,6 +168,7 @@ export function useViewportAutoCollapse({
     observerRef.current?.disconnect();
     observedElementsRef.current.clear();
     autoCollapsedRef.current.clear();
+    seenIntersectingRef.current.clear();
 
     const observer = new IntersectionObserver(handleIntersection, {
       root: scrollContainer,


### PR DESCRIPTION
## Summary
- Fix visual scroll jump (content scrolls up then snaps back) when sending a new message in a multi-turn thread
- Root cause: `loadSnapshot` merge logic silently dropped optimistic user messages (`local-user-*`), and the snapshot's persisted message used a different ID, causing React key changes → DOM remount → height thrash → smooth scroll animation visible as a "bounce"
- Solution: track the optimistic message ID via `lastOptimisticUserIdRef`, and when the snapshot arrives with the persisted version, replace its ID with the optimistic one to keep the React key stable and avoid DOM remount

## Test Plan
- [ ] Send a message in an existing multi-turn thread — no upward scroll jump before content settles
- [ ] Rapidly send multiple messages — each appears smoothly without bounce
- [ ] Switch threads and send a message — scroll behavior is correct
- [ ] First message in a new empty thread still works normally
- [ ] `stream_resync_required` triggered snapshots handle optimistic messages correctly

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)