### PR TITLE
feat(worktree): ✨ Fix branch tracking and support remote branch checkout

### DIFF
--- a/src-tauri/src/core/worktree_manager.rs
+++ b/src-tauri/src/core/worktree_manager.rs
@@ -163,6 +163,7 @@ impl WorktreeManager {
             .filter(|s| !s.is_empty())
             .map(str::to_string);
         let create_branch = input.create_branch;
+        let track_upstream = input.track_upstream;
 
         task::spawn_blocking(move || {
             run_git_worktree_add(
@@ -172,6 +173,7 @@ impl WorktreeManager {
                 &branch_name,
                 create_branch,
                 base_ref.as_deref(),
+                track_upstream,
             )
         })
         .await
@@ -548,6 +550,7 @@ fn run_git_worktree_add(
     branch: &str,
     create_branch: bool,
     base_ref: Option<&str>,
+    track_upstream: bool,
 ) -> Result<(), AppError> {
     // `git worktree add` uses the final path component as the worktree
     // registration name. We don't force it explicitly; the caller is expected
@@ -560,6 +563,13 @@ fn run_git_worktree_add(
     if create_branch {
         args.push("-b".to_string());
         args.push(branch.to_string());
+        // When track_upstream is false, prevent the new branch from tracking
+        // the base ref so that `git push` won't accidentally target the base
+        // branch's upstream. When track_upstream is true (e.g. checking out a
+        // remote branch locally), we let Git set up tracking normally.
+        if base_ref.is_some() && !track_upstream {
+            args.push("--no-track".to_string());
+        }
         args.push(target_path.to_string());
         if let Some(base) = base_ref {
             args.push(base.to_string());

--- a/src-tauri/src/model/workspace.rs
+++ b/src-tauri/src/model/workspace.rs
@@ -160,6 +160,12 @@ pub struct WorktreeCreateInput {
     /// When true, a new local branch is created and checked out in the worktree.
     #[serde(default)]
     pub create_branch: bool,
+    /// When true AND `create_branch` is true with a `base_ref`, the new branch
+    /// will track the base ref as its upstream (useful when checking out an
+    /// existing remote branch locally). Defaults to false so that brand-new
+    /// feature branches do not accidentally track the base.
+    #[serde(default)]
+    pub track_upstream: bool,
     /// Optional custom path for the new worktree directory. When None the
     /// manager derives `<repo parent>/<repo name>-<branch-slug>`.
     #[serde(default)]

--- a/src-tauri/tests/worktree.rs
+++ b/src-tauri/tests/worktree.rs
@@ -103,6 +103,7 @@ async fn worktree_create_registers_workspace_and_updates_parent_kind() {
                 branch: "feature/worktree-alpha".to_string(),
                 base_ref: None,
                 create_branch: true,
+                track_upstream: false,
                 path: None,
             },
         )
@@ -163,6 +164,7 @@ async fn worktree_create_rejects_non_repo_parent() {
                 branch: "feature/foo".to_string(),
                 base_ref: None,
                 create_branch: true,
+                track_upstream: false,
                 path: None,
             },
         )
@@ -203,6 +205,7 @@ async fn worktree_remove_cleans_up_admin_dir_and_db_row() {
                 branch: "feature/remove-me".to_string(),
                 base_ref: None,
                 create_branch: true,
+                track_upstream: false,
                 path: None,
             },
         )
@@ -268,6 +271,7 @@ async fn worktree_parent_remove_cascades_children() {
                 branch: "feature/child".to_string(),
                 base_ref: None,
                 create_branch: true,
+                track_upstream: false,
                 path: None,
             },
         )
@@ -337,6 +341,7 @@ async fn set_default_rejects_worktree_row() {
                 branch: "feature/no-default".to_string(),
                 base_ref: None,
                 create_branch: true,
+                track_upstream: false,
                 path: None,
             },
         )

--- a/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
+++ b/src/modules/workbench-shell/ui/new-worktree-dialog.tsx
@@ -111,6 +111,18 @@ export function NewWorktreeDialog({
     [branches],
   );
 
+  // Remote branches that don't already have a local counterpart.
+  const remoteBranchesWithoutLocal = useMemo(() => {
+    const localNames = new Set(localBranches.map((b) => b.name));
+    return branches.filter((b) => {
+      if (!b.isRemote) return false;
+      // Strip the remote prefix (e.g. "origin/feature-x" → "feature-x")
+      const slashIdx = b.name.indexOf("/");
+      const localName = slashIdx >= 0 ? b.name.slice(slashIdx + 1) : b.name;
+      return !localNames.has(localName);
+    });
+  }, [branches, localBranches]);
+
   const canSubmit =
     mode === "newBranch"
       ? Boolean(context && branch.trim() && !submitting)
@@ -150,11 +162,34 @@ export function NewWorktreeDialog({
       setError(null);
       setSubmitting(true);
       try {
-        const input: WorktreeCreateInput = {
-          branch: selectedExistingBranch,
-          createBranch: false,
-          path: path.trim() || undefined,
-        };
+        // Check if the selected branch is a remote ref.
+        const isRemote = remoteBranchesWithoutLocal.some(
+          (b) => b.name === selectedExistingBranch,
+        );
+
+        let input: WorktreeCreateInput;
+        if (isRemote) {
+          // For remote branches, create a local tracking branch from the remote ref.
+          const slashIdx = selectedExistingBranch.indexOf("/");
+          const localName =
+            slashIdx >= 0
+              ? selectedExistingBranch.slice(slashIdx + 1)
+              : selectedExistingBranch;
+          input = {
+            branch: localName,
+            createBranch: true,
+            baseRef: selectedExistingBranch,
+            trackUpstream: true,
+            path: path.trim() || undefined,
+          };
+        } else {
+          input = {
+            branch: selectedExistingBranch,
+            createBranch: false,
+            path: path.trim() || undefined,
+          };
+        }
+
         const created = await workspaceCreateWorktree(context.repo.id, input);
         onCreated?.(created);
         onClose();
@@ -170,6 +205,7 @@ export function NewWorktreeDialog({
     branch,
     baseBranch,
     selectedExistingBranch,
+    remoteBranchesWithoutLocal,
     path,
     t,
     onCreated,
@@ -291,7 +327,7 @@ export function NewWorktreeDialog({
             </>
           ) : (
             <>
-              {/* Existing branch selector (local only) */}
+              {/* Existing branch selector (local + unchecked-out remote) */}
               <div className="flex flex-col gap-1.5">
                 <label className="text-sm font-medium">{t("worktree.field.selectBranch")}</label>
                 <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border bg-muted/20 p-1">
@@ -300,32 +336,59 @@ export function NewWorktreeDialog({
                       <LoaderCircle className="h-3.5 w-3.5 animate-spin" />
                       {t("worktree.loading.branches")}
                     </div>
-                  ) : localBranches.length === 0 ? (
+                  ) : localBranches.length === 0 &&
+                    remoteBranchesWithoutLocal.length === 0 ? (
                     <div className="px-2 py-4 text-sm text-muted-foreground">
                       {t("worktree.empty.branches")}
                     </div>
                   ) : (
-                    localBranches.map((b) => {
-                      const isActive = selectedExistingBranch === b.name;
-                      return (
-                        <button
-                          key={b.name}
-                          type="button"
-                          onClick={() => setSelectedExistingBranch(b.name)}
-                          className={cn(
-                            "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
-                            isActive && "bg-background font-medium",
-                          )}
-                        >
-                          <span className="truncate">{b.name}</span>
-                          {b.isHead && (
-                            <span className="ml-2 rounded bg-muted px-1 text-[10px] font-medium text-muted-foreground">
-                              HEAD
+                    <>
+                      {localBranches.map((b) => {
+                        const isActive = selectedExistingBranch === b.name;
+                        return (
+                          <button
+                            key={b.name}
+                            type="button"
+                            onClick={() => setSelectedExistingBranch(b.name)}
+                            className={cn(
+                              "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                              isActive && "bg-background font-medium",
+                            )}
+                          >
+                            <span className="truncate">{b.name}</span>
+                            <span className="ml-2 flex items-center gap-1">
+                              {b.isHead && (
+                                <span className="rounded bg-muted px-1 text-[10px] font-medium text-muted-foreground">
+                                  HEAD
+                                </span>
+                              )}
+                              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                                local
+                              </span>
                             </span>
-                          )}
-                        </button>
-                      );
-                    })
+                          </button>
+                        );
+                      })}
+                      {remoteBranchesWithoutLocal.map((b) => {
+                        const isActive = selectedExistingBranch === b.name;
+                        return (
+                          <button
+                            key={`remote:${b.name}`}
+                            type="button"
+                            onClick={() => setSelectedExistingBranch(b.name)}
+                            className={cn(
+                              "flex items-center justify-between rounded px-2 py-1 text-left text-sm hover:bg-background",
+                              isActive && "bg-background font-medium",
+                            )}
+                          >
+                            <span className="truncate">{b.name}</span>
+                            <span className="ml-2 text-[10px] uppercase tracking-wider text-muted-foreground">
+                              remote
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </>
                   )}
                 </div>
                 {selectedExistingBranch && (

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -47,6 +47,7 @@ export interface WorktreeCreateInput {
   branch: string;
   baseRef?: string | null;
   createBranch?: boolean;
+  trackUpstream?: boolean;
   path?: string | null;
 }
 


### PR DESCRIPTION
## Summary
- Fix new branch worktree accidentally tracking the base branch (causing push to wrong upstream)
- Add `--no-track` when creating a new branch from a base ref, unless `trackUpstream` is explicitly true
- Support checking out remote branches (without local counterpart) in the "existing branch" worktree mode, creating a local tracking branch automatically

## Test Plan
- [ ] Create worktree with new branch from base → verify no upstream tracking set
- [ ] Create worktree selecting a remote-only branch → verify local branch tracks remote correctly
- [ ] Push from new-branch worktree → verify it does NOT push to base branch
- [ ] Push from remote-checkout worktree → verify it pushes to correct remote branch

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)