### PR TITLE
fix(thread-stream): 🐛 Cache toolName in ThreadStream to fix task board tool collapse

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6133,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.1.17-rc.26042420"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee166774d123cb5b99203107d0031a271e37bb8b5729caeacd66c7d365d0a60d"
+checksum = "7df35bb83d637b5e7c4c6a3757a480d92bcf510c31603d37fe061eaacccfba6a"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.1.17-rc.26042420"
+tiycore = "0.1.17"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src/services/thread-stream/thread-stream.ts
+++ b/src/services/thread-stream/thread-stream.ts
@@ -174,6 +174,7 @@ export class ThreadStream {
 
   private currentRunId: string | null = null;
   private hiddenToolCallIds = new Set<string>();
+  private toolNameCache = new Map<string, string>();
   private disposed = false;
 
   get runId() {
@@ -366,6 +367,7 @@ export class ThreadStream {
   reset() {
     this.currentRunId = null;
     this.hiddenToolCallIds.clear();
+    this.toolNameCache.clear();
   }
 
   /**
@@ -510,6 +512,7 @@ export class ThreadStream {
         break;
 
       case "tool_requested":
+        this.toolNameCache.set(event.toolCallId, event.toolName);
         if (isRuntimeOrchestrationToolName(event.toolName)) {
           this.hiddenToolCallIds.add(event.toolCallId);
           break;
@@ -524,6 +527,7 @@ export class ThreadStream {
         break;
 
       case "approval_required":
+        this.toolNameCache.set(event.toolCallId, event.toolName);
         this.onRunStateChange?.("waiting_approval", event.runId);
         this.onApproval?.({
           kind: "required",
@@ -536,6 +540,7 @@ export class ThreadStream {
         break;
 
       case "clarify_required":
+        this.toolNameCache.set(event.toolCallId, event.toolName);
         this.onRunStateChange?.("needs_reply", event.runId);
         this.onToolEvent?.({
           kind: "clarify-required",
@@ -552,6 +557,7 @@ export class ThreadStream {
           kind: "resolved",
           runId: event.runId,
           toolCallId: event.toolCallId,
+          toolName: this.toolNameCache.get(event.toolCallId),
           approved: event.approved,
         });
         break;
@@ -562,6 +568,7 @@ export class ThreadStream {
           kind: "clarify-resolved",
           runId: event.runId,
           toolCallId: event.toolCallId,
+          toolName: this.toolNameCache.get(event.toolCallId),
           response: event.response,
           result: event.response,
         });
@@ -575,33 +582,40 @@ export class ThreadStream {
           kind: "running",
           runId: event.runId,
           toolCallId: event.toolCallId,
+          toolName: this.toolNameCache.get(event.toolCallId),
         });
         break;
 
       case "tool_completed":
         if (this.hiddenToolCallIds.has(event.toolCallId)) {
           this.hiddenToolCallIds.delete(event.toolCallId);
+          this.toolNameCache.delete(event.toolCallId);
           break;
         }
         this.onToolEvent?.({
           kind: "completed",
           runId: event.runId,
           toolCallId: event.toolCallId,
+          toolName: this.toolNameCache.get(event.toolCallId),
           result: event.result,
         });
+        this.toolNameCache.delete(event.toolCallId);
         break;
 
       case "tool_failed":
         if (this.hiddenToolCallIds.has(event.toolCallId)) {
           this.hiddenToolCallIds.delete(event.toolCallId);
+          this.toolNameCache.delete(event.toolCallId);
           break;
         }
         this.onToolEvent?.({
           kind: "failed",
           runId: event.runId,
           toolCallId: event.toolCallId,
+          toolName: this.toolNameCache.get(event.toolCallId),
           error: event.error,
         });
+        this.toolNameCache.delete(event.toolCallId);
         break;
 
       case "thread_title_updated":


### PR DESCRIPTION
## Summary
- Add `toolNameCache` (Map<string, string>) in `ThreadStream` to persist toolCallId → toolName across the event lifecycle
- Inject cached `toolName` into `tool_running`, `tool_completed`, `tool_failed`, `approval_resolved`, and `clarify_resolved` events that previously lacked it
- Cache is populated on `tool_requested`, `approval_required`, and `clarify_required` events; cleaned up on terminal events and `reset()`/`dispose()`

**Root cause**: Events like `tool_running` / `tool_completed` don't carry `toolName` from the backend. When the preceding `tool_requested` event is missed (e.g. broadcast channel lag → `stream_resync_required`), the surface layer falls back to the literal string `"tool"`, causing `isTaskBoardTool("tool")` to return `false` and `getDefaultToolOpenState` to force-expand the collapsible — defeating the default-collapsed behavior for task board tools.

## Test Plan
- [x] `npm run typecheck` — passes
- [x] `npm run test:unit` — 81/81 tests pass

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)