### PR TITLE
refactor(workbench-shell): ♻️ Hide redundant COMMAND block in shell tool detail view

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface-tools.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-tools.tsx
@@ -344,6 +344,7 @@ function getShellToolPresentation(tool: RuntimeSurfaceToolEntry): CommandOutputT
     detailLabel: cwd ? `cwd · ${cwd}` : null,
     output,
     outputLanguage: "log",
+    showCommandBlock: false,
     summaryLabel: summarizeInlineText(command, "shell"),
   };
 }


### PR DESCRIPTION
## Summary
- Hide the COMMAND section in the shell tool's expanded detail view since the command text is already displayed in the tool header line
- Set `showCommandBlock: false` in `getShellToolPresentation` to eliminate duplicate information and save vertical space

## Test Plan
- [ ] Expand a shell tool result in the thread — only the OUTPUT section should appear
- [ ] Verify terminal tools (`term_write`, `term_restart`) still show their command blocks as before
- [ ] Verify git tools still show their command blocks as before

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)