### PR TITLE
feat(task-board): ✨ Improve composer task board long lists

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2794,10 +2794,11 @@ export function RuntimeThreadSurface({
         <div className="mx-auto flex w-full max-w-4xl flex-col gap-0">
           {taskBoards.activeBoard ? (
             <div
-              className="overflow-hidden rounded-t-[24px] rounded-b-none border border-b-0 border-app-border/80 bg-app-menu/96 px-2 pb-0 pt-2 shadow-[0_26px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur-xl"
+              className="min-h-0 max-h-[min(36vh,320px)] overflow-hidden rounded-t-[24px] rounded-b-none border border-b-0 border-app-border/80 bg-app-menu/96 px-2 pb-0 pt-2 shadow-[0_26px_70px_-42px_rgba(15,23,42,0.45)] backdrop-blur-xl"
             >
               <TaskBoardCard
                 board={taskBoards.activeBoard}
+                variant="composer"
                 className="rounded-[18px] rounded-b-none border-x-0 border-t-0 border-b border-app-border/55 bg-app-surface/52 px-4 pb-3 pt-3 shadow-none"
               />
             </div>

--- a/src/modules/workbench-shell/ui/task-board-card.test.tsx
+++ b/src/modules/workbench-shell/ui/task-board-card.test.tsx
@@ -1,0 +1,81 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import type { TaskBoardDto, TaskItemDto, TaskStage } from "@/shared/types/api";
+import { TaskBoardCard } from "./task-board-card";
+
+function task(id: string, stage: TaskStage, sortOrder: number): TaskItemDto {
+  return {
+    id,
+    taskBoardId: "board-1",
+    description: `Task ${sortOrder + 1}`,
+    stage,
+    sortOrder,
+    errorDetail: stage === "failed" ? "boom" : null,
+    createdAt: "2026-04-25T00:00:00Z",
+    updatedAt: "2026-04-25T00:00:00Z",
+  };
+}
+
+function board(overrides: Partial<TaskBoardDto> = {}): TaskBoardDto {
+  const tasks = [
+    task("task-1", "completed", 0),
+    task("task-2", "completed", 1),
+    task("task-3", "in_progress", 2),
+    task("task-4", "pending", 3),
+    task("task-5", "pending", 4),
+    task("task-6", "failed", 5),
+    task("task-7", "pending", 6),
+    task("task-8", "pending", 7),
+  ];
+
+  return {
+    id: "board-1",
+    threadId: "thread-1",
+    title: "Implementation plan",
+    status: "active",
+    activeTaskId: "task-3",
+    tasks,
+    createdAt: "2026-04-25T00:00:00Z",
+    updatedAt: "2026-04-25T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("TaskBoardCard", () => {
+  it("constrains composer task boards and keeps the list internally scrollable", () => {
+    const html = renderToStaticMarkup(<TaskBoardCard board={board()} variant="composer" />);
+
+    expect(html).toContain("max-h-[min(32vh,280px)]");
+    expect(html).toContain("min-h-0");
+    expect(html).toContain("overflow-y-auto");
+    expect(html).toContain("overscroll-contain");
+    expect(html).toContain("2/8 completed");
+    expect(html).toContain("1 failed");
+    expect(html).toContain("Current:");
+    expect(html).toContain("Task 3");
+    expect(html).toContain("Task 8");
+  });
+
+  it("shows a long-list summary without enabling composer scroll classes by default", () => {
+    const html = renderToStaticMarkup(<TaskBoardCard board={board()} />);
+
+    expect(html).toContain("2/8 completed");
+    expect(html).toContain("Current:");
+    expect(html).not.toContain("max-h-[min(32vh,280px)]");
+    expect(html).not.toContain("overflow-y-auto");
+  });
+
+  it("keeps short default boards close to the original full-list presentation", () => {
+    const shortBoard = board({
+      tasks: [task("task-1", "completed", 0), task("task-2", "in_progress", 1)],
+      activeTaskId: "task-2",
+    });
+    const html = renderToStaticMarkup(<TaskBoardCard board={shortBoard} />);
+
+    expect(html).toContain("Task 1");
+    expect(html).toContain("Task 2");
+    expect(html).not.toContain("completed</span>");
+    expect(html).not.toContain("overflow-y-auto");
+  });
+});

--- a/src/modules/workbench-shell/ui/task-board-card.tsx
+++ b/src/modules/workbench-shell/ui/task-board-card.tsx
@@ -4,7 +4,7 @@ import { CheckCircle2Icon, ChevronRightIcon, CircleIcon, Loader2Icon, XCircleIco
 import { ComponentProps, useCallback, useState } from "react";
 import { cn } from "@/shared/lib/utils";
 import type { TaskBoardDto, TaskItemDto, TaskStage } from "@/shared/types/api";
-import { computeProgress, hasFailedTasks, isBoardCompleted } from "../model/task-board";
+import { computeProgress, getActiveTask, hasFailedTasks, isBoardCompleted } from "../model/task-board";
 
 // ---------------------------------------------------------------------------
 // Task Stage Indicator
@@ -64,17 +64,19 @@ export const TaskItemRow = ({
       <TaskStageIndicator stage={task.stage} />
       <span
         className={cn(
-          "flex-1",
+          "min-w-0 flex-1 break-words",
           task.stage === "completed" && "text-muted-foreground/60 line-through",
           task.stage === "failed" && "text-destructive",
           task.stage === "pending" && "text-muted-foreground"
         )}
       >
         {task.description}
+        {task.errorDetail && (
+          <span className="mt-0.5 block text-xs text-destructive/80">
+            {task.errorDetail}
+          </span>
+        )}
       </span>
-      {task.errorDetail && (
-        <span className="text-xs text-destructive/80">{task.errorDetail}</span>
-      )}
     </li>
   );
 };
@@ -87,12 +89,16 @@ export type TaskBoardCardProps = ComponentProps<"div"> & {
   board: TaskBoardDto;
   showTitle?: boolean;
   defaultCollapsed?: boolean;
+  variant?: "default" | "composer";
+  compactThreshold?: number;
 };
 
 export const TaskBoardCard = ({
   board,
   showTitle = true,
   defaultCollapsed = false,
+  variant = "default",
+  compactThreshold = 6,
   className,
   ...props
 }: TaskBoardCardProps) => {
@@ -100,6 +106,14 @@ export const TaskBoardCard = ({
   const progress = computeProgress(board);
   const completed = isBoardCompleted(board);
   const hasFailed = hasFailedTasks(board);
+  const isComposerVariant = variant === "composer";
+  const totalCount = board.tasks.length;
+  const completedCount = board.tasks.filter((task: TaskItemDto) => task.stage === "completed").length;
+  const failedCount = board.tasks.filter((task: TaskItemDto) => task.stage === "failed").length;
+  const activeTask = board.tasks.find((task: TaskItemDto) => task.id === board.activeTaskId) ?? getActiveTask(board);
+  const isLongList = totalCount > compactThreshold;
+  const showSummary = isComposerVariant || isLongList || collapsed;
+  const taskCountSummary = `${completedCount}/${totalCount} completed`;
 
   const toggleCollapse = useCallback(() => setCollapsed((c) => !c), []);
 
@@ -107,6 +121,7 @@ export const TaskBoardCard = ({
     <div
       className={cn(
         "rounded-xl border border-app-border/40 bg-app-surface/40 p-3",
+        isComposerVariant && "flex max-h-[min(32vh,280px)] min-h-0 flex-col",
         completed && "border-success/30 bg-success/5",
         hasFailed && "border-destructive/30 bg-destructive/5",
         className
@@ -117,7 +132,7 @@ export const TaskBoardCard = ({
         <button
           type="button"
           onClick={toggleCollapse}
-          className="mb-3 flex w-full items-center justify-between gap-2 text-left"
+          className="mb-3 flex w-full shrink-0 items-center justify-between gap-2 text-left"
         >
           <div className="flex min-w-0 items-center gap-2">
             <ChevronRightIcon
@@ -142,7 +157,7 @@ export const TaskBoardCard = ({
       )}
 
       {/* Progress bar */}
-      <div className="mb-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+      <div className="mb-3 h-1.5 w-full shrink-0 overflow-hidden rounded-full bg-muted">
         <div
           className={cn(
             "h-full rounded-full transition-all duration-300",
@@ -154,22 +169,47 @@ export const TaskBoardCard = ({
         />
       </div>
 
+      {showSummary && (
+        <div className="mb-2 shrink-0 space-y-1 text-xs text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span>{taskCountSummary}</span>
+            {failedCount > 0 && (
+              <span className="text-destructive">
+                {failedCount} failed
+              </span>
+            )}
+          </div>
+          {activeTask && (
+            <div className="truncate">
+              Current: <span className="text-foreground/80">{activeTask.description}</span>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Task list */}
       {!collapsed && (
-        <ul className="space-y-0.5">
-          {board.tasks.map((task: TaskItemDto) => (
-            <TaskItemRow
-              key={task.id}
-              task={task}
-              isActive={task.id === board.activeTaskId}
-            />
-          ))}
-        </ul>
+        <div
+          className={cn(
+            "min-h-0",
+            isComposerVariant && "overflow-y-auto overscroll-contain pr-1"
+          )}
+        >
+          <ul className="space-y-0.5">
+            {board.tasks.map((task: TaskItemDto) => (
+              <TaskItemRow
+                key={task.id}
+                task={task}
+                isActive={task.id === board.activeTaskId}
+              />
+            ))}
+          </ul>
+        </div>
       )}
 
       {/* Status badge */}
       {!collapsed && board.status !== "active" && (
-        <div className="mt-2 text-xs text-muted-foreground">
+        <div className="mt-2 shrink-0 text-xs text-muted-foreground">
           {board.status === "completed" ? "✓ Completed" : "⊘ Abandoned"}
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add a composer variant for task board cards with bounded height and internal task-list scrolling.
- Show compact progress details, current task, and failed-task count for long or composer task boards.
- Add unit coverage for constrained composer rendering, long-list summaries, and short-list compatibility.

## Test Plan
- [x] npm run typecheck
- [x] npm run test:unit
- [ ] Manually smoke test the desktop UI with short, long, and failed active task boards.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
