### PR TITLE
fix(workbench-shell): 🐛 Sync activeThreadId across thread lifecycle actions

### DIFF
--- a/src/modules/workbench-shell/model/workbench-actions.ts
+++ b/src/modules/workbench-shell/model/workbench-actions.ts
@@ -182,6 +182,7 @@ export function selectThread(threadId: string): void {
 
   threadStore.setState({
     isNewThreadMode: false,
+    activeThreadId: threadId,
     activeThreadProfileIdOverride: resolvedProfileId,
     editingThreadId: null,
   });
@@ -344,6 +345,7 @@ export async function deleteThread(threadId: string, options?: ThreadDeleteOptio
     });
     threadStore.setState({
       isNewThreadMode: true,
+      activeThreadId: null,
       activeThreadProfileIdOverride: null,
     });
     composerStore.setState({ error: null });
@@ -668,7 +670,7 @@ export async function submitNewThread(submission: NewThreadSubmission): Promise<
   threadStore.setState({ activeThreadProfileIdOverride: activeAgentProfileId });
 
   // Transition to thread mode
-  threadStore.setState({ isNewThreadMode: false });
+  threadStore.setState({ isNewThreadMode: false, activeThreadId: threadId });
 
   // Clear new-thread terminal binding
   const bindingKey = getNewThreadTerminalBindingKey(workspaceId);
@@ -707,6 +709,7 @@ export function enterNewThreadMode(): void {
 
   threadStore.setState({
     isNewThreadMode: true,
+    activeThreadId: null,
     activeThreadProfileIdOverride: null,
   });
   threadStore.setState((prev) => ({


### PR DESCRIPTION
## Summary
- Fix thread deletion entering an ownerless state instead of new-thread mode
- Root cause: `selectThread()` never set `activeThreadId`, so `deleteThread()` could never detect it was deleting the active thread
- Add `activeThreadId` synchronization to `selectThread`, `submitNewThread`, `deleteThread`, and `enterNewThreadMode`

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` — 540 tests pass
- [ ] Manual: select a thread → delete it → verify app enters new-thread mode (not empty state)
- [ ] Manual: create new thread → verify sidebar highlights correctly

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)