### PR TITLE
fix(workbench-shell): 🐛 Prevent stale snapshot from regressing waiting_approval state

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -603,8 +603,30 @@ export function RuntimeThreadSurface({
       setHelpers((snapshot.helpers ?? []).map((helper) => mapSnapshotHelper(helper, snapshot.toolCalls ?? [])));
       setTaskBoards(taskBoardsFromSnapshot(snapshot.taskBoards ?? [], snapshot.activeTaskBoardId ?? null));
       setRuntimeError(getSnapshotRuntimeError(snapshot));
-      if (threadId) runMachine.reset(nextState as RunMachineState, {
-        runId: snapshot.activeRun?.id ?? null, errorMessage: null, retryCount: 0 });
+      // Prevent stale snapshots from regressing an active approval/reply state.
+      // When the stream has already transitioned the machine to waiting_approval
+      // or needs_reply, a snapshot still reporting "running" is stale — the DB
+      // write hasn't landed yet. Keep the current state and schedule a retry.
+      const currentMachineState = runMachine.getState();
+      const isStaleRegression =
+        (currentMachineState === "waiting_approval" || currentMachineState === "needs_reply")
+        && nextState === "running";
+
+      if (threadId && !isStaleRegression) {
+        runMachine.reset(nextState as RunMachineState, {
+          runId: snapshot.activeRun?.id ?? null, errorMessage: null, retryCount: 0,
+        });
+      }
+
+      // If the snapshot was stale, retry after a short delay to pick up the
+      // approval_prompt message once the backend commit completes.
+      if (isStaleRegression) {
+        setTimeout(() => {
+          if (snapshotLoadRequestRef.current === requestId) {
+            void loadSnapshot();
+          }
+        }, 800);
+      }
       setSelectedRunMode((current) => deriveSelectedRunMode(snapshot, current));
       if (!shouldPreserveContextUsage) {
         threadStore.setState({ runtimeContextUsage: nextContextUsage });


### PR DESCRIPTION
## Summary
- Fix race condition where `loadSnapshot()` triggered by `run_checkpointed` event returns stale backend data (`running` status) that overwrites the correct `waiting_approval` state
- Add state regression guard in `loadSnapshot()` to prevent downgrading active approval/reply states
- Schedule 800ms retry when stale snapshot detected, allowing backend DB write to complete

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` — 592 tests passed
- [ ] Manual: run agent in plan mode, verify Composer/title icon/sidebar icon all show approval state immediately on `run_checkpointed` without requiring thread switch

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)