### PR TITLE
feat(open-in): ✨ add Ghostty terminal detection on macOS

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -175,7 +175,7 @@ struct WorkspaceOpenAppSpec {
 }
 
 #[cfg(target_os = "macos")]
-const WORKSPACE_OPEN_APP_SPECS: [WorkspaceOpenAppSpec; 12] = [
+const WORKSPACE_OPEN_APP_SPECS: [WorkspaceOpenAppSpec; 13] = [
     WorkspaceOpenAppSpec {
         id: "finder",
         name: "Finder",
@@ -250,6 +250,12 @@ const WORKSPACE_OPEN_APP_SPECS: [WorkspaceOpenAppSpec; 12] = [
         name: "Android Studio",
         bundle_names: &["Android Studio.app", "Android Studio Preview.app"],
         preferred_paths: &[],
+    },
+    WorkspaceOpenAppSpec {
+        id: "ghostty",
+        name: "Ghostty",
+        bundle_names: &["Ghostty.app"],
+        preferred_paths: &["/Applications/Ghostty.app"],
     },
 ];
 
@@ -346,7 +352,7 @@ fn tree_path_open_behavior_macos(app_id: &str, is_directory: bool) -> TreePathOp
 
     match app_id {
         "finder" => TreePathOpenBehavior::RevealTarget,
-        "terminal" | "iterm2" | "warp" => TreePathOpenBehavior::OpenContainingFolder,
+        "terminal" | "iterm2" | "warp" | "ghostty" => TreePathOpenBehavior::OpenContainingFolder,
         _ => TreePathOpenBehavior::OpenTarget,
     }
 }

--- a/src/modules/workbench-shell/ui/project-panel.tsx
+++ b/src/modules/workbench-shell/ui/project-panel.tsx
@@ -58,6 +58,7 @@ const APP_ICON_FALLBACKS: Record<
   terminal: { label: "T", className: "bg-linear-to-br from-slate-700 to-slate-950 text-white" },
   iterm2: { label: "IT", className: "bg-linear-to-br from-slate-600 to-slate-900 text-white" },
   warp: { label: "WP", className: "bg-linear-to-br from-lime-300 to-emerald-500 text-slate-950" },
+  ghostty: { label: "G", className: "bg-linear-to-br from-blue-400 to-indigo-600 text-white" },
   powershell: { label: "PS", className: "bg-linear-to-br from-sky-500 to-indigo-700 text-white" },
   "git-bash": { label: "GB", className: "bg-linear-to-br from-emerald-400 to-teal-600 text-white" },
   vscode: { label: "VS", className: "bg-linear-to-br from-sky-500 to-blue-700 text-white" },


### PR DESCRIPTION
## Summary
为 macOS 平台的「在外部应用中打开」列表增加 Ghostty 终端检测与支持。

## Changes
### 后端 (Rust)
- `src-tauri/src/commands/system.rs`: 在 `WORKSPACE_OPEN_APP_SPECS` 中新增 Ghostty 条目（`Ghostty.app`），优先查找 `/Applications/Ghostty.app`
- 将 Ghostty 加入树形路径打开行为匹配，打开文件时启动到所在文件夹

### 前端 (TypeScript)
- `src/modules/workbench-shell/ui/project-panel.tsx`: 新增 Ghostty 图标回退（蓝色渐变，标签 G）

## Test Plan
- [ ] macOS 上安装 Ghostty 后，project panel 的 open in 列表中出现 Ghostty
- [ ] 点击 Ghostty 后在该终端中打开当前目录/文件所在目录
- [ ] 未安装 Ghostty 时不显示

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)