### PR TITLE
fix(composer): 🐛 preserve slash command arguments when template lacks {{arguments}}

### DIFF
--- a/src/modules/workbench-shell/model/composer-commands.test.ts
+++ b/src/modules/workbench-shell/model/composer-commands.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { RunMode } from "@/shared/types/api";
 import {
+  buildCommandEffectivePrompt,
   buildComposerCommandRegistry,
   buildComposerSubmission,
   parseSlashCommandInput,
@@ -142,5 +143,51 @@ describe("parseSlashCommandInput", () => {
     const result = parseSlashCommandInput("/", registry);
     expect(result).not.toBeNull();
     expect(result?.query).toBe("");
+  });
+});
+
+describe("buildCommandEffectivePrompt", () => {
+  const makeCommand = (prompt: string, name = "test-cmd") => ({
+    name,
+    prompt,
+    source: "settings" as const,
+    path: `/prompts:${name}`,
+    description: "Test command",
+    argumentHint: "",
+    behavior: "prompt" as const,
+    smartSend: "always" as const,
+  });
+
+  it("appends arguments when template has no {{arguments}} placeholder", () => {
+    const cmd = makeCommand("Do something useful for the user.");
+    const result = buildCommandEffectivePrompt(cmd, "--style=full");
+    expect(result).toBe("Do something useful for the user.\n\nCommand arguments: --style=full");
+  });
+
+  it("uses placeholder substitution when {{arguments}} exists", () => {
+    const cmd = makeCommand("Run with args: {{arguments}} now.");
+    const result = buildCommandEffectivePrompt(cmd, "--draft");
+    expect(result).toBe("Run with args: --draft now.");
+    expect(result).not.toContain("Command arguments:");
+  });
+
+  it("does not append when argumentsText is empty", () => {
+    const cmd = makeCommand("Do something.");
+    const result = buildCommandEffectivePrompt(cmd, "");
+    expect(result).toBe("Do something.");
+    expect(result).not.toContain("Command arguments:");
+  });
+
+  it("does not append when argumentsText is whitespace only", () => {
+    const cmd = makeCommand("Do something.");
+    const result = buildCommandEffectivePrompt(cmd, "   \t  ");
+    expect(result).toBe("Do something.");
+    expect(result).not.toContain("Command arguments:");
+  });
+
+  it("replaces {{command}} placeholder with command name", () => {
+    const cmd = makeCommand("Running {{command}} command.", "my-cmd");
+    const result = buildCommandEffectivePrompt(cmd, "");
+    expect(result).toBe("Running my-cmd command.");
   });
 });

--- a/src/modules/workbench-shell/model/composer-commands.ts
+++ b/src/modules/workbench-shell/model/composer-commands.ts
@@ -345,10 +345,16 @@ export function buildCommandEffectivePrompt(
   command: ComposerCommandDescriptor,
   argumentsText: string,
 ) {
-  return replaceTemplateVariables(command.prompt, {
-    arguments: argumentsText.trim(),
+  const trimmedArgs = argumentsText.trim();
+  const hasPlaceholder = /\{\{\s*arguments\s*\}\}/.test(command.prompt);
+  let result = replaceTemplateVariables(command.prompt, {
+    arguments: trimmedArgs,
     command: command.name,
   }).trim();
+  if (trimmedArgs && !hasPlaceholder) {
+    result += `\n\nCommand arguments: ${trimmedArgs}`;
+  }
+  return result;
 }
 
 export function buildComposerSubmission(

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -42,6 +42,7 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import { Suggestion, Suggestions } from "@/components/ai-elements/suggestion";
 import {
+  buildCommandEffectivePrompt,
   buildComposerCommandRegistry,
   filterComposerCommands,
   parseSlashCommandInput,
@@ -193,10 +194,7 @@ function buildSubmissionFromPromptInput(
     };
   }
 
-  const effectivePrompt = parsedCommand.command.prompt
-    .replace(/{{\s*arguments\s*}}/g, parsedCommand.argumentsText)
-    .replace(/{{\s*command\s*}}/g, parsedCommand.command.name)
-    .trim();
+  const effectivePrompt = buildCommandEffectivePrompt(parsedCommand.command, parsedCommand.argumentsText);
 
   return {
     kind: "command",


### PR DESCRIPTION
## Summary
- Fix slash command arguments being silently dropped when the prompt template does not contain `{{arguments}}`
- Automatically append arguments to the end of the effective prompt when no placeholder is present
- Unify prompt construction by reusing `buildCommandEffectivePrompt` in both UI and model layers
- Add unit tests covering placeholder substitution, automatic appending, and edge cases

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` passes (22 tests, including 5 new ones)

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)