### PR TITLE
fix(runtime): 🐛 Harden agent run lifecycle

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -24,7 +24,7 @@ pub(crate) const DEFAULT_CONTEXT_WINDOW: u32 = 128_000;
 const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 32_000;
 pub(crate) const DEFAULT_FULL_TOOL_PROFILE: &str = "default_full";
 pub(crate) const PLAN_READ_ONLY_TOOL_PROFILE: &str = "plan_read_only";
-const STANDARD_TOOL_TIMEOUT_SECS: u64 = 120;
+pub(crate) const STANDARD_TOOL_TIMEOUT_SECS: u64 = 120;
 const SUBAGENT_TOOL_TIMEOUT_SECS: u64 = 600;
 /// Main agent timeout is effectively unlimited (24 h) because user-interactive
 /// tools like `clarify` and approval prompts must wait for human input without
@@ -33,6 +33,9 @@ const SUBAGENT_TOOL_TIMEOUT_SECS: u64 = 600;
 /// tool calls.
 const MAIN_AGENT_TOOL_TIMEOUT_SECS: u64 = 86_400;
 pub(crate) const CLARIFY_TOOL_NAME: &str = "clarify";
+pub(crate) const PLAN_TOOL_NAME: &str = "update_plan";
+pub(crate) const RENDER_TOOL_NAME: &str = "render";
+pub(crate) const TASK_TOOL_NAMES: &[&str] = &["create_task", "update_task", "query_task"];
 pub(crate) const PLAN_MODE_MISSING_CHECKPOINT_ERROR: &str =
     "Plan mode requires publishing a plan with update_plan before the run can finish.";
 pub(crate) const TEXT_ATTACHMENT_MAX_CHARS: usize = 12_000;

--- a/src-tauri/src/core/agent_session_compression.rs
+++ b/src-tauri/src/core/agent_session_compression.rs
@@ -281,7 +281,8 @@ pub(crate) async fn run_auto_compression(
     // id slightly overshoot (include a few more old DB rows in the next reload
     // than strictly necessary) but NEVER undershoot — so no in-memory recent
     // message can get dropped by the next load.
-    // **重要**: 该缓冲区解决了 DB 层 ID 与内存层 Message 数量不一致的问题，保证边界标记的稳健性。
+    // The buffer accounts for DB rows that expand into multiple in-memory
+    // messages, keeping boundary marker resolution conservative and robust.
     const BOUNDARY_BUFFER: usize = 16;
 
     match summary_result {

--- a/src-tauri/src/core/agent_session_compression.rs
+++ b/src-tauri/src/core/agent_session_compression.rs
@@ -281,6 +281,7 @@ pub(crate) async fn run_auto_compression(
     // id slightly overshoot (include a few more old DB rows in the next reload
     // than strictly necessary) but NEVER undershoot — so no in-memory recent
     // message can get dropped by the next load.
+    // **重要**: 该缓冲区解决了 DB 层 ID 与内存层 Message 数量不一致的问题，保证边界标记的稳健性。
     const BOUNDARY_BUFFER: usize = 16;
 
     match summary_result {

--- a/src-tauri/src/core/agent_session_events.rs
+++ b/src-tauri/src/core/agent_session_events.rs
@@ -45,7 +45,8 @@ pub(crate) fn handle_agent_event(
             ..
         } => {
             // Track the current turn_index for response boundary grouping
-            if let Ok(mut guard) = current_turn_index.lock() {
+            {
+                let mut guard = lock_or_recover(current_turn_index, "current_turn_index");
                 *guard = Some(*turn_index);
             }
             match assistant_event.as_ref() {
@@ -61,28 +62,29 @@ pub(crate) fn handle_agent_event(
                     reset_reasoning_state(current_reasoning_message_id, reasoning_buffer);
                 }
                 AssistantMessageEvent::ThinkingDelta { delta, .. } => {
-                    if let Ok(mut buffer) = reasoning_buffer.lock() {
-                        buffer.push_str(delta);
-                        let message_id = ensure_message_id(current_reasoning_message_id);
-                        let ti = current_turn_index.lock().ok().and_then(|g| *g);
-                        let _ = event_tx.send(ThreadStreamEvent::ReasoningUpdated {
-                            run_id: run_id.to_string(),
-                            message_id,
-                            reasoning: buffer.clone(),
-                            thinking_signature: None,
-                            turn_index: ti,
-                        });
-                    }
+                    let mut buffer =
+                        lock_or_recover(reasoning_buffer, "ThinkingDelta:reasoning_buffer");
+                    buffer.push_str(delta);
+                    let message_id = ensure_message_id(current_reasoning_message_id);
+                    let ti =
+                        lock_or_recover(current_turn_index, "ThinkingDelta:turn_index").clone();
+                    let _ = event_tx.send(ThreadStreamEvent::ReasoningUpdated {
+                        run_id: run_id.to_string(),
+                        message_id,
+                        reasoning: buffer.clone(),
+                        thinking_signature: None,
+                        turn_index: ti,
+                    });
                 }
                 AssistantMessageEvent::ThinkingEnd {
                     content, partial, ..
                 } => {
-                    let reasoning = if let Ok(mut buffer) = reasoning_buffer.lock() {
+                    let reasoning = {
+                        let mut buffer =
+                            lock_or_recover(reasoning_buffer, "ThinkingEnd:reasoning_buffer");
                         buffer.clear();
                         buffer.push_str(content);
                         buffer.clone()
-                    } else {
-                        content.clone()
                     };
 
                     if reasoning.trim().is_empty() {
@@ -94,6 +96,7 @@ pub(crate) fn handle_agent_event(
                     // Thinking content block.  The signature is populated by the
                     // protocol layer during streaming and is complete by the time
                     // ThinkingEnd fires.
+                    // 从 partial.content 的最后一个 ThinkingContent 块中提取（反向查找）。
                     let thinking_signature = partial
                         .content
                         .iter()
@@ -102,7 +105,7 @@ pub(crate) fn handle_agent_event(
                         .and_then(|t| t.thinking_signature.clone());
 
                     let message_id = ensure_message_id(current_reasoning_message_id);
-                    let ti = current_turn_index.lock().ok().and_then(|g| *g);
+                    let ti = lock_or_recover(current_turn_index, "ThinkingEnd:turn_index").clone();
                     let _ = event_tx.send(ThreadStreamEvent::ReasoningUpdated {
                         run_id: run_id.to_string(),
                         message_id,
@@ -172,7 +175,7 @@ pub(crate) fn handle_agent_event(
                 );
                 let message_id = take_or_create_message_id(current_message_id);
                 set_last_completed_message_id(last_completed_message_id, Some(message_id.clone()));
-                let ti = current_turn_index.lock().ok().and_then(|g| *g);
+                let ti = lock_or_recover(current_turn_index, "MessageEnd:turn_index").clone();
                 let _ = event_tx.send(ThreadStreamEvent::MessageCompleted {
                     run_id: run_id.to_string(),
                     message_id,
@@ -205,7 +208,8 @@ fn emit_usage_update_if_changed(
     context_window: &str,
     model_display_name: &str,
 ) {
-    let should_emit = if let Ok(mut previous_usage) = last_usage.lock() {
+    let should_emit = {
+        let mut previous_usage = lock_or_recover(last_usage, "emit_usage:last_usage");
         if previous_usage.as_ref() == Some(usage) {
             return;
         }
@@ -221,12 +225,6 @@ fn emit_usage_update_if_changed(
 
         *previous_usage = Some(*usage);
         true
-    } else {
-        usage.total_tokens > 0
-            || usage.input > 0
-            || usage.output > 0
-            || usage.cache_read > 0
-            || usage.cache_write > 0
     };
 
     if !should_emit {
@@ -243,52 +241,52 @@ fn emit_usage_update_if_changed(
     });
 }
 
+/// Helper to recover a poisoned `StdMutex`. All mutex helpers below use this
+/// pattern so that a panic in an unrelated thread never silently corrupts
+/// message-tracking state.
+fn lock_or_recover<'a, T>(mutex: &'a StdMutex<T>, context: &str) -> std::sync::MutexGuard<'a, T> {
+    mutex.lock().unwrap_or_else(|poisoned| {
+        tracing::warn!("{context}: mutex poisoned, recovering");
+        poisoned.into_inner()
+    })
+}
+
 fn ensure_message_id(current_message_id: &StdMutex<Option<String>>) -> String {
-    if let Ok(mut guard) = current_message_id.lock() {
-        if let Some(existing) = guard.clone() {
-            return existing;
-        }
-
-        let message_id = uuid::Uuid::now_v7().to_string();
-        *guard = Some(message_id.clone());
-        return message_id;
+    let mut guard = lock_or_recover(current_message_id, "ensure_message_id");
+    if let Some(existing) = guard.clone() {
+        return existing;
     }
-
-    uuid::Uuid::now_v7().to_string()
+    let message_id = uuid::Uuid::now_v7().to_string();
+    *guard = Some(message_id.clone());
+    message_id
 }
 
 fn take_or_create_message_id(current_message_id: &StdMutex<Option<String>>) -> String {
-    if let Ok(mut guard) = current_message_id.lock() {
-        if let Some(existing) = guard.take() {
-            return existing;
-        }
+    let mut guard = lock_or_recover(current_message_id, "take_or_create_message_id");
+    if let Some(existing) = guard.take() {
+        return existing;
     }
-
     uuid::Uuid::now_v7().to_string()
 }
 
 fn reset_message_id(current_message_id: &StdMutex<Option<String>>) {
-    if let Ok(mut guard) = current_message_id.lock() {
-        *guard = None;
-    }
+    let mut guard = lock_or_recover(current_message_id, "reset_message_id");
+    *guard = None;
 }
 
 fn set_last_completed_message_id(
     last_completed_message_id: &StdMutex<Option<String>>,
     value: Option<String>,
 ) {
-    if let Ok(mut guard) = last_completed_message_id.lock() {
-        *guard = value;
-    }
+    let mut guard = lock_or_recover(last_completed_message_id, "set_last_completed_message_id");
+    *guard = value;
 }
 
 fn read_last_completed_message_id(
     last_completed_message_id: &StdMutex<Option<String>>,
 ) -> Option<String> {
-    last_completed_message_id
-        .lock()
-        .ok()
-        .and_then(|guard| guard.clone())
+    let guard = lock_or_recover(last_completed_message_id, "read_last_completed_message_id");
+    guard.clone()
 }
 
 fn reset_reasoning_state(
@@ -296,7 +294,6 @@ fn reset_reasoning_state(
     reasoning_buffer: &StdMutex<String>,
 ) {
     reset_message_id(current_reasoning_message_id);
-    if let Ok(mut buffer) = reasoning_buffer.lock() {
-        buffer.clear();
-    }
+    let mut buffer = lock_or_recover(reasoning_buffer, "reset_reasoning_state");
+    buffer.clear();
 }

--- a/src-tauri/src/core/agent_session_events.rs
+++ b/src-tauri/src/core/agent_session_events.rs
@@ -92,11 +92,10 @@ pub(crate) fn handle_agent_event(
                         return;
                     }
 
-                    // Extract thinking_signature from the partial message's last
-                    // Thinking content block.  The signature is populated by the
-                    // protocol layer during streaming and is complete by the time
-                    // ThinkingEnd fires.
-                    // 从 partial.content 的最后一个 ThinkingContent 块中提取（反向查找）。
+                    // Extract thinking_signature from the partial message's final
+                    // Thinking content block. The protocol layer populates this
+                    // during streaming, so search from the end of partial.content
+                    // to find the complete block when ThinkingEnd fires.
                     let thinking_signature = partial
                         .content
                         .iter()
@@ -296,4 +295,32 @@ fn reset_reasoning_state(
     reset_message_id(current_reasoning_message_id);
     let mut buffer = lock_or_recover(reasoning_buffer, "reset_reasoning_state");
     buffer.clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_or_recover_recovers_poisoned_mutex() {
+        let mutex = StdMutex::new(String::from("before"));
+
+        let result = std::panic::catch_unwind(|| {
+            let _guard = mutex.lock().expect("mutex should lock before poison");
+            panic!("poison mutex for recovery test");
+        });
+        assert!(result.is_err());
+
+        {
+            let mut guard = lock_or_recover(&mutex, "test");
+            assert_eq!(guard.as_str(), "before");
+            guard.clear();
+            guard.push_str("after");
+        }
+
+        let guard = mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        assert_eq!(guard.as_str(), "after");
+    }
 }

--- a/src-tauri/src/core/agent_session_execution.rs
+++ b/src-tauri/src/core/agent_session_execution.rs
@@ -3,6 +3,10 @@ use std::sync::atomic::Ordering;
 use tiycore::agent::AgentToolResult;
 use tiycore::types::{ContentBlock, TextContent};
 
+use crate::core::agent_session::{
+    standard_tool_timeout, CLARIFY_TOOL_NAME, PLAN_TOOL_NAME, RENDER_TOOL_NAME,
+    STANDARD_TOOL_TIMEOUT_SECS, TASK_TOOL_NAMES,
+};
 use crate::core::agent_session_tools::{
     agent_error_result, agent_tool_result_from_output, resolve_helper_model_role,
     resolve_helper_profile, validate_clarify_input,
@@ -22,7 +26,7 @@ use crate::ipc::frontend_channels::{ArtifactStatus, ThreadStreamEvent};
 use crate::model::thread::MessageRecord;
 use crate::persistence::repo::{message_repo, tool_call_repo};
 
-use super::agent_session::{standard_tool_timeout, AgentSession, CLARIFY_TOOL_NAME};
+use super::agent_session::AgentSession;
 
 #[derive(Debug)]
 struct HelperToolTask {
@@ -66,18 +70,46 @@ impl AgentSession {
         tool_call_id: &str,
         tool_input: &serde_json::Value,
     ) -> AgentToolResult {
-        if tool_name == "update_plan" {
-            return self.execute_plan_checkpoint(tool_input).await;
+        if tool_name == PLAN_TOOL_NAME {
+            return match tokio::time::timeout(
+                standard_tool_timeout(),
+                self.execute_plan_checkpoint(tool_input),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => agent_error_result(format!(
+                    "Tool '{tool_name}' timed out after {STANDARD_TOOL_TIMEOUT_SECS}s"
+                )),
+            };
         }
 
-        if tool_name == "create_task" || tool_name == "update_task" || tool_name == "query_task" {
-            return self
-                .execute_task_tool(tool_name, tool_call_id, tool_input)
-                .await;
+        if TASK_TOOL_NAMES.contains(&tool_name) {
+            return match tokio::time::timeout(
+                standard_tool_timeout(),
+                self.execute_task_tool(tool_name, tool_call_id, tool_input),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => agent_error_result(format!(
+                    "Tool '{tool_name}' timed out after {STANDARD_TOOL_TIMEOUT_SECS}s"
+                )),
+            };
         }
 
-        if tool_name == "render" {
-            return self.execute_render(tool_call_id, tool_input).await;
+        if tool_name == RENDER_TOOL_NAME {
+            return match tokio::time::timeout(
+                standard_tool_timeout(),
+                self.execute_render(tool_call_id, tool_input),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => agent_error_result(format!(
+                    "Tool '{tool_name}' timed out after {STANDARD_TOOL_TIMEOUT_SECS}s"
+                )),
+            };
         }
 
         if tool_name == CLARIFY_TOOL_NAME {

--- a/src-tauri/src/core/agent_session_history.rs
+++ b/src-tauri/src/core/agent_session_history.rs
@@ -162,7 +162,7 @@ pub(crate) fn convert_history_messages(
         let mut pos_to_timeline_idx: std::collections::HashMap<usize, usize> =
             std::collections::HashMap::new();
         for (tl_idx, (key, _)) in timeline.iter().enumerate() {
-            if key.sub == 2 {
+            if key.sub == sub_position::POSITIONAL {
                 // sub == 2 means a positional message (not a tool call)
                 pos_to_timeline_idx.insert(key.position, tl_idx);
             }
@@ -264,7 +264,7 @@ pub(crate) fn convert_history_messages(
                 .iter()
                 .rposition(|(key, entry)| {
                     key.position == insert_pos
-                        && key.sub == 3
+                        && key.sub == sub_position::STANDALONE_TOOL_CALL
                         && matches!(entry, TimelineEntry::Msg(AgentMessage::Assistant(_)))
                 })
                 .and_then(|tl_idx| {
@@ -361,21 +361,36 @@ pub(crate) fn convert_history_messages(
     result
 }
 
+/// Sub-position constants for [`SortKey`] ordering.
+///
+/// These govern how entries at the same `position` are interleaved:
+///
+/// | Value | Meaning                                               |
+/// |-------|-------------------------------------------------------|
+/// |   0   | Merged tool-call result, placed *before* positional   |
+/// |   2   | Positional message (Phase 1 text/reasoning/plan)      |
+/// |   3   | Standalone tool-call assistant + result, placed *after*|
+mod sub_position {
+    /// Tool result merged into preceding assistant message (before positional).
+    pub const MERGED_TOOL_RESULT: u8 = 0;
+    /// Original positional message from Phase 1.
+    pub const POSITIONAL: u8 = 2;
+    /// Standalone tool-call assistant + result (after positional messages, so
+    /// that Phase 4 can attach preceding `PendingThinking`).
+    pub const STANDALONE_TOOL_CALL: u8 = 3;
+}
+
 /// Sort key for interleaving messages and tool calls chronologically.
 ///
 /// Messages get a whole-number position (their index in the original list).
 /// Tool calls are placed relative to a specific position using sub-keys.
 ///
-/// Sub-key ordering (ascending):
-///   0 = merged tool-call result placed *before* a positional message
-///   2 = positional message (Phase 1 text / reasoning / plan entries)
-///   3 = standalone tool-call assistant + result placed *after* positional
-///       messages so that Phase 4 can attach preceding PendingThinking
+/// Sub-key ordering (ascending) — see [`sub_position`] for the constants.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) struct SortKey {
     /// Main position (message index).
     position: usize,
-    /// Determines ordering within the same position — see doc above.
+    /// Determines ordering within the same position — see [`sub_position`].
     sub: u8,
     /// Tiebreaker for multiple entries at the same (position, sub).
     seq: usize,
@@ -385,7 +400,7 @@ impl SortKey {
     pub(crate) fn positional(pos: usize) -> Self {
         Self {
             position: pos,
-            sub: 2,
+            sub: sub_position::POSITIONAL,
             seq: 0,
         }
     }
@@ -393,7 +408,7 @@ impl SortKey {
     pub(crate) fn before_position(pos: usize, seq: usize) -> Self {
         Self {
             position: pos,
-            sub: 0,
+            sub: sub_position::MERGED_TOOL_RESULT,
             seq,
         }
     }
@@ -406,7 +421,7 @@ impl SortKey {
     pub(crate) fn after_position(pos: usize, seq: usize) -> Self {
         Self {
             position: pos,
-            sub: 3,
+            sub: sub_position::STANDALONE_TOOL_CALL,
             seq,
         }
     }

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -424,12 +424,13 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn plan_read_only_profile_includes_shell_excludes_mutating_terminal_tools() {
+    fn plan_read_only_profile_excludes_shell_and_mutating_terminal_tools() {
         let tools = runtime_tools_for_profile(PLAN_READ_ONLY_TOOL_PROFILE);
         let tool_names: Vec<&str> = tools.iter().map(|tool| tool.name.as_str()).collect();
 
-        // Shell is available in plan mode (follows normal approval policy).
-        assert!(tool_names.contains(&"shell"));
+        // Shell is excluded in plan mode — arbitrary command execution is not
+        // compatible with read-only intent (prompt-only constraint was insufficient).
+        assert!(!tool_names.contains(&"shell"));
         // Write-oriented terminal tools are excluded.
         assert!(!tool_names.contains(&"term_write"));
         assert!(!tool_names.contains(&"term_restart"));

--- a/src-tauri/src/core/agent_session_tools.rs
+++ b/src-tauri/src/core/agent_session_tools.rs
@@ -309,23 +309,23 @@ You may call this tool multiple times in a run to incrementally refine the plan.
     ];
     tools.extend(runtime_orchestration_tools());
 
-    // Shell is available in both profiles (plan mode applies read-only constraints via prompt).
-    tools.push(AgentTool::new(
-        "shell",
-        "Run Command",
-        "Run a non-interactive shell command inside the current workspace.",
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "command": { "type": "string" },
-                "cwd": { "type": "string" },
-                "timeout": { "type": "number" }
-            },
-            "required": ["command"]
-        }),
-    ));
-
     if profile_name == DEFAULT_FULL_TOOL_PROFILE {
+        // Shell is gated to the full profile — plan mode must not allow arbitrary
+        // command execution (the previous prompt-only constraint was insufficient).
+        tools.push(AgentTool::new(
+            "shell",
+            "Run Command",
+            "Run a non-interactive shell command inside the current workspace.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "command": { "type": "string" },
+                    "cwd": { "type": "string" },
+                    "timeout": { "type": "number" }
+                },
+                "required": ["command"]
+            }),
+        ));
         tools.push(AgentTool::new(
             "edit",
             "Edit File",

--- a/src-tauri/src/persistence/repo/message_repo.rs
+++ b/src-tauri/src/persistence/repo/message_repo.rs
@@ -115,7 +115,7 @@ pub async fn list_since_last_reset(
     pool: &SqlitePool,
     thread_id: &str,
 ) -> Result<Vec<MessageRecord>, AppError> {
-    const SAFETY_LIMIT: i64 = 2000;
+    const SAFETY_LIMIT: i64 = 10000;
 
     let reset = find_last_context_reset(pool, thread_id).await?;
 

--- a/src/modules/workbench-shell/model/thread-store.test.ts
+++ b/src/modules/workbench-shell/model/thread-store.test.ts
@@ -221,6 +221,60 @@ describe("batchSetThreadStatuses", () => {
     expect(statuses["thread-2"].status).toBe("idle");
   });
 
+  it("applies same-run updates without updatedAt even when existing status is newer", () => {
+    threadStore.reset();
+    setThreadStatus("thread-1", "running", {
+      runId: "run-1",
+      source: "stream",
+      updatedAt: 200,
+    });
+
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    batchSetThreadStatuses({
+      "thread-1": { status: "waiting_approval", runId: "run-1", source: "snapshot" },
+    });
+    nowSpy.mockRestore();
+
+    const status = threadStore.getState().threadStatuses["thread-1"];
+    expect(status.status).toBe("waiting_approval");
+    expect(status.runId).toBe("run-1");
+    expect(status.updatedAt).toBe(1_000);
+  });
+
+  it("skips same-run updates with an explicit older updatedAt", () => {
+    threadStore.reset();
+    setThreadStatus("thread-1", "running", {
+      runId: "run-1",
+      source: "stream",
+      updatedAt: 200,
+    });
+
+    batchSetThreadStatuses({
+      "thread-1": { status: "waiting_approval", runId: "run-1", updatedAt: 100 },
+    });
+
+    const status = threadStore.getState().threadStatuses["thread-1"];
+    expect(status.status).toBe("running");
+    expect(status.updatedAt).toBe(200);
+  });
+
+  it("applies same-run updates with an explicit newer updatedAt", () => {
+    threadStore.reset();
+    setThreadStatus("thread-1", "running", {
+      runId: "run-1",
+      source: "stream",
+      updatedAt: 200,
+    });
+
+    batchSetThreadStatuses({
+      "thread-1": { status: "waiting_approval", runId: "run-1", updatedAt: 300 },
+    });
+
+    const status = threadStore.getState().threadStatuses["thread-1"];
+    expect(status.status).toBe("waiting_approval");
+    expect(status.updatedAt).toBe(300);
+  });
+
   it("rejects idle/null downgrade for running threads in batch", () => {
     threadStore.reset();
     setThreadStatus("thread-1", "running", { runId: "run-1", source: "stream" });

--- a/src/modules/workbench-shell/model/thread-store.ts
+++ b/src/modules/workbench-shell/model/thread-store.ts
@@ -172,13 +172,16 @@ export function batchSetThreadStatuses(
     const next = { ...prev.threadStatuses };
     for (const [threadId, upd] of Object.entries(updates)) {
       const existing = next[threadId];
+      // Guard 1: ignore stale writes within the same run (same semantics as
+      // setThreadStatus — only compare when updatedAt is explicitly provided).
       if (
         existing &&
         existing.runId !== null &&
         upd.runId !== undefined &&
         upd.runId !== null &&
         existing.runId === upd.runId &&
-        existing.updatedAt > (upd.updatedAt ?? 0)
+        upd.updatedAt !== undefined &&
+        existing.updatedAt > upd.updatedAt
       ) {
         continue;
       }

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
@@ -56,6 +56,9 @@ export function mapSnapshotHelper(
 
   return {
     completedSteps: toolSummary.completedSteps,
+    // Defaults below are overridden by applyHelperSnapshot() when live
+    // stream events arrive. They are intentional initial values for the
+    // snapshot-only path (no streaming data yet).
     currentAction: null,
     error: helper.errorSummary ?? undefined,
     finishedAt: helper.finishedAt,

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-logic.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-logic.ts
@@ -1,5 +1,12 @@
 import type { RunState } from "@/services/thread-stream";
 import type { MessageDto, MessagePartDto, ThreadSnapshotDto } from "@/shared/types/api";
+import {
+  isDefaultCollapsedTool,
+  isTaskBoardTool,
+} from "@/shared/constants/tool-names";
+
+// Re-export from shared constants for backward compatibility with existing imports.
+export { isDefaultCollapsedTool, isTaskBoardTool };
 
 export type RuntimeSurfaceToolState =
   | "approval-requested"
@@ -115,17 +122,6 @@ export function shouldUseLongMessagePreview(message: RuntimeSurfaceMessagePrevie
   return true;
 }
 
-export function isTaskBoardTool(toolName: string) {
-  return (
-    toolName === "create_task"
-    || toolName === "update_task"
-    || toolName === "query_task"
-  );
-}
-
-export function isDefaultCollapsedTool(toolName: string) {
-  return isTaskBoardTool(toolName) || toolName === "render";
-}
 
 export function getDefaultToolOpenState(
   toolName: string,

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -606,6 +606,10 @@ export function getToolStatusClass(state: SurfaceToolState) {
 /**
  * Defines a rough ordering of tool states through their lifecycle.
  * Higher numbers mean the tool is further along.
+ *
+ * Terminal states are differentiated so that `isMoreAdvancedToolState` can
+ * correctly resolve conflicts when a live event and a stale snapshot report
+ * different terminal outcomes (e.g. denied vs. available).
  */
 const TOOL_STATE_ORDER: Record<SurfaceToolState, number> = {
   "input-streaming": 0,
@@ -613,9 +617,9 @@ const TOOL_STATE_ORDER: Record<SurfaceToolState, number> = {
   "clarify-requested": 2,
   "approval-requested": 3,
   "approval-responded": 4,
-  "output-available": 5,
   "output-denied": 5,
-  "output-error": 5,
+  "output-error": 6,
+  "output-available": 7,
 };
 
 /**

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { mapSnapshotToRunState, isTaskBoardTool, getDefaultToolOpenState } from "./runtime-thread-surface-logic";
-import { mapMessageParts, mapSnapshotMessage } from "./runtime-thread-surface-state";
+import { mapMessageParts, mapSnapshotMessage, mergeSnapshotTools } from "./runtime-thread-surface-state";
 import type { MessageDto, RunStatus, ThreadSnapshotDto } from "@/shared/types/api";
 
 function makeMessage(overrides: Partial<MessageDto> = {}): MessageDto {
@@ -59,6 +59,19 @@ function makeSnapshot(activeStatus: RunStatus | null): ThreadSnapshotDto {
     helpers: [],
     taskBoards: [],
     activeTaskBoardId: null,
+  };
+}
+
+type TestSurfaceTool = Parameters<typeof mergeSnapshotTools>[0][number];
+
+function makeTool(overrides: Partial<TestSurfaceTool>): TestSurfaceTool {
+  return {
+    id: "tool-1",
+    name: "read",
+    runId: "run-1",
+    startedAt: "2026-05-06T00:00:00Z",
+    state: "output-available",
+    ...overrides,
   };
 }
 
@@ -140,6 +153,27 @@ describe("isTaskBoardTool", () => {
     expect(isTaskBoardTool("")).toBe(false);
     expect(isTaskBoardTool("create_task_extra")).toBe(false);
     expect(isTaskBoardTool("CREATE_TASK")).toBe(false);
+  });
+});
+
+describe("mergeSnapshotTools", () => {
+  it("keeps the more advanced live terminal state when merging stale snapshots", () => {
+    const deniedSnapshot = makeTool({ state: "output-denied", result: "denied snapshot" });
+    const errorLive = makeTool({ state: "output-error", error: "live error" });
+
+    expect(mergeSnapshotTools([deniedSnapshot], [errorLive])[0]).toBe(errorLive);
+
+    const errorSnapshot = makeTool({ state: "output-error", error: "snapshot error" });
+    const availableLive = makeTool({ state: "output-available", result: "live result" });
+
+    expect(mergeSnapshotTools([errorSnapshot], [availableLive])[0]).toBe(availableLive);
+  });
+
+  it("keeps the snapshot when a live terminal state is less advanced", () => {
+    const availableSnapshot = makeTool({ state: "output-available", result: "snapshot result" });
+    const deniedLive = makeTool({ state: "output-denied", result: "denied live" });
+
+    expect(mergeSnapshotTools([availableSnapshot], [deniedLive])[0]).toBe(availableSnapshot);
   });
 });
 

--- a/src/services/thread-stream/thread-stream.test.ts
+++ b/src/services/thread-stream/thread-stream.test.ts
@@ -54,6 +54,20 @@ function emit(events: ThreadStreamEvent[]) {
   };
 }
 
+type TerminalRunEvent = Extract<
+  ThreadStreamEvent,
+  { type: "run_checkpointed" | "run_completed" | "run_limit_reached" | "run_failed" | "run_cancelled" | "run_interrupted" }
+>;
+
+const terminalRunEvents: TerminalRunEvent[] = [
+  { type: "run_checkpointed", runId: "run-1" },
+  { type: "run_completed", runId: "run-1" },
+  { type: "run_limit_reached", runId: "run-1", error: "limit reached", maxTurns: 3 },
+  { type: "run_failed", runId: "run-1", error: "fatal error" },
+  { type: "run_cancelled", runId: "run-1" },
+  { type: "run_interrupted", runId: "run-1" },
+];
+
 describe("ThreadStream event routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -410,6 +424,81 @@ describe("ThreadStream uncovered events", () => {
     await stream.startRun("thread-1", { prompt: "hi" });
     expect(onRunStateChange).toHaveBeenCalledWith("running", "run-1");
     expect(stream.runId).toBe("run-1");
+  });
+
+  it.each(terminalRunEvents)("clears run caches for $type events", async (terminalEvent) => {
+    const stream = new ThreadStream();
+    const onToolEvent = vi.fn();
+    stream.onToolEvent = onToolEvent;
+
+    threadSubscribeRunMock.mockImplementationOnce((
+      _threadId: string,
+      onEvent: (event: ThreadStreamEvent) => void,
+    ) => {
+      for (const event of [
+        { type: "run_started", runId: "run-1", runMode: "default" } as const,
+        { type: "tool_requested", runId: "run-1", toolCallId: "tool-reused", toolName: "agent_review", toolInput: {} } as const,
+        terminalEvent,
+        { type: "tool_requested", runId: "run-2", toolCallId: "tool-reused", toolName: "read", toolInput: { path: "README.md" } } as const,
+        { type: "tool_running", runId: "run-2", toolCallId: "tool-reused" } as const,
+      ]) {
+        onEvent(event);
+      }
+      return Promise.resolve(null);
+    });
+
+    await stream.subscribe("thread-1");
+
+    expect(stream.runId).toBeNull();
+    expect(onToolEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "requested",
+      runId: "run-2",
+      toolCallId: "tool-reused",
+      toolName: "read",
+    }));
+    expect(onToolEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "running",
+      runId: "run-2",
+      toolCallId: "tool-reused",
+      toolName: "read",
+    }));
+  });
+
+  it("clears run caches on reset", async () => {
+    const stream = new ThreadStream();
+    const onToolEvent = vi.fn();
+    stream.onToolEvent = onToolEvent;
+
+    threadStartRunMock.mockImplementationOnce(emit([
+      { type: "run_started", runId: "run-1", runMode: "default" },
+      { type: "tool_requested", runId: "run-1", toolCallId: "tool-reused", toolName: "agent_review", toolInput: {} },
+    ]));
+
+    await stream.startRun("thread-1", { prompt: "hi" });
+    expect(stream.runId).toBe("run-1");
+
+    stream.reset();
+    expect(stream.runId).toBeNull();
+
+    threadStartRunMock.mockImplementationOnce(emit([
+      { type: "tool_requested", runId: "run-2", toolCallId: "tool-reused", toolName: "read", toolInput: { path: "README.md" } },
+      { type: "tool_running", runId: "run-2", toolCallId: "tool-reused" },
+    ]));
+
+    await stream.startRun("thread-1", { prompt: "again" });
+
+    expect(onToolEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "requested",
+      runId: "run-2",
+      toolCallId: "tool-reused",
+      toolName: "read",
+    }));
+    expect(onToolEvent).toHaveBeenCalledWith(expect.objectContaining({
+      kind: "running",
+      runId: "run-2",
+      toolCallId: "tool-reused",
+      toolName: "read",
+    }));
   });
 
   it("routes tool_failed events for visible tools", async () => {

--- a/src/services/thread-stream/thread-stream.ts
+++ b/src/services/thread-stream/thread-stream.ts
@@ -34,6 +34,7 @@ import type {
 } from "@/shared/types/api";
 import type { ThreadStreamEvent } from "./types";
 import { formatInvokeErrorMessage } from "@/shared/lib/invoke-error";
+import { isRuntimeOrchestrationToolName } from "@/shared/constants/tool-names";
 
 // ---------------------------------------------------------------------------
 // Callback types for AI Elements mapping
@@ -377,6 +378,15 @@ export class ThreadStream {
    * Reset stream state (e.g. when switching threads).
    */
   reset() {
+    this.clearRunCaches();
+  }
+
+  /**
+   * Clear all per-run caches. Called on terminal events and reset().
+   * Prevents unbounded growth of toolNameCache and hiddenToolCallIds
+   * when tool lifecycle events are lost (e.g. network interruption).
+   */
+  private clearRunCaches() {
     this.currentRunId = null;
     this.hiddenToolCallIds.clear();
     this.toolNameCache.clear();
@@ -661,7 +671,7 @@ export class ThreadStream {
         break;
 
       case "run_checkpointed":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("waiting_approval", event.runId);
         break;
 
@@ -671,38 +681,31 @@ export class ThreadStream {
         break;
 
       case "run_completed":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("completed", event.runId);
         break;
 
       case "run_limit_reached":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("limit_reached", event.runId);
         this.onError?.(event.error, event.runId);
         break;
 
       case "run_failed":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("failed", event.runId);
         this.onError?.(event.error, event.runId);
         break;
 
       case "run_cancelled":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("cancelled", event.runId);
         break;
 
       case "run_interrupted":
-        this.currentRunId = null;
+        this.clearRunCaches();
         this.onRunStateChange?.("interrupted", event.runId);
         break;
     }
   }
-}
-
-function isRuntimeOrchestrationToolName(toolName: string) {
-  return (
-    toolName === "agent_explore"
-    || toolName === "agent_review"
-  );
 }

--- a/src/shared/constants/tool-names.ts
+++ b/src/shared/constants/tool-names.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared tool name constants.
+ *
+ * These mirror the Rust-side constants in `agent_session.rs` to eliminate
+ * hardcoded tool name strings scattered across the frontend codebase.
+ */
+
+/** Runtime orchestration tools — hidden from UI (never shown in timeline). */
+export const RUNTIME_ORCHESTRATION_TOOLS = [
+  "agent_explore",
+  "agent_review",
+] as const;
+
+/** Task board tools. */
+export const TASK_BOARD_TOOLS = [
+  "create_task",
+  "update_task",
+  "query_task",
+] as const;
+
+/** Tools that are collapsed by default in the timeline. */
+export const DEFAULT_COLLAPSED_TOOLS = [
+  ...TASK_BOARD_TOOLS,
+  "render",
+] as const;
+
+export function isRuntimeOrchestrationToolName(toolName: string): boolean {
+  return (RUNTIME_ORCHESTRATION_TOOLS as ReadonlyArray<string>).includes(toolName);
+}
+
+export function isTaskBoardTool(toolName: string): boolean {
+  return (TASK_BOARD_TOOLS as ReadonlyArray<string>).includes(toolName);
+}
+
+export function isDefaultCollapsedTool(toolName: string): boolean {
+  return (DEFAULT_COLLAPSED_TOOLS as ReadonlyArray<string>).includes(toolName);
+}


### PR DESCRIPTION
## Summary
- Harden agent session event handling by recovering poisoned mutex state and preserving message tracking.
- Apply standard timeouts to plan, task, and render runtime tools.
- Align history/tool naming and frontend thread stream handling with shared tool constants.

## Test Plan
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml`
- [x] `npm run typecheck`
- [x] `npm run test:unit`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
