### PR TITLE
fix(model-icons): Match hy-number aliases to Hunyuan

### DIFF
--- a/src/shared/lib/llm-brand-matcher.test.ts
+++ b/src/shared/lib/llm-brand-matcher.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { matchModelIcon } from "@/shared/lib/llm-brand-matcher";
+
+describe("matchModelIcon", () => {
+  it("maps hunyuan short model aliases like hy3 and hy4 to the hunyuan icon slug", () => {
+    expect(matchModelIcon("hy3")).toBe("hunyuan");
+    expect(matchModelIcon("hy4")).toBe("hunyuan");
+    expect(matchModelIcon("foo/hy5-chat")).toBe("hunyuan");
+    expect(matchModelIcon("model-hy12-preview")).toBe("hunyuan");
+  });
+
+  it("does not match unrelated names that only contain hy without digits", () => {
+    expect(matchModelIcon("hyperbolic")).toBeNull();
+    expect(matchModelIcon("my-hybrid-model")).toBeNull();
+    expect(matchModelIcon("hy-model")).toBeNull();
+  });
+});

--- a/src/shared/lib/llm-brand-matcher.ts
+++ b/src/shared/lib/llm-brand-matcher.ts
@@ -19,7 +19,7 @@ const BRAND_RULES: ReadonlyArray<BrandRule> = [
   { slug: "grok", providerPatterns: ["grok"], modelPatterns: ["grok"] },
   { slug: "sora", providerPatterns: ["sora"], modelPatterns: ["sora"] },
   { slug: "chatglm", providerPatterns: ["chatglm", "chat glm", "glm", "glmv"], modelPatterns: ["chatglm", "chat glm", "glm", "glmv"] },
-  { slug: "hunyuan", providerPatterns: ["hunyuan"], modelPatterns: ["hunyuan"] },
+  { slug: "hunyuan", providerPatterns: ["hunyuan"], modelPatterns: ["hunyuan", /(^|[^a-z0-9])hy\d+(?:[^a-z0-9]|$)/u] },
   { slug: "longcat", providerPatterns: ["longcat"], modelPatterns: ["longcat"] },
   { slug: "minimax", providerPatterns: ["minimax", "mini max"], modelPatterns: ["minimax", "mini max"] },
   { slug: "nanobanana", providerPatterns: ["nano banana", "nanobanana"], modelPatterns: ["nano banana", "nanobanana"] },


### PR DESCRIPTION
## Summary
- Update Hunyuan model icon matching to recognize short aliases like `hy3`.
- Add a boundary-safe `hy\d+` model pattern so future versions such as `hy4` and `hy5` also resolve to the Hunyuan logo.
- Add unit tests covering positive and negative matching cases for the new alias rule.

## Test Plan
- [x] Run `npm run test:unit -- src/shared/lib/llm-brand-matcher.test.ts`
- [ ] Manually verify a `hy3` model now renders the Hunyuan icon in the UI
- [ ] Manually verify unrelated model names containing `hy` without digits still use their normal fallback behavior

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
