### PR TITLE
fix(agent-session): 🐛 Hierarchical cancellation for subagent tool calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@ The desktop UI lives in `src/` with React + TypeScript. Use `src/app/` for boots
 - `cargo test --manifest-path src-tauri/Cargo.toml` — run Rust integration tests.
 - `cargo fmt --manifest-path src-tauri/Cargo.toml` — format Rust code before committing.
 
+## Test Coverage
+
+- **Frontend** — run `npm run test:unit -- --coverage` to generate a Vitest + `@vitest/coverage-v8` report. The summary is printed to the terminal; detailed HTML reports are written to `coverage/`.
+- **Backend** — run `cargo llvm-cov --manifest-path src-tauri/Cargo.toml` (requires [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov)) to generate line/branch coverage for Rust integration tests. Add `--html` to open a detailed report, or `--text` for a terminal summary.
+
 ## Coding Style & Naming Conventions
 Use 2-space indentation in TypeScript/TSX. Prefer functional React components with named exports. File names should be kebab-case, for example `workbench-top-bar.tsx`; components use PascalCase; hooks use `use...`. Prefer the `@/` alias over deep relative imports. Keep code close to the feature unless it is clearly reusable. Reuse design tokens from `src/app/styles/globals.css` and align UI work with `docs/design-spec.md`. In Rust, preserve the existing `commands/`, `core/`, `model/`, and `persistence/` separation.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@vitejs/plugin-react": "^4.6.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "tailwindcss": "^4.1.12",
         "typescript": "~5.8.3",
         "vite": "^7.0.4",
@@ -390,6 +391,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@braintree/sanitize-url": {
@@ -5663,17 +5674,48 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -5682,13 +5724,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -5709,9 +5751,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5722,13 +5764,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -5736,14 +5778,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -5752,9 +5794,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -5762,13 +5804,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -5833,6 +5875,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/bail": {
       "version": "2.0.2",
@@ -6949,6 +7010,16 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hast-util-from-dom": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
@@ -7199,6 +7270,13 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7300,6 +7378,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -7699,6 +7816,47 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/markdown-table": {
@@ -9690,6 +9848,19 @@
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
@@ -10166,19 +10337,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -10206,12 +10377,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "@vitest/coverage-v8": "^4.1.5",
     "tailwindcss": "^4.1.12",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -1294,7 +1294,12 @@ impl AgentRunManager {
             | ThreadStreamEvent::ToolFailed { .. }
             | ThreadStreamEvent::SubagentCompleted { .. }
             | ThreadStreamEvent::SubagentFailed { .. } => {
-                run_repo::update_status(&self.pool, run_id, "running").await?;
+                // When the run is already being cancelled, do not revert the
+                // status back to "running" — keep it at "cancelling" so the
+                // terminal RunCancelled event sees a consistent state.
+                if !self.was_cancel_requested(run_id).await {
+                    run_repo::update_status(&self.pool, run_id, "running").await?;
+                }
             }
             ThreadStreamEvent::ThreadUsageUpdated { usage, .. } => {
                 let usage = tiycore::types::Usage {

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -389,8 +389,15 @@ impl AgentSession {
 
     pub async fn cancel(&self) {
         self.cancel_requested.store(true, Ordering::SeqCst);
+        // 1. Cascade-cancel all in-flight tool_gateway calls (including subagent ones
+        //    via child tokens) so they return Cancelled immediately.
         self.abort_signal.cancel();
+        // 2. Abort subagent Agent instances so their LLM streaming / run loops stop.
         self.helper_orchestrator.cancel_run(&self.spec.run_id).await;
+        // 3. Yield to let already-aborted subagents finish cleanup and emit
+        //    SubagentFailed before the main agent terminates.
+        tokio::task::yield_now().await;
+        // 4. Finally abort the main agent.
         self.agent.abort();
     }
 
@@ -861,6 +868,7 @@ impl AgentSession {
                 workspace_path: self.spec.workspace_path.clone(),
                 run_mode: self.spec.run_mode.clone(),
                 event_tx: self.event_tx.clone(),
+                session_abort_signal: self.abort_signal.clone(),
             })
             .await;
 

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -33,6 +33,10 @@ pub struct HelperRunRequest {
     pub workspace_path: String,
     pub run_mode: String,
     pub event_tx: tokio::sync::mpsc::UnboundedSender<ThreadStreamEvent>,
+    /// Session-level abort signal. Child tokens derived from this signal are
+    /// passed to each subagent tool call so that session cancellation cascades
+    /// into in-flight tool executions.
+    pub session_abort_signal: tiycore::agent::AbortSignal,
 }
 
 pub struct HelperRunResult {
@@ -58,10 +62,17 @@ pub struct SubagentProgressSnapshot {
     pub recent_actions: Vec<String>,
 }
 
+/// Tracks active helper agents for a single run, with a cancellation guard
+/// that prevents new helpers from registering after `cancel_run` has fired.
+struct RunHelpersState {
+    helpers: Vec<Arc<Agent>>,
+    cancelled: bool,
+}
+
 pub struct HelperAgentOrchestrator {
     pool: SqlitePool,
     tool_gateway: Arc<ToolGateway>,
-    active_helpers: Arc<Mutex<HashMap<String, Vec<Arc<Agent>>>>>,
+    active_helpers: Arc<Mutex<HashMap<String, RunHelpersState>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -167,6 +178,7 @@ impl HelperAgentOrchestrator {
         let escalation_summary_ref = Arc::clone(&escalation_summary);
         let progress_state_ref = Arc::clone(&progress_state);
         let progress_event_tx = request.event_tx.clone();
+        let helper_session_abort_signal = request.session_abort_signal.clone();
         agent.set_tool_executor(move |tool_name, tool_call_id, tool_input, _update_cb| {
             let tool_name = tool_name.to_string();
             let tool_input = tool_input.clone();
@@ -185,6 +197,7 @@ impl HelperAgentOrchestrator {
             let helper_id_for_events = helper_id_for_events.clone();
             let helper_id_for_storage = helper_id_for_events.clone();
             let helper_started_at_for_events = helper_started_at_for_events.clone();
+            let helper_abort_signal = helper_session_abort_signal.clone();
 
             async move {
                 let action = describe_subagent_action(&tool_name, &tool_input);
@@ -246,7 +259,7 @@ impl HelperAgentOrchestrator {
                 match helper_gateway
                     .execute_tool_call(
                         request,
-                        tiycore::agent::AbortSignal::new(),
+                        helper_abort_signal.child_token(),
                         ToolExecutionOptions {
                             allow_user_approval: false,
                             execution_timeout: None,
@@ -378,10 +391,19 @@ impl HelperAgentOrchestrator {
 
         {
             let mut helpers = self.active_helpers.lock().await;
-            helpers
+            let state = helpers
                 .entry(request.run_id.clone())
-                .or_default()
-                .push(Arc::clone(&agent));
+                .or_insert_with(|| RunHelpersState {
+                    helpers: Vec::new(),
+                    cancelled: false,
+                });
+            if state.cancelled {
+                return Err(AppError::internal(
+                    ErrorSource::Thread,
+                    "run cancelled".to_string(),
+                ));
+            }
+            state.helpers.push(Arc::clone(&agent));
         }
 
         let helper_run_id_for_usage = request.run_id.clone();
@@ -488,7 +510,12 @@ impl HelperAgentOrchestrator {
     pub async fn cancel_run(&self, run_id: &str) {
         let helpers = {
             let mut active = self.active_helpers.lock().await;
-            active.remove(run_id).unwrap_or_default()
+            if let Some(state) = active.get_mut(run_id) {
+                state.cancelled = true;
+                std::mem::take(&mut state.helpers)
+            } else {
+                Vec::new()
+            }
         };
 
         for helper in helpers {
@@ -498,9 +525,11 @@ impl HelperAgentOrchestrator {
 
     async fn remove_helper(&self, run_id: &str, helper: &Arc<Agent>) {
         let mut active = self.active_helpers.lock().await;
-        if let Some(helpers) = active.get_mut(run_id) {
-            helpers.retain(|candidate| !Arc::ptr_eq(candidate, helper));
-            if helpers.is_empty() {
+        if let Some(state) = active.get_mut(run_id) {
+            state
+                .helpers
+                .retain(|candidate| !Arc::ptr_eq(candidate, helper));
+            if state.helpers.is_empty() {
                 active.remove(run_id);
             }
         }

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -529,7 +529,7 @@ impl HelperAgentOrchestrator {
             state
                 .helpers
                 .retain(|candidate| !Arc::ptr_eq(candidate, helper));
-            if state.helpers.is_empty() {
+            if state.helpers.is_empty() && !state.cancelled {
                 active.remove(run_id);
             }
         }

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -529,7 +529,7 @@ impl HelperAgentOrchestrator {
             state
                 .helpers
                 .retain(|candidate| !Arc::ptr_eq(candidate, helper));
-            if state.helpers.is_empty() && !state.cancelled {
+            if state.helpers.is_empty() {
                 active.remove(run_id);
             }
         }

--- a/src-tauri/src/core/tool_gateway.rs
+++ b/src-tauri/src/core/tool_gateway.rs
@@ -203,6 +203,7 @@ impl ToolGateway {
                     &policy_json,
                     resolved_tool.as_ref(),
                     options.execution_timeout,
+                    abort_signal.clone(),
                     false,
                 )
                 .await
@@ -296,6 +297,7 @@ impl ToolGateway {
                             &policy_json,
                             resolved_tool.as_ref(),
                             options.execution_timeout,
+                            abort_signal.clone(),
                             true,
                         )
                         .await
@@ -371,29 +373,45 @@ impl ToolGateway {
         policy_json: &str,
         resolved_tool: Option<&ResolvedTool>,
         execution_timeout: Option<std::time::Duration>,
+        abort_signal: tiycore::agent::AbortSignal,
         approval_required: bool,
     ) -> Result<ToolGatewayOutcome, crate::model::errors::AppError> {
+        let tool_call_id = request.tool_call_id.clone();
+        let exec_future = self.execute_and_audit(&request, policy_json, resolved_tool);
+
         let output = if let Some(timeout) = execution_timeout {
-            match tokio::time::timeout(
-                timeout,
-                self.execute_and_audit(&request, policy_json, resolved_tool),
-            )
-            .await
-            {
-                Ok(result) => result?,
-                Err(_) => {
+            tokio::select! {
+                result = tokio::time::timeout(timeout, exec_future) => {
+                    match result {
+                        Ok(inner) => inner?,
+                        Err(_) => {
+                            return Ok(ToolGatewayOutcome {
+                                approval_required,
+                                result: ToolGatewayResult::TimedOut {
+                                    tool_call_id,
+                                    timeout_secs: timeout.as_secs(),
+                                },
+                            });
+                        }
+                    }
+                }
+                _ = abort_signal.cancelled() => {
                     return Ok(ToolGatewayOutcome {
                         approval_required,
-                        result: ToolGatewayResult::TimedOut {
-                            tool_call_id: request.tool_call_id,
-                            timeout_secs: timeout.as_secs(),
-                        },
+                        result: ToolGatewayResult::Cancelled { tool_call_id },
                     });
                 }
             }
         } else {
-            self.execute_and_audit(&request, policy_json, resolved_tool)
-                .await?
+            tokio::select! {
+                result = exec_future => result?,
+                _ = abort_signal.cancelled() => {
+                    return Ok(ToolGatewayOutcome {
+                        approval_required,
+                        result: ToolGatewayResult::Cancelled { tool_call_id },
+                    });
+                }
+            }
         };
 
         Ok(ToolGatewayOutcome {

--- a/src-tauri/tests/tool_gateway.rs
+++ b/src-tauri/tests/tool_gateway.rs
@@ -1467,3 +1467,73 @@ async fn test_execution_timeout_fires_for_slow_tool() {
         _ => panic!("expected TimedOut, got a different variant"),
     }
 }
+
+// =========================================================================
+// T1.6.y — Pre-cancelled abort signal returns Cancelled immediately
+// =========================================================================
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_abort_signal_cancels_tool_execution() {
+    use tiycode_lib::core::terminal_manager::TerminalManager;
+    use tiycode_lib::core::tool_gateway::{
+        ToolExecutionOptions, ToolExecutionRequest, ToolGateway, ToolGatewayResult,
+    };
+    use tiycore::agent::AbortSignal;
+
+    let pool = test_helpers::setup_test_pool().await;
+    let workspace_root = std::env::temp_dir().join(format!("tiy-abort-{}", uuid::Uuid::now_v7()));
+    std::fs::create_dir_all(&workspace_root).unwrap();
+    let workspace_root = std::fs::canonicalize(&workspace_root).unwrap();
+
+    test_helpers::seed_workspace(&pool, "ws-abort", workspace_root.to_str().unwrap()).await;
+    test_helpers::seed_thread(&pool, "t-abort", "ws-abort", None).await;
+    test_helpers::seed_run(&pool, "r-abort", "t-abort", "running", "default").await;
+    test_helpers::seed_tool_call(&pool, "tc-abort", "r-abort", "t-abort", "read", "requested")
+        .await;
+
+    // Create a file for the read tool to target so the policy check
+    // resolves to AutoAllow and the execution reaches execute_with_timeout.
+    let target_file = workspace_root.join("abort_test.txt");
+    std::fs::write(&target_file, "hello").unwrap();
+
+    let terminal_manager = Arc::new(TerminalManager::new(pool.clone()));
+    let gateway = Arc::new(ToolGateway::new(pool, terminal_manager));
+
+    // Pre-cancel the abort signal before calling execute_tool_call.
+    // The AutoAllow branch in execute_with_timeout should immediately
+    // select the abort_signal.cancelled() branch and return Cancelled.
+    let abort_signal = AbortSignal::new();
+    abort_signal.cancel();
+
+    let outcome = gateway
+        .execute_tool_call(
+            ToolExecutionRequest {
+                run_id: "r-abort".into(),
+                thread_id: "t-abort".into(),
+                tool_call_id: "tc-abort".into(),
+                tool_call_storage_id: "tc-abort".into(),
+                tool_name: "read".into(),
+                tool_input: serde_json::json!({
+                    "path": target_file.display().to_string(),
+                }),
+                workspace_path: workspace_root.display().to_string(),
+                run_mode: "default".into(),
+            },
+            abort_signal,
+            ToolExecutionOptions {
+                allow_user_approval: false,
+                execution_timeout: None,
+            },
+            |_| {},
+            || {},
+        )
+        .await
+        .unwrap();
+
+    match outcome.result {
+        ToolGatewayResult::Cancelled { tool_call_id } => {
+            assert_eq!(tool_call_id, "tc-abort");
+        }
+        _ => panic!("expected Cancelled, got a different variant"),
+    }
+}


### PR DESCRIPTION
## Summary
- Replace orphaned `AbortSignal::new()` in subagent tool executor with `session_abort_signal.child_token()`, enabling session-level cancellation to cascade into in-flight subagent tool calls via `CancellationToken` hierarchy
- Add `abort_signal` parameter to `ToolGateway.execute_with_timeout` with `tokio::select!` racing, so AutoAllow tool calls (all subagent tools) now respond to cancellation signals
- Introduce `RunHelpersState` with a `cancelled` flag to prevent race conditions where new helpers register after `cancel_run` has fired
- Reorder `AgentSession.cancel()` sequence: cancel token → abort subagents → yield → abort main agent, improving event ordering
- Skip reverting run status to "running" in `AgentRunManager` when the run is already being cancelled

## Test Plan
- [x] `cargo fmt --check` — passed
- [x] `cargo check` — passed
- [x] `cargo test` — 711 tests passed (including 25 tool_gateway tests and 18 agent_run tests with test_run_cancellation)
- [ ] Manual: stop thread while subagent runs shell command → verify tool call interrupted, SubagentFailed arrives before RunCancelled
- [ ] Manual: stop thread while subagent awaits LLM response → verify clean cancellation
- [ ] Manual: normal run without cancellation → verify no regression

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)