### PR TITLE
fix(settings): 🐛 correct MiniMax provider base URL to include API version path

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6133,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.15"
+version = "0.1.16-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda1901ecebcb7e971d1512a0ab1ca361f855a046880b7dd640e47502276a78f"
+checksum = "7bbdbb43f339c168da8cdbd86d02503b6fb019682621992800f9c6f3dfc07696"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.1.15"
+tiycore = "0.1.16-rc.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -90,7 +90,7 @@ const BUILTIN_PROVIDER_CATALOG: &[ProviderCatalogEntry] = &[
         provider_key: "minimax",
         provider_type: "minimax",
         display_name: "MiniMax",
-        default_base_url: "https://api.minimax.io/anthropic",
+        default_base_url: "https://api.minimax.io/anthropic/v1",
     },
     ProviderCatalogEntry {
         provider_key: "kimi-coding",

--- a/src/modules/settings-center/ui/settings-center-overlay.tsx
+++ b/src/modules/settings-center/ui/settings-center-overlay.tsx
@@ -269,8 +269,8 @@ function getApprovalPolicyOptions(t: TFunc) {
 }
 
 const MINIMAX_BASE_URL_OPTIONS = [
-  "https://api.minimax.io/anthropic",
-  "https://api.minimaxi.com/anthropic",
+  "https://api.minimax.io/anthropic/v1",
+  "https://api.minimaxi.com/anthropic/v1",
 ] as const;
 
 function deriveWorkspaceNameFromPath(path: string) {


### PR DESCRIPTION
## Summary
- Fix MiniMax provider default base URL missing API version path
- Update tiycore dependency to v0.1.16-rc.2 for upstream MiniMax fix
- Update settings-center MiniMax base URL options to include /v1 path

## Test Plan
- [ ] Verify MiniMax provider uses correct base URL with /v1 suffix
- [ ] Confirm settings UI displays updated base URL options

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)