### PR TITLE
fix(composer): 🐛 Persist attachments in thread drafts & remove plan mode toggle

### DIFF
--- a/src/modules/workbench-shell/model/composer-store.test.ts
+++ b/src/modules/workbench-shell/model/composer-store.test.ts
@@ -11,6 +11,7 @@ import {
   setComposerError,
   clearComposerError,
   clearNewThreadComposer,
+  type SerializableAttachment,
 } from "./composer-store";
 
 beforeEach(() => {
@@ -47,13 +48,13 @@ describe("composerStore", () => {
 
   describe("drafts", () => {
     it("should set and get drafts", () => {
-      setDraft("thread-1", { text: "draft content", referencedFiles: [] });
+      setDraft("thread-1", { text: "draft content", referencedFiles: [], attachmentData: [] });
       expect(getDraft("thread-1").text).toBe("draft content");
       expect(getDraft("thread-2").text).toBe(""); // non-existent → empty
     });
 
     it("should remove drafts", () => {
-      setDraft("thread-1", { text: "content", referencedFiles: [] });
+      setDraft("thread-1", { text: "content", referencedFiles: [], attachmentData: [] });
       removeDraft("thread-1");
       expect(getDraft("thread-1").text).toBe("");
     });
@@ -64,22 +65,41 @@ describe("composerStore", () => {
     });
 
     it("should support multiple thread drafts", () => {
-      setDraft("t1", { text: "a", referencedFiles: [] });
-      setDraft("t2", { text: "b", referencedFiles: [] });
+      setDraft("t1", { text: "a", referencedFiles: [], attachmentData: [] });
+      setDraft("t2", { text: "b", referencedFiles: [], attachmentData: [] });
       expect(getDraft("t1").text).toBe("a");
       expect(getDraft("t2").text).toBe("b");
     });
 
     it("setDraft should update existing draft", () => {
-      setDraft("t1", { text: "first", referencedFiles: [] });
-      setDraft("t1", { text: "second", referencedFiles: [] });
+      setDraft("t1", { text: "first", referencedFiles: [], attachmentData: [] });
+      setDraft("t1", { text: "second", referencedFiles: [], attachmentData: [] });
       expect(getDraft("t1").text).toBe("second");
     });
 
     it("should store and retrieve referencedFiles", () => {
       const files = [{ name: "app.ts", path: "src/app.ts", parentPath: "src" }];
-      setDraft("t1", { text: "hello", referencedFiles: files });
+      setDraft("t1", { text: "hello", referencedFiles: files, attachmentData: [] });
       expect(getDraft("t1").referencedFiles).toEqual(files);
+    });
+
+    it("should store and retrieve attachmentData", () => {
+      const attachments: SerializableAttachment[] = [
+        { id: "1", name: "photo.png", mediaType: "image/png", dataUrl: "data:image/png;base64,abc" },
+      ];
+      setDraft("t1", { text: "check this out", referencedFiles: [], attachmentData: attachments });
+      expect(getDraft("t1").attachmentData).toEqual(attachments);
+    });
+
+    it("should update attachmentData independently of other draft fields", () => {
+      setDraft("t1", { text: "hello", referencedFiles: [], attachmentData: [] });
+      const existing = getDraft("t1");
+      const attachments: SerializableAttachment[] = [
+        { id: "2", name: "doc.pdf", mediaType: "application/pdf", dataUrl: "data:application/pdf;base64,xyz" },
+      ];
+      setDraft("t1", { ...existing, attachmentData: attachments });
+      expect(getDraft("t1").text).toBe("hello");
+      expect(getDraft("t1").attachmentData).toEqual(attachments);
     });
 
     it("getDraft should handle legacy string drafts", () => {
@@ -88,6 +108,25 @@ describe("composerStore", () => {
       const draft = getDraft("legacy");
       expect(draft.text).toBe("old text");
       expect(draft.referencedFiles).toEqual([]);
+      expect(draft.attachmentData).toEqual([]);
+    });
+
+    it("getDraft should handle drafts missing attachmentData (backward compat)", () => {
+      // Simulate an old object draft that lacks attachmentData
+      composerStore.setState({
+        drafts: {
+          oldObj: { text: "old draft", referencedFiles: [] } as any,
+        },
+      });
+      const draft = getDraft("oldObj");
+      expect(draft.text).toBe("old draft");
+      expect(draft.referencedFiles).toEqual([]);
+      expect(draft.attachmentData).toEqual([]);
+    });
+
+    it("getDraft should return empty attachmentData for non-existent thread", () => {
+      const draft = getDraft("nonexistent");
+      expect(draft.attachmentData).toEqual([]);
     });
   });
 

--- a/src/modules/workbench-shell/model/composer-store.ts
+++ b/src/modules/workbench-shell/model/composer-store.ts
@@ -19,6 +19,8 @@ export interface SerializableAttachment {
 export interface ComposerDraftData {
   text: string;
   referencedFiles: ComposerReferencedFile[];
+  /** Serialized attachment data (images, files) for draft restore after thread switch. */
+  attachmentData: SerializableAttachment[];
 }
 
 export interface ComposerStoreState {
@@ -105,13 +107,18 @@ export function setDraft(threadId: string, data: ComposerDraftData): void {
 export function getDraft(threadId: string): ComposerDraftData {
   const raw = composerStore.getState().drafts[threadId];
   if (!raw) {
-    return { text: "", referencedFiles: [] };
+    return { text: "", referencedFiles: [], attachmentData: [] };
   }
   // Backward compat: old drafts were plain strings.
   if (typeof raw === "string") {
-    return { text: raw, referencedFiles: [] };
+    return { text: raw, referencedFiles: [], attachmentData: [] };
   }
-  return raw as ComposerDraftData;
+  const draft = raw as ComposerDraftData;
+  return {
+    text: draft.text,
+    referencedFiles: draft.referencedFiles ?? [],
+    attachmentData: draft.attachmentData ?? [],
+  };
 }
 
 export function removeDraft(threadId: string): void {

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -114,7 +114,6 @@ import {
 import {
   composerStore,
   setNewThreadValue,
-  setNewThreadRunMode,
   setNewThreadReferencedFiles,
   setNewThreadAttachmentData,
   setComposerError,
@@ -972,15 +971,12 @@ export function DashboardWorkbench() {
                             enabledSkills={enabledSkillEntries}
                             error={composerError}
                             onErrorMessageChange={setComposerError}
-                            onRunModeChange={setNewThreadRunMode}
                             onOpenProfileSettings={() => handleOpenSettings("general")}
                             onSelectAgentProfile={handleSelectAgentProfileForThread}
                             onStop={() => undefined}
                             onSubmit={handleComposerSubmit}
                             placeholder={t("composer.placeholder")}
                             providers={providers}
-                            runMode={newThreadRunMode}
-                            showRunModeToggle
                             status="ready"
                             value={composerValue}
                             workspaceId={selectedProjectWorkspaceId}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -56,7 +56,7 @@ import {
   registerRunMachine,
   unregisterRunMachine,
 } from "@/modules/workbench-shell/model/run-event-dispatcher";
-import { composerStore, setDraft, getDraft } from "@/modules/workbench-shell/model/composer-store";
+import { composerStore, setDraft, getDraft, type SerializableAttachment } from "@/modules/workbench-shell/model/composer-store";
 import { settingsStore } from "@/modules/settings-center/model/settings-store";
 import { threadUpdateProfile } from "@/services/bridge";
 import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
@@ -3051,11 +3051,18 @@ export function RuntimeThreadSurface({
             }
             onValueChange={setComposerValue}
             initialReferencedFiles={threadId ? getDraft(threadId).referencedFiles : []}
+            initialAttachmentData={threadId ? getDraft(threadId).attachmentData : undefined}
             clearSignal={composerClearSignal}
             onReferencedFilesChange={(files) => {
               if (threadId) {
                 const existing = getDraft(threadId);
                 setDraft(threadId, { ...existing, referencedFiles: files as ComposerReferencedFile[] });
+              }
+            }}
+            onAttachmentDataChange={(data: ReadonlyArray<SerializableAttachment>) => {
+              if (threadId) {
+                const existing = getDraft(threadId);
+                setDraft(threadId, { ...existing, attachmentData: data as SerializableAttachment[] });
               }
             }}
           />

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2966,7 +2966,6 @@ export function RuntimeThreadSurface({
             enabledSkills={enabledSkills}
             error={composerError}
             onErrorMessageChange={setComposerError}
-            onRunModeChange={setSelectedRunMode}
             onOpenProfileSettings={() => {
               uiLayoutStore.setState({ activeOverlay: "settings" });
             }}
@@ -3036,9 +3035,6 @@ export function RuntimeThreadSurface({
             onSubmit={handleSubmit}
             placeholder="Ask Tiy anything, @ to add files, / for commands, $ for skills"
             providers={providers}
-            runMode={selectedRunMode}
-            runModeDisabled={runState === "running" || runState === "waiting_approval"}
-            showRunModeToggle
             status={composerStatus}
             value={composerValue}
             workspaceId={

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -69,7 +69,6 @@ import { cn } from "@/shared/lib/utils";
 import { Badge } from "@/shared/ui/badge";
 import { Button } from "@/shared/ui/button";
 import { ModelBrandIcon } from "@/shared/ui/model-brand-icon";
-import { Switch } from "@/shared/ui/switch";
 
 type ComposerAttachment = {
   id: string;
@@ -110,15 +109,11 @@ type WorkbenchPromptComposerProps = {
   error?: string | null;
   onErrorMessageChange?: (message: string | null) => void;
   onOpenProfileSettings?: () => void;
-  onRunModeChange?: (mode: RunMode) => void;
   onSelectAgentProfile: (id: string) => void;
   onStop: () => void;
   onSubmit: (submission: ComposerSubmission) => void | Promise<void>;
   placeholder: string;
   providers: ReadonlyArray<ProviderEntry>;
-  runMode?: RunMode;
-  runModeDisabled?: boolean;
-  showRunModeToggle?: boolean;
   status: ChatStatus;
   suggestions?: ReadonlyArray<string>;
   textareaClassName?: string;
@@ -1165,38 +1160,6 @@ function ProfileDetailsPanel({
   );
 }
 
-function RunModeToggle({
-  disabled = false,
-  onChange,
-  runMode,
-}: {
-  disabled?: boolean;
-  onChange: (mode: RunMode) => void;
-  runMode: RunMode;
-}) {
-  const checked = runMode === "plan";
-
-  return (
-    <div className="inline-flex items-center gap-2">
-      <Switch
-        aria-label="Toggle plan mode"
-        checked={checked}
-        disabled={disabled}
-        onCheckedChange={(nextChecked) => onChange(nextChecked ? "plan" : "default")}
-        size="sm"
-      />
-      <span
-        className={cn(
-          "min-w-[6.75rem] text-left text-sm font-medium",
-          checked ? "text-app-info" : "text-app-muted",
-        )}
-      >
-        {checked ? "Plan mode" : "Default mode"}
-      </span>
-    </div>
-  );
-}
-
 export function mapComposerAttachments(files: Array<FileUIPart>) {
   return files.map((file, index) => ({
     id: file.url || `${file.filename || "attachment"}-${index}`,
@@ -1252,15 +1215,11 @@ export function WorkbenchPromptComposer({
   error,
   onErrorMessageChange,
   onOpenProfileSettings,
-  onRunModeChange = () => undefined,
   onSelectAgentProfile,
   onStop,
   onSubmit,
   placeholder,
   providers,
-  runMode = "default",
-  runModeDisabled = false,
-  showRunModeToggle = false,
   status,
   suggestions,
   textareaClassName,
@@ -1512,7 +1471,7 @@ export function WorkbenchPromptComposer({
   // must be called inside a PromptInput descendant.
 
   const handlePromptSubmit = async (message: PromptInputMessage) => {
-    const submission = buildSubmissionFromPromptInput(message, commandRegistry, runMode, referencedFiles);
+    const submission = buildSubmissionFromPromptInput(message, commandRegistry, "default", referencedFiles);
     await onSubmit(submission);
     // Only clear referenced files and sources after a successful submit.
     // If onSubmit throws (e.g. thread has an active run), the composer
@@ -2051,16 +2010,7 @@ export function WorkbenchPromptComposer({
                   </PromptInputButton>
                 )}
 
-                {showRunModeToggle ? (
-                  <>
-                    <span aria-hidden="true" className="h-4 w-px bg-app-border/55" />
-                    <RunModeToggle
-                      disabled={runModeDisabled || hasMissingActiveProfile}
-                      onChange={onRunModeChange}
-                      runMode={runMode}
-                    />
-                  </>
-                ) : null}
+                
               </div>
             </PromptInputTools>
 


### PR DESCRIPTION
## Summary
- Fix image/file attachments being lost when switching between threads by persisting `attachmentData` in composer drafts
- Remove the plan/default mode toggle from the prompt composer UI (simplification)

## Changes
- **composer-store**: Add `attachmentData` field to `ComposerDraftData`; `getDraft()` normalizes missing/legacy data with backward compatibility
- **runtime-thread-surface**: Pass `initialAttachmentData` and `onAttachmentDataChange` to the composer so attachments survive thread switches
- **workbench-prompt-composer**: Remove `RunModeToggle` component and related props (`runMode`, `showRunModeToggle`, `onRunModeChange`, `runModeDisabled`); hard-code run mode to `"default"` in `buildSubmissionFromPromptInput`
- **dashboard-workbench**: Remove plan mode toggle props from new-thread composer
- **composer-store.test**: Add tests for `attachmentData` persistence, independent update, backward compat for legacy drafts missing `attachmentData`

## Test Plan
- [ ] Attach an image, switch threads, switch back — image should still be present
- [ ] Attach a file, switch threads, switch back — file should still be present
- [ ] Verify legacy thread drafts (string or object without `attachmentData`) render without errors
- [ ] Confirm plan/default mode toggle is no longer visible in the composer
- [ ] Run `npm run typecheck` and `npm run test:unit` to verify no regressions

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
