### PR TITLE
fix(settings): 🐛 Auto-select newly added provider

### DIFF
--- a/src/modules/settings-center/ui/settings-center-overlay.tsx
+++ b/src/modules/settings-center/ui/settings-center-overlay.tsx
@@ -2298,6 +2298,8 @@ function ProviderSettingsPanel({
   const [modelTestFeedback, setModelTestFeedback] = useState<Record<string, ProviderModelConnectionTestResultDto>>({});
   const [isMiniMaxCustomBaseUrl, setIsMiniMaxCustomBaseUrl] = useState(false);
   const modelTestFeedbackTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+  const pendingSelectNewProviderRef = useRef(false);
+  const previousProviderIdsRef = useRef(new Set(providers.map((provider) => provider.id)));
 
   const selectedProvider = providers.find((provider) => provider.id === selectedProviderId) ?? null;
   const isMiniMaxProvider = selectedProvider?.providerKey === "minimax";
@@ -2336,6 +2338,22 @@ function ProviderSettingsPanel({
         })),
     [providerCatalog],
   );
+
+  useEffect(() => {
+    const currentProviderIds = new Set(providers.map((provider) => provider.id));
+
+    if (pendingSelectNewProviderRef.current) {
+      for (const provider of providers) {
+        if (!previousProviderIdsRef.current.has(provider.id)) {
+          setSelectedProviderId(provider.id);
+          pendingSelectNewProviderRef.current = false;
+          break;
+        }
+      }
+    }
+
+    previousProviderIdsRef.current = currentProviderIds;
+  }, [providers]);
 
   useEffect(() => {
     if (!providers.some((provider) => provider.id === selectedProviderId)) {
@@ -2396,6 +2414,7 @@ function ProviderSettingsPanel({
       enabled: false,
       models: [],
     };
+    pendingSelectNewProviderRef.current = true;
     onAddProvider(newProvider);
   };
 


### PR DESCRIPTION
## Summary
- Auto-select a provider immediately after it is added in the settings panel.
- Track provider IDs to detect the newly inserted provider without changing existing selection fallback behavior.
- Keep the fix isolated to the provider settings UI state flow.

## Test Plan
- [ ] Add a new provider from Settings and verify it becomes selected automatically.
- [ ] Verify existing provider selection still falls back when the selected provider is removed.
- [ ] Run `npm run typecheck`.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
