### PR TITLE
fix(logging): 🐛 improve RUST_LOG env var parsing to fix default log level

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod persistence;
 
 use std::fs;
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
@@ -105,8 +106,12 @@ fn init_logging() {
         .build(&log_path)
         .expect("failed to create log appender");
 
-    let env_filter =
-        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,sqlx=warn"));
+    let env_filter = match std::env::var("RUST_LOG") {
+        Ok(val) if !val.is_empty() => {
+            EnvFilter::from_str(&val).unwrap_or_else(|_| EnvFilter::new("info,sqlx=warn"))
+        }
+        _ => EnvFilter::new("info,sqlx=warn"),
+    };
 
     tracing_subscriber::registry()
         .with(env_filter)


### PR DESCRIPTION
## Summary
- Replace `EnvFilter::try_from_default_env()` with explicit `std::env::var("RUST_LOG")` check in `init_logging()`
- Fix an issue where tiycore warn logs were not captured to log files unless `RUST_LOG` was explicitly set
- The previous `try_from_default_env()` API in tracing-subscriber 0.3.23 did not reliably error when `RUST_LOG` was unset, causing the default `info` level fallback to never trigger

## Changes
- `src-tauri/src/lib.rs`: Replace `EnvFilter::try_from_default_env()` fallback pattern with explicit `match std::env::var("RUST_LOG")` guard, ensuring the default `info,sqlx=warn` filter is correctly applied when `RUST_LOG` is not set

## Test Plan
- [ ] Verify tiycore warn logs appear in log files without setting `RUST_LOG`
- [ ] Verify `RUST_LOG=tiycore=debug` still works to override default level
- [ ] Verify invalid `RUST_LOG` values fall back to default gracefully

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)