### PR TITLE
fix(core): 🐛 Adapt to updated tiycore API

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6179,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.5"
+version = "0.2.5-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed277a6d6b5f57dd68d7123f88744dab83e20bdbb75212f8d5812f02244c6c1b"
+checksum = "8a7258f03f278a67752b95051d9897f7c1fa156185292a284f3272576fd76788"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.5"
+tiycore = "0.2.5-rc.4"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -636,7 +636,7 @@ pub async fn resolve_runtime_model_role(
     // requests that omit it with HTTP 400.
     if let Some(true) = role.reasoning_content_constrained {
         let mut compat = maybe_compat.unwrap_or_default();
-        compat.reasoning_content_constrained = true;
+        compat.thinking.content_constrained = true;
         builder = builder.compat(compat);
     } else if let Some(compat) = maybe_compat {
         builder = builder.compat(compat);

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -1481,14 +1481,14 @@ Used for prompt assembly coverage.
 
         // When reasoning_content_constrained is Some(true), the compat flag must be set.
         let constrained_compat = constrained.model.compat.as_ref().expect("compat present");
-        assert!(constrained_compat.reasoning_content_constrained);
+        assert!(constrained_compat.thinking.content_constrained);
 
         // When Some(false) or None, the compat flag must remain at its default (false).
         let unconstrained_compat = unconstrained.model.compat.as_ref().expect("compat present");
-        assert!(!unconstrained_compat.reasoning_content_constrained);
+        assert!(!unconstrained_compat.thinking.content_constrained);
 
         let unspecified_compat = unspecified.model.compat.as_ref().expect("compat present");
-        assert!(!unspecified_compat.reasoning_content_constrained);
+        assert!(!unspecified_compat.thinking.content_constrained);
     }
 
     #[tokio::test]
@@ -1559,7 +1559,7 @@ Used for prompt assembly coverage.
             .compat
             .as_ref()
             .expect("compat created for constrained");
-        assert!(constrained_compat.reasoning_content_constrained);
+        assert!(constrained_compat.thinking.content_constrained);
 
         // For Some(false) or None, no compat should be applied at all
         // (unlike openai-compatible providers that always get compat).

--- a/src-tauri/src/core/agent_session_types.rs
+++ b/src-tauri/src/core/agent_session_types.rs
@@ -101,7 +101,7 @@ pub(crate) fn default_openai_compatible_compat(
     }
 
     let mut compat = OpenAICompletionsCompat::default();
-    compat.supports_developer_role = false;
+    compat.capabilities.supports_developer_role = false;
     Some(compat)
 }
 

--- a/src-tauri/tests/agent_run.rs
+++ b/src-tauri/tests/agent_run.rs
@@ -738,7 +738,7 @@ async fn test_build_session_spec_defaults_openai_compatible_to_system_role_compa
         .expect("openai-compatible models should set explicit compat defaults");
 
     assert!(spec.model_plan.primary.model.reasoning);
-    assert!(!compat.supports_developer_role);
+    assert!(!compat.capabilities.supports_developer_role);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Update `tiycore` to `0.2.5-rc.4` in Cargo dependencies.
- Adapt `OpenAICompletionsCompat` field access to the updated nested API.
- Update related Rust tests to assert the new compat field paths.

## Test Plan
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
