### PR TITLE
feat(providers): ✨ Add Xiaomi MIMO provider support

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6179,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.4-rc.2"
+version = "0.2.5-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be6391df2477899ced3abf3e782e89662c19edc54faa05f7c72514a757d433c4"
+checksum = "2acd82695c5c4e264f82645b7440dd71b3e62847e8564031fff66e8a3266de31"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.4-rc.2"
+tiycore = "0.2.5-rc.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/core/agent_session_tools.rs
+++ b/src-tauri/src/core/agent_session_tools.rs
@@ -637,8 +637,8 @@ pub(crate) fn effective_api_for_model(model: &Model) -> tiycore::types::Api {
         | Provider::OpenCode
         | Provider::OpenCodeGo
         | Provider::DeepSeek
-        | Provider::Zenmux
-        | Provider::Bai => tiycore::types::Api::OpenAICompletions,
+        | Provider::XiaomiMIMO
+        | Provider::Zenmux => tiycore::types::Api::OpenAICompletions,
         Provider::AmazonBedrock => tiycore::types::Api::BedrockConverseStream,
         Provider::Custom(name) => tiycore::types::Api::Custom(name.clone()),
     }

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -123,6 +123,12 @@ const BUILTIN_PROVIDER_CATALOG: &[ProviderCatalogEntry] = &[
         display_name: "OpenCode Go",
         default_base_url: "https://opencode.ai/zen/go/v1",
     },
+    ProviderCatalogEntry {
+        provider_key: "xiaomi-mimo",
+        provider_type: "xiaomi-mimo",
+        display_name: "Xiaomi MIMO",
+        default_base_url: "https://api.xiaomimimo.com/v1",
+    },
 ];
 
 const CUSTOM_PROVIDER_TYPE_CATALOG: &[ProviderCatalogEntry] = &[

--- a/src/modules/settings-center/model/types.ts
+++ b/src/modules/settings-center/model/types.ts
@@ -32,7 +32,8 @@ export type ProviderType =
   | "kimi-coding"
   | "zai"
   | "deepseek"
-  | "zenmux";
+  | "zenmux"
+  | "xiaomi-mimo";
 
 export type CustomProviderType =
   | "openai-compatible"


### PR DESCRIPTION
## Summary
- Upgrade `tiycore` to `0.2.5-rc.0` and sync `Cargo.lock`
- Add Xiaomi MIMO as a built-in provider (key: `xiaomi-mimo`, base URL: `https://api.xiaomimimo.com/v1`)
- Add `Provider::XiaomiMIMO` to the API protocol match arm
- Remove obsolete `Provider::Bai` variant (dropped in tiycore 0.2.5)
- Add `"xiaomi-mimo"` to frontend `ProviderType` union type

## Test Plan
- [x] `cargo check` passes
- [x] `npm run typecheck` passes
- [ ] `cargo test --locked` in CI
- [ ] Manual verification: provider appears in settings catalog after app restart

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
