### PR TITLE
fix(persistence): 🐛 Separate tool call storage and runtime IDs

### DIFF
--- a/src-tauri/migrations/20260424000000_tool_call_storage_id.sql
+++ b/src-tauri/migrations/20260424000000_tool_call_storage_id.sql
@@ -1,0 +1,13 @@
+-- Split tool_calls storage identity from provider/runtime tool call identity.
+-- Existing rows used tool_calls.id for both purposes; keep those rows compatible
+-- by backfilling tool_call_id from id. New rows use id as an internal storage
+-- primary key and tool_call_id as the raw model/runtime correlation id.
+
+ALTER TABLE tool_calls ADD COLUMN tool_call_id TEXT;
+
+UPDATE tool_calls
+SET tool_call_id = id
+WHERE tool_call_id IS NULL OR TRIM(tool_call_id) = '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tool_calls_run_tool_call_id_unique
+    ON tool_calls(run_id, tool_call_id);

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -261,6 +261,7 @@ mod tests {
 
     async fn seed_tool_call(
         pool: &sqlx::SqlitePool,
+        storage_id: &str,
         tool_call_id: &str,
         run_id: &str,
         thread_id: &str,
@@ -271,7 +272,7 @@ mod tests {
             "INSERT INTO tool_calls (id, tool_call_id, run_id, thread_id, tool_name, tool_input_json, status, started_at)
              VALUES (?, ?, ?, ?, ?, '{}', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
         )
-        .bind(tool_call_id)
+        .bind(storage_id)
         .bind(tool_call_id)
         .bind(run_id)
         .bind(thread_id)
@@ -351,6 +352,7 @@ mod tests {
         .await;
         seed_tool_call(
             &pool,
+            "tc-storage-dup-approval",
             "tc-dup-approval",
             "r-dup-approval",
             "t-dup-approval",
@@ -374,7 +376,7 @@ mod tests {
                         run_id: "r-dup-approval".into(),
                         thread_id: "t-dup-approval".into(),
                         tool_call_id: "tc-dup-approval".into(),
-                        tool_call_storage_id: "tc-dup-approval".into(),
+                        tool_call_storage_id: "tc-storage-dup-approval".into(),
                         tool_name: "write".into(),
                         tool_input: serde_json::json!({
                             "path": target_file_text,
@@ -424,7 +426,7 @@ mod tests {
         }
 
         let row = sqlx::query(
-            "SELECT status, approval_status FROM tool_calls WHERE id = 'tc-dup-approval'",
+            "SELECT status, approval_status FROM tool_calls WHERE id = 'tc-storage-dup-approval'",
         )
         .fetch_one(&pool)
         .await

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -268,9 +268,10 @@ mod tests {
         status: &str,
     ) {
         sqlx::query(
-            "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, tool_input_json, status, started_at)
-             VALUES (?, ?, ?, ?, '{}', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
+            "INSERT INTO tool_calls (id, tool_call_id, run_id, thread_id, tool_name, tool_input_json, status, started_at)
+             VALUES (?, ?, ?, ?, ?, '{}', ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))",
         )
+        .bind(tool_call_id)
         .bind(tool_call_id)
         .bind(run_id)
         .bind(thread_id)
@@ -373,6 +374,7 @@ mod tests {
                         run_id: "r-dup-approval".into(),
                         thread_id: "t-dup-approval".into(),
                         tool_call_id: "tc-dup-approval".into(),
+                        tool_call_storage_id: "tc-dup-approval".into(),
                         tool_name: "write".into(),
                         tool_input: serde_json::json!({
                             "path": target_file_text,

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -542,10 +542,12 @@ impl AgentSession {
                 .await;
         }
 
+        let tool_call_storage_id = uuid::Uuid::now_v7().to_string();
         let insert_result = tool_call_repo::insert(
             &self.pool,
             &tool_call_repo::ToolCallInsert {
-                id: tool_call_id.to_string(),
+                id: tool_call_storage_id.clone(),
+                tool_call_id: tool_call_id.to_string(),
                 run_id: self.spec.run_id.clone(),
                 thread_id: self.spec.thread_id.clone(),
                 tool_name: tool_name.to_string(),
@@ -561,7 +563,7 @@ impl AgentSession {
 
         if let Some(tool) = RuntimeOrchestrationTool::parse(tool_name) {
             return self
-                .execute_helper_tool(tool, tool_call_id, tool_input)
+                .execute_helper_tool(tool, tool_call_id, &tool_call_storage_id, tool_input)
                 .await;
         }
 
@@ -576,6 +578,7 @@ impl AgentSession {
             run_id: self.spec.run_id.clone(),
             thread_id: self.spec.thread_id.clone(),
             tool_call_id: tool_call_id.to_string(),
+            tool_call_storage_id: tool_call_storage_id.clone(),
             tool_name: tool_name.to_string(),
             tool_input: tool_input.clone(),
             workspace_path: self.spec.workspace_path.clone(),
@@ -668,7 +671,7 @@ impl AgentSession {
                         let result = serde_json::json!({ "error": message.clone() });
                         tool_call_repo::update_result(
                             &self.pool,
-                            tool_call_id,
+                            &tool_call_storage_id,
                             &result.to_string(),
                             "failed",
                         )
@@ -710,10 +713,12 @@ impl AgentSession {
             return agent_error_result(error);
         }
 
+        let tool_call_storage_id = uuid::Uuid::now_v7().to_string();
         if let Err(error) = tool_call_repo::insert(
             &self.pool,
             &tool_call_repo::ToolCallInsert {
-                id: tool_call_id.to_string(),
+                id: tool_call_storage_id.clone(),
+                tool_call_id: tool_call_id.to_string(),
                 run_id: self.spec.run_id.clone(),
                 thread_id: self.spec.thread_id.clone(),
                 tool_name: tool_name.to_string(),
@@ -737,6 +742,7 @@ impl AgentSession {
             run_id: self.spec.run_id.clone(),
             thread_id: self.spec.thread_id.clone(),
             tool_call_id: tool_call_id.to_string(),
+            tool_call_storage_id: tool_call_storage_id.clone(),
             tool_name: tool_name.to_string(),
             tool_input: tool_input.clone(),
             workspace_path: self.spec.workspace_path.clone(),
@@ -790,6 +796,7 @@ impl AgentSession {
         &self,
         tool: RuntimeOrchestrationTool,
         tool_call_id: &str,
+        tool_call_storage_id: &str,
         tool_input: &serde_json::Value,
     ) -> AgentToolResult {
         let (task, review_request) = if tool == RuntimeOrchestrationTool::Review {
@@ -798,7 +805,7 @@ impl AgentSession {
                 Err(error) => {
                     tool_call_repo::update_result(
                         &self.pool,
-                        tool_call_id,
+                        tool_call_storage_id,
                         &serde_json::json!({ "error": error }).to_string(),
                         "failed",
                     )
@@ -820,7 +827,7 @@ impl AgentSession {
         if task.is_empty() {
             tool_call_repo::update_result(
                 &self.pool,
-                tool_call_id,
+                tool_call_storage_id,
                 &serde_json::json!({ "error": "missing helper task" }).to_string(),
                 "failed",
             )
@@ -869,7 +876,7 @@ impl AgentSession {
                 });
                 tool_call_repo::update_result(
                     &self.pool,
-                    tool_call_id,
+                    tool_call_storage_id,
                     &result.to_string(),
                     "completed",
                 )
@@ -884,7 +891,7 @@ impl AgentSession {
             Err(error) => {
                 tool_call_repo::update_result(
                     &self.pool,
-                    tool_call_id,
+                    tool_call_storage_id,
                     &serde_json::json!({ "error": error.to_string() }).to_string(),
                     "failed",
                 )
@@ -993,10 +1000,12 @@ impl AgentSession {
         use crate::model::task_board::{CreateTaskInput, QueryTaskInput, UpdateTaskInput};
 
         // Persist the tool call record
+        let tool_call_storage_id = uuid::Uuid::now_v7().to_string();
         if let Err(error) = tool_call_repo::insert(
             &self.pool,
             &tool_call_repo::ToolCallInsert {
-                id: tool_call_id.to_string(),
+                id: tool_call_storage_id.clone(),
+                tool_call_id: tool_call_id.to_string(),
                 run_id: self.spec.run_id.clone(),
                 thread_id: self.spec.thread_id.clone(),
                 tool_name: tool_name.to_string(),
@@ -1085,7 +1094,7 @@ impl AgentSession {
             Ok(result_json) => {
                 tool_call_repo::update_result(
                     &self.pool,
-                    tool_call_id,
+                    &tool_call_storage_id,
                     &result_json.to_string(),
                     "completed",
                 )
@@ -1110,7 +1119,7 @@ impl AgentSession {
                 let error_json = serde_json::json!({ "error": &error });
                 tool_call_repo::update_result(
                     &self.pool,
-                    tool_call_id,
+                    &tool_call_storage_id,
                     &error_json.to_string(),
                     "failed",
                 )

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -199,10 +199,12 @@ impl HelperAgentOrchestrator {
                     |progress| progress.record_started(&tool_name, &action.current_action),
                 );
 
+                let tool_call_storage_id = uuid::Uuid::now_v7().to_string();
                 if let Err(error) = tool_call_repo::insert(
                     &helper_pool,
                     &tool_call_repo::ToolCallInsert {
-                        id: persisted_tool_call_id.clone(),
+                        id: tool_call_storage_id.clone(),
+                        tool_call_id: persisted_tool_call_id.clone(),
                         run_id: helper_run_id.clone(),
                         thread_id: helper_thread_id.clone(),
                         tool_name: tool_name.clone(),
@@ -232,6 +234,7 @@ impl HelperAgentOrchestrator {
                     run_id: helper_run_id.clone(),
                     thread_id: helper_thread_id.clone(),
                     tool_call_id: persisted_tool_call_id.clone(),
+                    tool_call_storage_id: tool_call_storage_id.clone(),
                     tool_name: tool_name.clone(),
                     tool_input: tool_input.clone(),
                     workspace_path: helper_workspace_path.clone(),

--- a/src-tauri/src/core/tool_gateway.rs
+++ b/src-tauri/src/core/tool_gateway.rs
@@ -28,7 +28,10 @@ use crate::persistence::repo::{
 pub struct ToolExecutionRequest {
     pub run_id: String,
     pub thread_id: String,
+    /// Runtime/provider correlation id used for model tool-result pairing and UI events.
     pub tool_call_id: String,
+    /// Internal database primary key for the persisted tool_calls row.
+    pub tool_call_storage_id: String,
     pub tool_name: String,
     pub tool_input: serde_json::Value,
     pub workspace_path: String,
@@ -159,12 +162,13 @@ impl ToolGateway {
 
         match verdict {
             PolicyVerdict::Deny { reason } => {
-                tool_call_repo::update_status(&self.pool, &request.tool_call_id, "denied").await?;
+                tool_call_repo::update_status(&self.pool, &request.tool_call_storage_id, "denied")
+                    .await?;
 
                 self.write_audit(
                     &request.run_id,
                     &request.thread_id,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &request.tool_name,
                     "tool_denied",
                     &policy_json,
@@ -207,7 +211,7 @@ impl ToolGateway {
                 if !options.allow_user_approval {
                     tool_call_repo::update_approval(
                         &self.pool,
-                        &request.tool_call_id,
+                        &request.tool_call_storage_id,
                         "escalation_required",
                         "denied",
                     )
@@ -216,7 +220,7 @@ impl ToolGateway {
                     self.write_audit(
                         &request.run_id,
                         &request.thread_id,
-                        &request.tool_call_id,
+                        &request.tool_call_storage_id,
                         &request.tool_name,
                         "tool_approval_escalated",
                         &policy_json,
@@ -236,7 +240,7 @@ impl ToolGateway {
 
                 tool_call_repo::update_status(
                     &self.pool,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     "waiting_approval",
                 )
                 .await?;
@@ -269,7 +273,7 @@ impl ToolGateway {
                     Some(true) => {
                         tool_call_repo::update_approval(
                             &self.pool,
-                            &request.tool_call_id,
+                            &request.tool_call_storage_id,
                             "approved",
                             "approved",
                         )
@@ -299,7 +303,7 @@ impl ToolGateway {
                     Some(false) => {
                         tool_call_repo::update_approval(
                             &self.pool,
-                            &request.tool_call_id,
+                            &request.tool_call_storage_id,
                             "denied",
                             "denied",
                         )
@@ -308,7 +312,7 @@ impl ToolGateway {
                         self.write_audit(
                             &request.run_id,
                             &request.thread_id,
-                            &request.tool_call_id,
+                            &request.tool_call_storage_id,
                             &request.tool_name,
                             "tool_approval_denied",
                             &serde_json::to_string(&check).unwrap_or_default(),
@@ -328,7 +332,7 @@ impl ToolGateway {
                     None => {
                         tool_call_repo::update_status(
                             &self.pool,
-                            &request.tool_call_id,
+                            &request.tool_call_storage_id,
                             "cancelled",
                         )
                         .await?;
@@ -336,7 +340,7 @@ impl ToolGateway {
                         self.write_audit(
                             &request.run_id,
                             &request.thread_id,
-                            &request.tool_call_id,
+                            &request.tool_call_storage_id,
                             &request.tool_name,
                             "tool_cancelled",
                             &serde_json::to_string(&check).unwrap_or_default(),
@@ -429,13 +433,17 @@ impl ToolGateway {
     where
         FR: FnMut(),
     {
-        tool_call_repo::update_status(&self.pool, &request.tool_call_id, "waiting_clarification")
-            .await?;
+        tool_call_repo::update_status(
+            &self.pool,
+            &request.tool_call_storage_id,
+            "waiting_clarification",
+        )
+        .await?;
 
         self.write_audit(
             &request.run_id,
             &request.thread_id,
-            &request.tool_call_id,
+            &request.tool_call_storage_id,
             &request.tool_name,
             "tool_clarification_requested",
             "{}",
@@ -472,7 +480,7 @@ impl ToolGateway {
             Some(response) => {
                 tool_call_repo::update_result(
                     &self.pool,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &response.to_string(),
                     "completed",
                 )
@@ -481,7 +489,7 @@ impl ToolGateway {
                 self.write_audit(
                     &request.run_id,
                     &request.thread_id,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &request.tool_name,
                     "tool_clarification_resolved",
                     "{}",
@@ -496,13 +504,17 @@ impl ToolGateway {
                 })
             }
             None => {
-                tool_call_repo::update_status(&self.pool, &request.tool_call_id, "cancelled")
-                    .await?;
+                tool_call_repo::update_status(
+                    &self.pool,
+                    &request.tool_call_storage_id,
+                    "cancelled",
+                )
+                .await?;
 
                 self.write_audit(
                     &request.run_id,
                     &request.thread_id,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &request.tool_name,
                     "tool_cancelled",
                     "{}",
@@ -581,7 +593,7 @@ impl ToolGateway {
         policy_json: &str,
         resolved_tool: Option<&ResolvedTool>,
     ) -> Result<ToolOutput, crate::model::errors::AppError> {
-        tool_call_repo::update_status(&self.pool, &request.tool_call_id, "running").await?;
+        tool_call_repo::update_status(&self.pool, &request.tool_call_storage_id, "running").await?;
         let writable_roots = self.load_writable_roots().await?;
 
         let output = match if let Some(resolved_tool) = resolved_tool {
@@ -611,7 +623,7 @@ impl ToolGateway {
 
                 tool_call_repo::update_result(
                     &self.pool,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &result_json,
                     "failed",
                 )
@@ -621,7 +633,7 @@ impl ToolGateway {
                 self.write_audit(
                     &request.run_id,
                     &request.thread_id,
-                    &request.tool_call_id,
+                    &request.tool_call_storage_id,
                     &request.tool_name,
                     "tool_failed",
                     policy_json,
@@ -641,13 +653,18 @@ impl ToolGateway {
         } else {
             "failed"
         };
-        tool_call_repo::update_result(&self.pool, &request.tool_call_id, &result_json, status)
-            .await?;
+        tool_call_repo::update_result(
+            &self.pool,
+            &request.tool_call_storage_id,
+            &result_json,
+            status,
+        )
+        .await?;
 
         self.write_audit(
             &request.run_id,
             &request.thread_id,
-            &request.tool_call_id,
+            &request.tool_call_storage_id,
             &request.tool_name,
             &format!("tool_{status}"),
             policy_json,
@@ -664,7 +681,7 @@ impl ToolGateway {
                 &request.workspace_path,
                 &request.thread_id,
                 &request.run_id,
-                &request.tool_call_id,
+                &request.tool_call_storage_id,
             )
             .await
             .ok();
@@ -743,7 +760,7 @@ impl ToolGateway {
                 &request.workspace_path,
                 &request.thread_id,
                 &request.run_id,
-                &request.tool_call_id,
+                &request.tool_call_storage_id,
             )
             .await
     }

--- a/src-tauri/src/model/thread.rs
+++ b/src-tauri/src/model/thread.rs
@@ -194,6 +194,7 @@ pub struct RunSummaryDto {
 #[serde(rename_all = "camelCase")]
 pub struct ToolCallDto {
     pub id: String,
+    pub storage_id: String,
     pub run_id: String,
     pub thread_id: String,
     pub tool_name: String,

--- a/src-tauri/src/persistence/repo/tool_call_repo.rs
+++ b/src-tauri/src/persistence/repo/tool_call_repo.rs
@@ -7,7 +7,8 @@ use crate::model::thread::ToolCallDto;
 
 #[derive(sqlx::FromRow)]
 struct ToolCallRow {
-    id: String,
+    storage_id: String,
+    tool_call_id: String,
     run_id: String,
     thread_id: String,
     tool_name: String,
@@ -22,7 +23,8 @@ struct ToolCallRow {
 impl ToolCallRow {
     fn into_dto(self) -> ToolCallDto {
         ToolCallDto {
-            id: self.id,
+            id: self.tool_call_id,
+            storage_id: self.storage_id,
             run_id: self.run_id,
             thread_id: self.thread_id,
             tool_name: self.tool_name,
@@ -41,6 +43,7 @@ impl ToolCallRow {
 
 pub struct ToolCallInsert {
     pub id: String,
+    pub tool_call_id: String,
     pub run_id: String,
     pub thread_id: String,
     pub tool_name: String,
@@ -51,8 +54,8 @@ pub struct ToolCallInsert {
 pub async fn insert(pool: &SqlitePool, r: &ToolCallInsert) -> Result<(), AppError> {
     let now = Utc::now().to_rfc3339();
     sqlx::query(
-        "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, tool_input_json, status, started_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, tool_input_json, status, started_at, tool_call_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(&r.id)
     .bind(&r.run_id)
@@ -61,12 +64,17 @@ pub async fn insert(pool: &SqlitePool, r: &ToolCallInsert) -> Result<(), AppErro
     .bind(&r.tool_input_json)
     .bind(&r.status)
     .bind(&now)
+    .bind(&r.tool_call_id)
     .execute(pool)
     .await?;
     Ok(())
 }
 
-pub async fn update_status(pool: &SqlitePool, id: &str, status: &str) -> Result<(), AppError> {
+pub async fn update_status(
+    pool: &SqlitePool,
+    storage_id: &str,
+    status: &str,
+) -> Result<(), AppError> {
     let is_terminal = matches!(status, "completed" | "failed" | "denied" | "cancelled");
 
     if is_terminal {
@@ -74,13 +82,13 @@ pub async fn update_status(pool: &SqlitePool, id: &str, status: &str) -> Result<
         sqlx::query("UPDATE tool_calls SET status = ?, finished_at = ? WHERE id = ?")
             .bind(status)
             .bind(&now)
-            .bind(id)
+            .bind(storage_id)
             .execute(pool)
             .await?;
     } else {
         sqlx::query("UPDATE tool_calls SET status = ? WHERE id = ?")
             .bind(status)
-            .bind(id)
+            .bind(storage_id)
             .execute(pool)
             .await?;
     }
@@ -89,7 +97,7 @@ pub async fn update_status(pool: &SqlitePool, id: &str, status: &str) -> Result<
 
 pub async fn update_result(
     pool: &SqlitePool,
-    id: &str,
+    storage_id: &str,
     output_json: &str,
     status: &str,
 ) -> Result<(), AppError> {
@@ -100,7 +108,7 @@ pub async fn update_result(
     .bind(output_json)
     .bind(status)
     .bind(&now)
-    .bind(id)
+    .bind(storage_id)
     .execute(pool)
     .await?;
     Ok(())
@@ -108,14 +116,14 @@ pub async fn update_result(
 
 pub async fn update_approval(
     pool: &SqlitePool,
-    id: &str,
+    storage_id: &str,
     approval_status: &str,
     tool_status: &str,
 ) -> Result<(), AppError> {
     sqlx::query("UPDATE tool_calls SET approval_status = ?, status = ? WHERE id = ?")
         .bind(approval_status)
         .bind(tool_status)
-        .bind(id)
+        .bind(storage_id)
         .execute(pool)
         .await?;
     Ok(())
@@ -145,7 +153,7 @@ pub async fn list_by_run_ids(
     }
 
     let mut query = QueryBuilder::new(
-        "SELECT id, run_id, thread_id, tool_name, tool_input_json, tool_output_json,
+        "SELECT id AS storage_id, COALESCE(tool_call_id, id) AS tool_call_id, run_id, thread_id, tool_name, tool_input_json, tool_output_json,
                 status, approval_status, started_at, finished_at
          FROM tool_calls
          WHERE run_id IN (",
@@ -164,4 +172,139 @@ pub async fn list_by_run_ids(
         .await?;
 
     Ok(rows.into_iter().map(ToolCallRow::into_dto).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use sqlx::Row;
+    use std::str::FromStr;
+
+    async fn setup_test_pool() -> SqlitePool {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("invalid sqlite options")
+            .foreign_keys(true);
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to create in-memory pool");
+
+        crate::persistence::sqlite::run_migrations(&pool)
+            .await
+            .expect("migrations failed");
+
+        sqlx::query(
+            "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
+                    is_default, is_git, auto_work_tree, status, created_at, updated_at)
+             VALUES ('ws-1', 'ws', '/tmp', '/tmp', '/tmp', 0, 0, 0, 'ready',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed workspace");
+
+        for thread_id in ["t1", "t2"] {
+            sqlx::query(
+                "INSERT INTO threads (id, workspace_id, title, status, created_at, updated_at, last_active_at)
+                 VALUES (?, 'ws-1', 't', 'idle',
+                         strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                         strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                         strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            )
+            .bind(thread_id)
+            .execute(&pool)
+            .await
+            .expect("seed thread");
+        }
+
+        for (run_id, thread_id) in [("r1", "t1"), ("r2", "t2")] {
+            sqlx::query(
+                "INSERT INTO thread_runs (id, thread_id, run_mode, status, started_at)
+                 VALUES (?, ?, 'default', 'running', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+            )
+            .bind(run_id)
+            .bind(thread_id)
+            .execute(&pool)
+            .await
+            .expect("seed run");
+        }
+
+        pool
+    }
+
+    fn insert_record(
+        storage_id: &str,
+        raw_id: &str,
+        run_id: &str,
+        thread_id: &str,
+    ) -> ToolCallInsert {
+        ToolCallInsert {
+            id: storage_id.to_string(),
+            tool_call_id: raw_id.to_string(),
+            run_id: run_id.to_string(),
+            thread_id: thread_id.to_string(),
+            tool_name: "shell".to_string(),
+            tool_input_json: serde_json::json!({ "command": "git status" }).to_string(),
+            status: "requested".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_runtime_tool_call_ids_are_allowed_across_runs() {
+        let pool = setup_test_pool().await;
+
+        insert(&pool, &insert_record("storage-1", "shell:3", "r1", "t1"))
+            .await
+            .expect("insert first tool call");
+        insert(&pool, &insert_record("storage-2", "shell:3", "r2", "t2"))
+            .await
+            .expect("insert second tool call with same runtime id");
+
+        update_result(
+            &pool,
+            "storage-2",
+            &serde_json::json!({ "ok": true }).to_string(),
+            "completed",
+        )
+        .await
+        .expect("update by storage id");
+
+        let calls = list_by_run_ids(&pool, &["r1".to_string(), "r2".to_string()])
+            .await
+            .expect("list tool calls");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].id, "shell:3");
+        assert_eq!(calls[0].storage_id, "storage-1");
+        assert_eq!(calls[0].status, "requested");
+        assert_eq!(calls[1].id, "shell:3");
+        assert_eq!(calls[1].storage_id, "storage-2");
+        assert_eq!(calls[1].status, "completed");
+
+        let first_status: String =
+            sqlx::query("SELECT status FROM tool_calls WHERE id = 'storage-1'")
+                .fetch_one(&pool)
+                .await
+                .expect("first row")
+                .get("status");
+        assert_eq!(first_status, "requested");
+    }
+
+    #[tokio::test]
+    async fn duplicate_runtime_tool_call_ids_are_rejected_within_same_run() {
+        let pool = setup_test_pool().await;
+
+        insert(&pool, &insert_record("storage-1", "shell:3", "r1", "t1"))
+            .await
+            .expect("insert first tool call");
+
+        let duplicate = insert(&pool, &insert_record("storage-2", "shell:3", "r1", "t1")).await;
+        assert!(
+            duplicate.is_err(),
+            "same run should not reuse a runtime tool call id"
+        );
+    }
 }

--- a/src-tauri/src/persistence/repo/tool_call_repo.rs
+++ b/src-tauri/src/persistence/repo/tool_call_repo.rs
@@ -307,4 +307,82 @@ mod tests {
             "same run should not reuse a runtime tool call id"
         );
     }
+
+    #[tokio::test]
+    async fn list_by_run_ids_falls_back_to_storage_id_for_legacy_rows() {
+        let pool = setup_test_pool().await;
+
+        sqlx::query(
+            "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, tool_input_json, status, started_at, tool_call_id)
+             VALUES ('legacy-storage-1', 'r1', 't1', 'shell', '{}', 'completed', strftime('%Y-%m-%dT%H:%M:%fZ', 'now'), NULL)",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert legacy tool call");
+
+        let calls = list_by_run_ids(&pool, &["r1".to_string()])
+            .await
+            .expect("list tool calls");
+
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "legacy-storage-1");
+        assert_eq!(calls[0].storage_id, "legacy-storage-1");
+    }
+
+    #[tokio::test]
+    async fn update_operations_target_rows_by_storage_id_when_runtime_ids_overlap() {
+        let pool = setup_test_pool().await;
+
+        insert(&pool, &insert_record("storage-1", "shell:3", "r1", "t1"))
+            .await
+            .expect("insert first tool call");
+        insert(&pool, &insert_record("storage-2", "shell:3", "r2", "t2"))
+            .await
+            .expect("insert second tool call with same runtime id");
+
+        update_status(&pool, "storage-1", "running")
+            .await
+            .expect("update first status by storage id");
+        update_approval(&pool, "storage-2", "approved", "approved")
+            .await
+            .expect("update second approval by storage id");
+        update_result(
+            &pool,
+            "storage-2",
+            &serde_json::json!({ "ok": true }).to_string(),
+            "completed",
+        )
+        .await
+        .expect("update second result by storage id");
+
+        let first = sqlx::query(
+            "SELECT status, approval_status, tool_output_json FROM tool_calls WHERE id = 'storage-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("first row");
+        assert_eq!(first.get::<String, _>("status"), "running");
+        assert!(first.get::<Option<String>, _>("approval_status").is_none());
+        assert!(first.get::<Option<String>, _>("tool_output_json").is_none());
+
+        let second = sqlx::query(
+            "SELECT status, approval_status, tool_output_json FROM tool_calls WHERE id = 'storage-2'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("second row");
+        assert_eq!(second.get::<String, _>("status"), "completed");
+        assert_eq!(
+            second
+                .get::<Option<String>, _>("approval_status")
+                .as_deref(),
+            Some("approved")
+        );
+        assert_eq!(
+            second
+                .get::<Option<String>, _>("tool_output_json")
+                .as_deref(),
+            Some(r#"{"ok":true}"#)
+        );
+    }
 }

--- a/src-tauri/tests/m1_6_tool_gateway.rs
+++ b/src-tauri/tests/m1_6_tool_gateway.rs
@@ -720,8 +720,8 @@ async fn test_tool_call_policy_verdict_stored() {
     let verdict = r#"{"toolName":"write","verdict":{"require_approval":{"reason":"Mutating tool"}},"checkedRules":["builtin","user_deny_list","workspace_boundary"]}"#;
 
     sqlx::query(
-        "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, status, policy_verdict_json)
-         VALUES ('tc-pv', 'r-pv', 't-pv', 'write', 'waiting_approval', ?)",
+        "INSERT INTO tool_calls (id, tool_call_id, run_id, thread_id, tool_name, status, policy_verdict_json)
+         VALUES ('tc-pv', 'tc-pv', 'r-pv', 't-pv', 'write', 'waiting_approval', ?)",
     )
     .bind(verdict)
     .execute(&pool)
@@ -898,6 +898,7 @@ async fn test_tool_gateway_can_fold_approval_into_escalation() {
                 run_id: "r-helper-escalate".into(),
                 thread_id: "t-helper-escalate".into(),
                 tool_call_id: "tc-helper-escalate".into(),
+                tool_call_storage_id: "tc-helper-escalate".into(),
                 tool_name: "write".into(),
                 tool_input: serde_json::json!({
                     "path": readme_path.display().to_string(),
@@ -1011,6 +1012,7 @@ async fn test_search_repo_allows_relative_directory_within_workspace() {
                 run_id: "r-search-relative".into(),
                 thread_id: "t-search-relative".into(),
                 tool_call_id: "tc-search-relative".into(),
+                tool_call_storage_id: "tc-search-relative".into(),
                 tool_name: "search".into(),
                 tool_input: serde_json::json!({
                     "query": "hello",
@@ -1116,6 +1118,7 @@ async fn test_search_repo_ignores_wildcard_file_pattern_and_limits_preview() {
                 run_id: "r-search-wildcard".into(),
                 thread_id: "t-search-wildcard".into(),
                 tool_call_id: "tc-search-wildcard".into(),
+                tool_call_storage_id: "tc-search-wildcard".into(),
                 tool_name: "search".into(),
                 tool_input: serde_json::json!({
                     "query": "hello",
@@ -1220,6 +1223,7 @@ async fn test_search_repo_treats_regex_metacharacters_as_literal_text() {
                 run_id: "r-search-literal".into(),
                 thread_id: "t-search-literal".into(),
                 tool_call_id: "tc-search-literal".into(),
+                tool_call_storage_id: "tc-search-literal".into(),
                 tool_name: "search".into(),
                 tool_input: serde_json::json!({
                     "query": "warn!(",
@@ -1327,6 +1331,7 @@ async fn test_search_repo_supports_regex_count_mode_and_case_insensitive_matchin
                 run_id: "r-search-regex-count".into(),
                 thread_id: "t-search-regex-count".into(),
                 tool_call_id: "tc-search-regex-count".into(),
+                tool_call_storage_id: "tc-search-regex-count".into(),
                 tool_name: "search".into(),
                 tool_input: serde_json::json!({
                     "query": "warn!\\(",
@@ -1426,6 +1431,7 @@ async fn test_execution_timeout_fires_for_slow_tool() {
                 run_id: "r-timeout".into(),
                 thread_id: "t-timeout".into(),
                 tool_call_id: "tc-timeout".into(),
+                tool_call_storage_id: "tc-timeout".into(),
                 tool_name: "shell".into(),
                 tool_input: serde_json::json!({
                     "command": "sleep 30",

--- a/src-tauri/tests/test_helpers.rs
+++ b/src-tauri/tests/test_helpers.rs
@@ -127,9 +127,10 @@ pub async fn seed_tool_call(
     status: &str,
 ) {
     sqlx::query(
-        "INSERT INTO tool_calls (id, run_id, thread_id, tool_name, status)
-         VALUES (?, ?, ?, ?, ?)",
+        "INSERT INTO tool_calls (id, tool_call_id, run_id, thread_id, tool_name, status)
+         VALUES (?, ?, ?, ?, ?, ?)",
     )
+    .bind(tool_call_id)
     .bind(tool_call_id)
     .bind(run_id)
     .bind(thread_id)

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -336,6 +336,7 @@ export interface RunUsageDto {
 
 export interface ToolCallDto {
   id: string;
+  storageId: string;
   runId: string;
   threadId: string;
   toolName: string;


### PR DESCRIPTION
## Summary
- Separate database `tool_calls.id` from raw runtime/provider `tool_call_id` to prevent cross-thread ID collisions.
- Add a SQLite migration plus Rust persistence/runtime updates so history replay still uses raw tool call IDs while DB updates and audits use storage IDs.
- Update tests and API types to cover duplicate raw IDs across runs and preserve existing UI/runtime behavior.

## Test Plan
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --check`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml tool_call`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml`
- [x] `npm run typecheck`
- [x] `npm run test:unit`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)