### PR TITLE
fix(agent): 🐛 Emit requested events for task tools

### DIFF
--- a/src-tauri/src/core/agent_session_execution.rs
+++ b/src-tauri/src/core/agent_session_execution.rs
@@ -535,12 +535,31 @@ impl AgentSession {
                 helper_id: None,
                 tool_name: tool_name.to_string(),
                 tool_input_json: tool_input.to_string(),
-                status: "running".to_string(),
+                status: "requested".to_string(),
             },
         )
         .await
         {
             return agent_error_result(format!("failed to persist tool call: {error}"));
+        }
+
+        let _ = self.event_tx.send(ThreadStreamEvent::ToolRequested {
+            run_id: self.spec.run_id.clone(),
+            tool_call_id: tool_call_id.to_string(),
+            tool_name: tool_name.to_string(),
+            tool_input: tool_input.clone(),
+        });
+
+        if let Err(error) =
+            tool_call_repo::update_status(&self.pool, &tool_call_storage_id, "running").await
+        {
+            let message = format!("failed to mark task tool call as running: {error}");
+            let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
+                run_id: self.spec.run_id.clone(),
+                tool_call_id: tool_call_id.to_string(),
+                error: message.clone(),
+            });
+            return agent_error_result(message);
         }
 
         let _ = self.event_tx.send(ThreadStreamEvent::ToolRunning {

--- a/src/services/thread-stream/thread-stream.test.ts
+++ b/src/services/thread-stream/thread-stream.test.ts
@@ -168,6 +168,57 @@ describe("ThreadStream event routing", () => {
     expect(onError).toHaveBeenCalledWith("too many turns", "run-1");
   });
 
+  it("preserves task tool name and input from requested events during live routing", async () => {
+    const stream = new ThreadStream();
+    const onToolEvent = vi.fn();
+    stream.onToolEvent = onToolEvent;
+
+    const taskInput = {
+      title: "Implementation",
+      steps: [{ description: "Patch task tool event flow" }],
+    };
+
+    threadStartRunMock.mockImplementationOnce(emit([
+      {
+        type: "tool_requested",
+        runId: "run-1",
+        toolCallId: "task-tool-1",
+        toolName: "create_task",
+        toolInput: taskInput,
+      },
+      { type: "tool_running", runId: "run-1", toolCallId: "task-tool-1" },
+      {
+        type: "tool_completed",
+        runId: "run-1",
+        toolCallId: "task-tool-1",
+        result: { id: "board-1", title: "Implementation" },
+      },
+    ]));
+
+    await stream.startRun("thread-1", { prompt: "plan" });
+
+    expect(onToolEvent).toHaveBeenNthCalledWith(1, {
+      kind: "requested",
+      runId: "run-1",
+      toolCallId: "task-tool-1",
+      toolName: "create_task",
+      toolInput: taskInput,
+    });
+    expect(onToolEvent).toHaveBeenNthCalledWith(2, {
+      kind: "running",
+      runId: "run-1",
+      toolCallId: "task-tool-1",
+      toolName: "create_task",
+    });
+    expect(onToolEvent).toHaveBeenNthCalledWith(3, {
+      kind: "completed",
+      runId: "run-1",
+      toolCallId: "task-tool-1",
+      toolName: "create_task",
+      result: { id: "board-1", title: "Implementation" },
+    });
+  });
+
   it("hides runtime orchestration tool events", async () => {
     const stream = new ThreadStream();
     const onToolEvent = vi.fn();


### PR DESCRIPTION
## Summary
- Emit `tool_requested` events for task tools before they enter the running state.
- Align task tool persistence with the requested → running lifecycle.
- Add a ThreadStream regression test to preserve task tool names and inputs in live routing.

## Test Plan
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- [x] `npm run test:unit -- src/services/thread-stream/thread-stream.test.ts`
- [x] `npm run typecheck`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --test task_tracking`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
