### PR TITLE
feat(workbench-shell): ✨ Default collapse task board tool details in timeline

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { mapSnapshotToRunState } from "./runtime-thread-surface";
+import { mapSnapshotToRunState, isTaskBoardTool, getDefaultToolOpenState } from "./runtime-thread-surface";
 import type { RunStatus, ThreadSnapshotDto } from "@/shared/types/api";
 
 function makeSnapshot(activeStatus: RunStatus | null): ThreadSnapshotDto {
@@ -66,5 +66,59 @@ describe("mapSnapshotToRunState", () => {
 
   it("falls back to completed when there is no active run", () => {
     expect(mapSnapshotToRunState(makeSnapshot(null))).toBe("completed");
+  });
+});
+
+describe("isTaskBoardTool", () => {
+  it("returns true for task board tool names", () => {
+    expect(isTaskBoardTool("create_task")).toBe(true);
+    expect(isTaskBoardTool("update_task")).toBe(true);
+    expect(isTaskBoardTool("query_task")).toBe(true);
+  });
+
+  it("returns false for non-task tool names", () => {
+    expect(isTaskBoardTool("read")).toBe(false);
+    expect(isTaskBoardTool("edit")).toBe(false);
+    expect(isTaskBoardTool("shell")).toBe(false);
+    expect(isTaskBoardTool("agent_explore")).toBe(false);
+    expect(isTaskBoardTool("update_plan")).toBe(false);
+  });
+
+  it("returns false for empty and edge-case strings", () => {
+    expect(isTaskBoardTool("")).toBe(false);
+    expect(isTaskBoardTool("create_task_extra")).toBe(false);
+    expect(isTaskBoardTool("CREATE_TASK")).toBe(false);
+  });
+});
+
+describe("getDefaultToolOpenState", () => {
+  it("defaults task board tools to collapsed", () => {
+    expect(getDefaultToolOpenState("create_task", "input-available", undefined)).toBe(false);
+    expect(getDefaultToolOpenState("update_task", "output-available", undefined)).toBe(false);
+    expect(getDefaultToolOpenState("query_task", "input-streaming", undefined)).toBe(false);
+  });
+
+  it("respects explicit open state for task board tools", () => {
+    expect(getDefaultToolOpenState("create_task", "output-available", true)).toBe(true);
+    expect(getDefaultToolOpenState("update_task", "output-available", false)).toBe(false);
+  });
+
+  it("defaults non-task running tools to expanded", () => {
+    expect(getDefaultToolOpenState("read", "input-available", undefined)).toBe(true);
+    expect(getDefaultToolOpenState("shell", "input-streaming", undefined)).toBe(true);
+  });
+
+  it("force-expands non-task running tools even with explicit false", () => {
+    expect(getDefaultToolOpenState("read", "input-available", false)).toBe(true);
+  });
+
+  it("defaults non-task completed tools to expanded", () => {
+    expect(getDefaultToolOpenState("read", "output-available", undefined)).toBe(true);
+    expect(getDefaultToolOpenState("edit", "output-error", undefined)).toBe(true);
+  });
+
+  it("respects explicit open state for non-task completed tools", () => {
+    expect(getDefaultToolOpenState("read", "output-available", false)).toBe(false);
+    expect(getDefaultToolOpenState("edit", "output-available", true)).toBe(true);
   });
 });

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -1979,12 +1979,32 @@ function isRuntimeOrchestrationTool(toolName: string) {
   );
 }
 
-function isTaskBoardTool(toolName: string) {
+/** Whether this tool name is a task-board management tool that should be collapsed by default. */
+export function isTaskBoardTool(toolName: string) {
   return (
     toolName === "create_task"
     || toolName === "update_task"
     || toolName === "query_task"
   );
+}
+
+/**
+ * Determine the default open state for a tool's collapsible detail block.
+ * Task board tools default to collapsed; other tools default to expanded
+ * (and stay force-expanded while still running).
+ */
+export function getDefaultToolOpenState(
+  toolName: string,
+  toolState: SurfaceToolState,
+  explicitOpen: boolean | undefined,
+): boolean {
+  if (isTaskBoardTool(toolName)) {
+    return explicitOpen ?? false;
+  }
+  if (!isCompletedToolState(toolState)) {
+    return true;
+  }
+  return explicitOpen ?? true;
 }
 
 function isVisibleTimelineTool(
@@ -3430,9 +3450,7 @@ export function RuntimeThreadSurface({
     for (const entry of presentationEntries) {
       if (entry.kind === "tool") {
         const isCompleted = isCompletedToolState(entry.tool.state);
-        const isOpen = isTaskBoardTool(entry.tool.name)
-          ? (completedToolOpen[entry.tool.id] ?? false)
-          : (!isCompleted ? true : (completedToolOpen[entry.tool.id] ?? true));
+        const isOpen = getDefaultToolOpenState(entry.tool.name, entry.tool.state, completedToolOpen[entry.tool.id]);
         result.push({ id: entry.tool.id, completed: isCompleted, currentOpen: isOpen });
       } else if (entry.kind === "helper") {
         const isCompleted = entry.helper.status === "completed";
@@ -3523,7 +3541,10 @@ export function RuntimeThreadSurface({
           // State changed — keep the block open (don't auto-collapse on
           // completion).  Only force open when transitioning *to* a
           // non-completed state so newly-started tools expand.
-          if (!isCompletedToolState(tool.state)) {
+          // Task board tools always default to collapsed regardless of state.
+          if (isTaskBoardTool(tool.name)) {
+            next[tool.id] = tool.id in current ? current[tool.id] : false;
+          } else if (!isCompletedToolState(tool.state)) {
             next[tool.id] = true;
           } else {
             // Completed: preserve current open state (default open).
@@ -3537,7 +3558,7 @@ export function RuntimeThreadSurface({
           continue;
         }
 
-        next[tool.id] = !isCompletedToolState(tool.state);
+        next[tool.id] = isTaskBoardTool(tool.name) ? false : !isCompletedToolState(tool.state);
       }
 
       const currentKeys = Object.keys(current);
@@ -3929,7 +3950,7 @@ export function RuntimeThreadSurface({
 
               handleCompletedToolOpenChange(tool.id, open);
             }}
-            open={isTaskBoardTool(tool.name) ? (completedToolOpen[tool.id] ?? false) : (!isCompletedToolState(tool.state) ? true : (completedToolOpen[tool.id] ?? true))}
+            open={getDefaultToolOpenState(tool.name, tool.state, completedToolOpen[tool.id])}
           >
             <CompactCollapsibleHeader
               className={cn(

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -1979,6 +1979,14 @@ function isRuntimeOrchestrationTool(toolName: string) {
   );
 }
 
+function isTaskBoardTool(toolName: string) {
+  return (
+    toolName === "create_task"
+    || toolName === "update_task"
+    || toolName === "query_task"
+  );
+}
+
 function isVisibleTimelineTool(
   tool: SurfaceToolEntry,
   helperIds: ReadonlySet<string>,
@@ -3422,7 +3430,9 @@ export function RuntimeThreadSurface({
     for (const entry of presentationEntries) {
       if (entry.kind === "tool") {
         const isCompleted = isCompletedToolState(entry.tool.state);
-        const isOpen = !isCompleted ? true : (completedToolOpen[entry.tool.id] ?? true);
+        const isOpen = isTaskBoardTool(entry.tool.name)
+          ? (completedToolOpen[entry.tool.id] ?? false)
+          : (!isCompleted ? true : (completedToolOpen[entry.tool.id] ?? true));
         result.push({ id: entry.tool.id, completed: isCompleted, currentOpen: isOpen });
       } else if (entry.kind === "helper") {
         const isCompleted = entry.helper.status === "completed";
@@ -3919,7 +3929,7 @@ export function RuntimeThreadSurface({
 
               handleCompletedToolOpenChange(tool.id, open);
             }}
-            open={!isCompletedToolState(tool.state) ? true : (completedToolOpen[tool.id] ?? true)}
+            open={isTaskBoardTool(tool.name) ? (completedToolOpen[tool.id] ?? false) : (!isCompletedToolState(tool.state) ? true : (completedToolOpen[tool.id] ?? true))}
           >
             <CompactCollapsibleHeader
               className={cn(


### PR DESCRIPTION
## Summary
- Add `isTaskBoardTool` helper to identify `create_task`, `update_task`, and `query_task` tools
- Default their collapsible detail blocks to **collapsed** in the timeline feed (both during execution and after completion)
- Sync the same default in `viewportCollapseEntries` so auto-collapse logic stays consistent
- Users can still manually expand; the existing `userManuallyOpenedIds` mechanism prevents re-collapse

## Test Plan
- [ ] Verify `create_task` / `update_task` / `query_task` tool entries appear collapsed by default
- [ ] Verify clicking the header expands the detail and it stays open
- [ ] Verify other tools (read, search, edit, shell, etc.) still default to expanded
- [ ] Verify viewport auto-collapse for non-task tools is unaffected

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)