### PR TITLE
feat(model): ✨ Add reasoning content constrained capability

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1128,7 +1128,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1329,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -2400,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2549,6 +2549,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3086,7 +3116,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4110,7 +4140,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4389,9 +4419,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4525,7 +4555,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4566,13 +4596,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -4582,7 +4612,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5027,6 +5057,22 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
@@ -5534,7 +5580,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5600,7 +5646,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5613,7 +5659,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -5818,7 +5864,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.2",
+ "reqwest 0.13.3",
  "rustls",
  "semver",
  "serde",
@@ -5860,7 +5906,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5883,7 +5929,7 @@ checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -5960,7 +6006,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6133,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.1-rc.26042720"
+version = "0.2.2-rc.26042811"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91552220d3a60cc13a87cb0abd8bc8a545b0aa350414204541833831a145fadb"
+checksum = "969256a421e482095afda42f23fa8c50fd0af7bb7b3236e93ebb553154b8e111"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -7056,7 +7102,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7757,7 +7803,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = { version = "0.2.1-rc.26042720" }
+tiycore = "0.2.2-rc.26042811"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -1312,6 +1312,7 @@ mod tests {
             max_output_tokens: Some("4096".to_string()),
             supports_image_input: Some(false),
             supports_reasoning: Some(false),
+            reasoning_content_constrained: None,
             custom_headers: None,
             provider_options: None,
         }

--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -404,6 +404,7 @@ mod tests {
             max_output_tokens: None,
             supports_image_input: None,
             supports_reasoning: None,
+            reasoning_content_constrained: None,
             custom_headers: None,
             provider_options: None,
         }

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -611,7 +611,10 @@ pub async fn resolve_runtime_model_role(
         builder = builder.headers(headers);
     }
 
-    if let Some(compat) = default_openai_compatible_compat(&role.provider_type) {
+    if let Some(mut compat) = default_openai_compatible_compat(&role.provider_type) {
+        if let Some(true) = role.reasoning_content_constrained {
+            compat.reasoning_content_constrained = true;
+        }
         builder = builder.compat(compat);
     }
 

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -128,6 +128,7 @@ pub(super) mod tests {
             max_output_tokens: Some("32000".to_string()),
             supports_image_input: Some(false),
             supports_reasoning,
+            reasoning_content_constrained: None,
             custom_headers: None,
             provider_options: None,
         }

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -1397,6 +1397,73 @@ Used for prompt assembly coverage.
     }
 
     #[tokio::test]
+    async fn reasoning_content_constrained_sets_compat_flag() {
+        let temp_dir = tempdir().expect("temp dir");
+        let db_path = temp_dir.path().join("test.db");
+        let pool = init_database(&db_path).await.expect("database");
+
+        let mut compat_provider = sample_provider_record("provider-compat");
+        compat_provider.provider_type = "openai-compatible".to_string();
+        provider_repo::insert(&pool, &compat_provider)
+            .await
+            .expect("provider insert");
+
+        let make_role = |record_id: &str, model_id: &str, constrained: Option<bool>| {
+            super::super::RuntimeModelRole {
+                provider_id: "provider-compat".to_string(),
+                model_record_id: record_id.to_string(),
+                provider: None,
+                provider_key: Some("openai-compatible".to_string()),
+                provider_type: "openai-compatible".to_string(),
+                provider_name: Some("Custom Gateway".to_string()),
+                model: model_id.to_string(),
+                model_id: model_id.to_string(),
+                model_display_name: Some(model_id.to_string()),
+                base_url: "https://api.example.com/v1".to_string(),
+                context_window: Some(TEST_CONTEXT_WINDOW.to_string()),
+                max_output_tokens: Some("32000".to_string()),
+                supports_image_input: Some(false),
+                supports_reasoning: Some(true),
+                reasoning_content_constrained: constrained,
+                custom_headers: None,
+                provider_options: None,
+            }
+        };
+
+        let constrained = resolve_runtime_model_role(
+            &pool,
+            make_role("rec-constrained", "constrained-model", Some(true)),
+        )
+        .await
+        .expect("constrained role");
+
+        let unconstrained = resolve_runtime_model_role(
+            &pool,
+            make_role("rec-unconstrained", "unconstrained-model", Some(false)),
+        )
+        .await
+        .expect("unconstrained role");
+
+        let unspecified = resolve_runtime_model_role(
+            &pool,
+            make_role("rec-unspecified", "unspecified-model", None),
+        )
+        .await
+        .expect("unspecified role");
+
+        // When reasoning_content_constrained is Some(true), the compat flag must be set.
+        let constrained_compat = constrained.model.compat.as_ref().expect("compat present");
+        assert!(constrained_compat.reasoning_content_constrained);
+
+        // When Some(false) or None, the compat flag must remain at its default (false).
+        let unconstrained_compat = unconstrained.model.compat.as_ref().expect("compat present");
+        assert!(!unconstrained_compat.reasoning_content_constrained);
+
+        let unspecified_compat = unspecified.model.compat.as_ref().expect("compat present");
+        assert!(!unspecified_compat.reasoning_content_constrained);
+    }
+
+    #[tokio::test]
     async fn model_plan_applies_thinking_level_to_all_reasoning_capable_roles_only() {
         let temp_dir = tempdir().expect("temp dir");
         let db_path = temp_dir.path().join("test.db");

--- a/src-tauri/src/core/agent_session_types.rs
+++ b/src-tauri/src/core/agent_session_types.rs
@@ -32,6 +32,8 @@ pub struct RuntimeModelRole {
     pub max_output_tokens: Option<String>,
     pub supports_image_input: Option<bool>,
     pub supports_reasoning: Option<bool>,
+    #[serde(default)]
+    pub reasoning_content_constrained: Option<bool>,
     pub custom_headers: Option<HashMap<String, String>>,
     pub provider_options: Option<serde_json::Value>,
 }

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -1689,6 +1689,50 @@ mod tests {
     }
 
     #[test]
+    fn catalog_capability_overrides_includes_reasoning_content_constrained() {
+        let constrained_model = UnifiedModelInfo {
+            provider: TiyProvider::OpenAI,
+            raw_id: "deepseek-r1".to_string(),
+            canonical_model_key: Some("openai:deepseek-r1".to_string()),
+            display_name: Some("DeepSeek R1".to_string()),
+            description: None,
+            context_window: Some(128_000),
+            max_output_tokens: Some(8_192),
+            max_input_tokens: None,
+            created_at: None,
+            modalities: Some(vec!["text".to_string()]),
+            capabilities: Some(vec!["tools".to_string(), "reasoning".to_string()]),
+            pricing: None,
+            match_confidence: Some(1.0),
+            metadata_sources: vec!["openrouter".to_string()],
+            reasoning_content_constrained: true,
+            raw: json!({}),
+        };
+
+        let overrides =
+            catalog_capability_overrides(&constrained_model).expect("overrides should be present");
+        assert_eq!(
+            overrides.get("reasoningContentConstrained"),
+            Some(&serde_json::Value::Bool(true)),
+        );
+        assert_eq!(
+            overrides.get("reasoning"),
+            Some(&serde_json::Value::Bool(true)),
+        );
+
+        // When reasoning_content_constrained is false, the key must be absent.
+        let normal_model = UnifiedModelInfo {
+            reasoning_content_constrained: false,
+            ..constrained_model
+        };
+        let normal_overrides =
+            catalog_capability_overrides(&normal_model).expect("overrides should be present");
+        assert!(normal_overrides
+            .get("reasoningContentConstrained")
+            .is_none());
+    }
+
+    #[test]
     fn embedding_detection_supports_capabilities_and_name_fallback() {
         let capability_model = ProviderModelRecord {
             id: "model-embedding".to_string(),

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -317,6 +317,13 @@ fn catalog_capability_overrides(model: &UnifiedModelInfo) -> Option<serde_json::
         overrides.insert("embedding".to_string(), serde_json::Value::Bool(true));
     }
 
+    if model.reasoning_content_constrained {
+        overrides.insert(
+            "reasoningContentConstrained".to_string(),
+            serde_json::Value::Bool(true),
+        );
+    }
+
     if overrides.is_empty() {
         None
     } else {
@@ -1638,6 +1645,7 @@ mod tests {
             pricing: None,
             match_confidence: Some(1.0),
             metadata_sources: vec!["openrouter".to_string()],
+            reasoning_content_constrained: false,
             raw: json!({}),
         };
 
@@ -1669,6 +1677,7 @@ mod tests {
             pricing: None,
             match_confidence: Some(1.0),
             metadata_sources: vec!["openrouter".to_string()],
+            reasoning_content_constrained: false,
             raw: json!({}),
         };
 

--- a/src/modules/settings-center/model/run-model-plan.test.ts
+++ b/src/modules/settings-center/model/run-model-plan.test.ts
@@ -167,6 +167,54 @@ describe("buildRunModelPlan", () => {
 
     expect(plan?.primary?.supportsReasoning).toBe(false);
   });
+
+  it("propagates reasoningContentConstrained from capability overrides", () => {
+    const plan = buildRunModelPlan(
+      profile({
+        primaryModelId: "model-constrained",
+        assistantModelId: "model-normal",
+        liteModelId: "missing",
+      }),
+      [
+        provider({
+          models: [
+            {
+              id: "model-constrained",
+              modelId: "deepseek-r1",
+              sortIndex: 0,
+              displayName: "DeepSeek R1",
+              enabled: true,
+              capabilityOverrides: { reasoning: true, reasoningContentConstrained: true },
+              providerOptions: {},
+            },
+            {
+              id: "model-normal",
+              modelId: "gpt-5",
+              sortIndex: 1,
+              displayName: "GPT 5",
+              enabled: true,
+              capabilityOverrides: { reasoning: true },
+              providerOptions: {},
+            },
+          ],
+        }),
+      ],
+    );
+
+    // Model with reasoningContentConstrained: true should propagate the flag.
+    expect(plan?.primary?.reasoningContentConstrained).toBe(true);
+    // Model without the override should default to null.
+    expect(plan?.auxiliary?.reasoningContentConstrained).toBeNull();
+  });
+
+  it("defaults reasoningContentConstrained to null when capability is undefined", () => {
+    const plan = buildRunModelPlan(
+      profile({ assistantModelId: "missing", liteModelId: "missing" }),
+      [provider()],
+    );
+
+    expect(plan?.primary?.reasoningContentConstrained).toBeNull();
+  });
 });
 
 describe("buildProfileModelPlan", () => {

--- a/src/modules/settings-center/model/run-model-plan.ts
+++ b/src/modules/settings-center/model/run-model-plan.ts
@@ -52,6 +52,7 @@ function toRunModelPlanRole(selection: ProviderModelSelection): RunModelPlanRole
     maxOutputTokens: model.maxOutputTokens ?? null,
     supportsImageInput: capabilities.vision,
     supportsReasoning: capabilities.reasoning,
+    reasoningContentConstrained: capabilities.reasoningContentConstrained ?? null,
     customHeaders: isNonEmptyRecord(provider.customHeaders) ? provider.customHeaders : null,
     providerOptions: isNonEmptyRecord(model.providerOptions) ? model.providerOptions : null,
   };

--- a/src/modules/settings-center/model/types.ts
+++ b/src/modules/settings-center/model/types.ts
@@ -56,6 +56,7 @@ export type ProviderModelCapabilities = {
   toolCalling: boolean;
   reasoning: boolean;
   embedding: boolean;
+  reasoningContentConstrained?: boolean;
 };
 
 export type ProviderModel = {

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -225,6 +225,7 @@ export interface RunModelPlanRoleDto {
   maxOutputTokens?: string | null;
   supportsImageInput?: boolean | null;
   supportsReasoning?: boolean | null;
+  reasoningContentConstrained?: boolean | null;
   customHeaders?: Record<string, string> | null;
   providerOptions?: Record<string, unknown> | null;
 }


### PR DESCRIPTION
## Summary
- Add `reasoningContentConstrained` model capability through settings and run model plan DTOs.
- Pass constrained reasoning capability into runtime OpenAI-compatible model compatibility.
- Update `tiycore` to `0.2.2-rc.26042811` and sync Cargo.lock.

## Test Plan
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
