### PR TITLE
fix(agent-runtime): 🐛 Retry transient provider network errors

### DIFF
--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -89,13 +89,109 @@ struct RetryContext {
     error: String,
 }
 
-/// Returns `true` when the error string looks like a retryable HTTP server /
-/// rate-limit error. Auth errors (401, 403) are intentionally excluded.
+/// Returns `true` when the error string looks like a retryable provider
+/// failure. Server/rate-limit HTTP responses and transient transport failures
+/// are retryable; authentication, authorization, malformed-request, and
+/// context-limit errors are intentionally excluded.
 fn is_retryable_provider_error(error: &str) -> bool {
     const RETRYABLE_CODES: &[&str] = &[
-        "HTTP 408", "HTTP 429", "HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504",
+        "http 408", "http 429", "http 500", "http 502", "http 503", "http 504",
     ];
-    RETRYABLE_CODES.iter().any(|code| error.contains(code))
+    const NON_RETRYABLE_MARKERS: &[&str] = &[
+        "http 400",
+        "http 401",
+        "http 403",
+        "bad request",
+        "invalid request",
+        "invalid api key",
+        "invalid_api_key",
+        "authentication",
+        "unauthorized",
+        "forbidden",
+        "permission denied",
+        "context length",
+        "context_length",
+        "maximum context",
+        "max context",
+        "token limit",
+        "model_not_found",
+        "model not found",
+    ];
+    const TRANSIENT_NETWORK_MARKERS: &[&str] = &[
+        "error sending request for url",
+        "request timed out",
+        "operation timed out",
+        "deadline has elapsed",
+        "connection reset",
+        "connection refused",
+        "connection closed",
+        "connection aborted",
+        "connection terminated",
+        "connection error",
+        "broken pipe",
+        "dns error",
+        "failed to lookup address",
+        "temporary failure in name resolution",
+        "tls handshake",
+        "unexpected eof",
+        "incomplete message",
+    ];
+
+    let normalized = error.to_ascii_lowercase();
+    if NON_RETRYABLE_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker))
+    {
+        return false;
+    }
+
+    if RETRYABLE_CODES.iter().any(|code| normalized.contains(code)) {
+        return true;
+    }
+
+    TRANSIENT_NETWORK_MARKERS
+        .iter()
+        .any(|marker| normalized.contains(marker))
+}
+
+async fn persist_run_retry_event_message(
+    pool: &SqlitePool,
+    thread_id: &str,
+    previous_run_id: &str,
+    next_run_id: &str,
+    attempt: usize,
+    max_attempts: usize,
+    delay_ms: u64,
+    reason: &str,
+) -> Result<(), AppError> {
+    let content = format!("正在重试请求（{attempt}/{max_attempts}）…");
+    let metadata = serde_json::json!({
+        "kind": "run_retrying",
+        "attempt": attempt,
+        "maxAttempts": max_attempts,
+        "delayMs": delay_ms,
+        "reason": reason,
+        "previousRunId": previous_run_id,
+        "nextRunId": next_run_id,
+    });
+
+    message_repo::insert(
+        pool,
+        &MessageRecord {
+            id: uuid::Uuid::now_v7().to_string(),
+            thread_id: thread_id.to_string(),
+            run_id: Some(next_run_id.to_string()),
+            role: "system".to_string(),
+            content_markdown: content,
+            parts_json: None,
+            message_type: "run_event".to_string(),
+            status: "completed".to_string(),
+            metadata_json: Some(metadata.to_string()),
+            attachments_json: None,
+            created_at: String::new(),
+        },
+    )
+    .await
 }
 
 async fn mark_thread_run_cancellation_requested(
@@ -825,6 +921,27 @@ impl AgentRunManager {
 
                 // Emit RunRetrying to frontend via the shared broadcast channel
                 let new_run_id = uuid::Uuid::now_v7().to_string();
+                if let Err(e) = persist_run_retry_event_message(
+                    &manager.pool,
+                    &thread_id,
+                    &last_run_id,
+                    &new_run_id,
+                    attempt,
+                    PROVIDER_ERROR_MAX_RETRIES,
+                    delay_ms,
+                    &retry_ctx.error,
+                )
+                .await
+                {
+                    tracing::warn!(
+                        thread_id = %thread_id,
+                        prev_run_id = %last_run_id,
+                        new_run_id = %new_run_id,
+                        attempt,
+                        error = %e,
+                        "failed to persist run retry event message"
+                    );
+                }
                 let _ = frontend_tx.send(ThreadStreamEvent::RunRetrying {
                     run_id: new_run_id.clone(),
                     attempt,

--- a/src-tauri/src/core/agent_run_manager_tests.rs
+++ b/src-tauri/src/core/agent_run_manager_tests.rs
@@ -7,8 +7,9 @@ pub(super) mod tests {
         build_orphaned_run_terminal_event, build_title_model_candidates, build_title_prompt,
         build_title_prompt_from_messages, collapse_whitespace, detect_prior_summary,
         extract_context_summary_block, extract_run_model_refs, extract_run_string,
-        is_terminal_runtime_event, mark_thread_run_cancellation_requested, merge_json_value,
-        normalize_compact_summary, normalize_generated_title, render_compact_summary_history,
+        is_retryable_provider_error, is_terminal_runtime_event,
+        mark_thread_run_cancellation_requested, merge_json_value, normalize_compact_summary,
+        normalize_generated_title, persist_run_retry_event_message, render_compact_summary_history,
         should_complete_reasoning_for_event, sidebar_status_for_runtime_event,
         summary_history_char_budget, terminal_event_status, truncate_chars,
         truncate_chars_keep_tail, truncate_tool_result_head_tail, ActiveRun,
@@ -20,7 +21,10 @@ pub(super) mod tests {
     };
     use crate::ipc::frontend_channels::ThreadStreamEvent;
     use crate::model::thread::{MessageRecord, RunStatus};
+    use crate::persistence::repo::message_repo;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
     use std::collections::HashMap;
+    use std::str::FromStr;
     use tiycore::agent::AgentMessage;
     use tiycore::types::{Message as TiyMessage, UserMessage};
     use tokio::sync::{broadcast, Mutex};
@@ -94,6 +98,51 @@ pub(super) mod tests {
         }
     }
 
+    async fn setup_retry_event_test_pool() -> sqlx::SqlitePool {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("invalid sqlite options")
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to create in-memory pool");
+        crate::persistence::sqlite::run_migrations(&pool)
+            .await
+            .expect("migrations failed");
+
+        sqlx::query(
+            "INSERT INTO workspaces (id, name, path, canonical_path, display_path, is_default, status)
+             VALUES ('workspace-retry', 'Retry Workspace', '/tmp/retry', '/tmp/retry', '/tmp/retry', 0, 'ready')",
+        )
+        .execute(&pool)
+        .await
+        .expect("workspace insert");
+        sqlx::query(
+            "INSERT INTO threads (id, workspace_id, title, status)
+             VALUES ('thread-retry', 'workspace-retry', 'Retry Thread', 'running')",
+        )
+        .execute(&pool)
+        .await
+        .expect("thread insert");
+        sqlx::query(
+            "INSERT INTO thread_runs (id, thread_id, run_mode, status)
+             VALUES ('run-previous', 'thread-retry', 'default', 'failed')",
+        )
+        .execute(&pool)
+        .await
+        .expect("previous run insert");
+        sqlx::query(
+            "INSERT INTO thread_runs (id, thread_id, run_mode, status)
+             VALUES ('run-next', 'thread-retry', 'default', 'running')",
+        )
+        .execute(&pool)
+        .await
+        .expect("next run insert");
+
+        pool
+    }
+
     #[test]
     fn orphaned_run_terminal_event_uses_cancelled_when_user_requested_stop() {
         let cancelled = build_orphaned_run_terminal_event("run-1", true);
@@ -107,6 +156,94 @@ pub(super) mod tests {
             interrupted,
             ThreadStreamEvent::RunInterrupted { ref run_id } if run_id == "run-2"
         ));
+    }
+
+    #[test]
+    fn retryable_provider_error_detects_http_and_transient_network_failures() {
+        let retryable_errors = [
+            "Provider error: Anthropic stream error: HTTP 429 rate limited",
+            "Provider error: upstream HTTP 503 unavailable",
+            "Provider error: Anthropic stream error: error sending request for url (https://www.pomoai.ai/v1/messages)",
+            "Provider error: request timed out while streaming response",
+            "Provider error: connection reset by peer",
+            "Provider error: temporary failure in name resolution",
+            "Provider error: TLS handshake failed with unexpected EOF",
+        ];
+
+        for error in retryable_errors {
+            assert!(
+                is_retryable_provider_error(error),
+                "expected retryable provider error: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn retryable_provider_error_excludes_auth_request_and_context_errors() {
+        let non_retryable_errors = [
+            "Provider error: HTTP 400 bad request",
+            "Provider error: HTTP 401 unauthorized",
+            "Provider error: HTTP 403 forbidden",
+            "Provider error: invalid API key",
+            "Provider error: permission denied",
+            "Provider error: context length exceeded",
+            "Provider error: model not found",
+            "Provider error: invalid request: unsupported tool schema",
+        ];
+
+        for error in non_retryable_errors {
+            assert!(
+                !is_retryable_provider_error(error),
+                "expected non-retryable provider error: {error}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn persist_run_retry_event_message_writes_structured_run_event() {
+        let pool = setup_retry_event_test_pool().await;
+
+        persist_run_retry_event_message(
+            &pool,
+            "thread-retry",
+            "run-previous",
+            "run-next",
+            2,
+            5,
+            4000,
+            "Provider error: Anthropic stream error: error sending request for url (https://www.pomoai.ai/v1/messages)",
+        )
+        .await
+        .expect("retry event message persisted");
+
+        let messages = message_repo::list_recent(&pool, "thread-retry", None, 10)
+            .await
+            .expect("messages loaded");
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.thread_id, "thread-retry");
+        assert_eq!(message.run_id.as_deref(), Some("run-next"));
+        assert_eq!(message.role, "system");
+        assert_eq!(message.message_type, "run_event");
+        assert_eq!(message.status, "completed");
+        assert_eq!(message.content_markdown, "正在重试请求（2/5）…");
+
+        let metadata: serde_json::Value = serde_json::from_str(
+            message
+                .metadata_json
+                .as_deref()
+                .expect("metadata should be present"),
+        )
+        .expect("metadata should be valid JSON");
+        assert_eq!(metadata["kind"], "run_retrying");
+        assert_eq!(metadata["attempt"], 2);
+        assert_eq!(metadata["maxAttempts"], 5);
+        assert_eq!(metadata["delayMs"], 4000);
+        assert_eq!(metadata["previousRunId"], "run-previous");
+        assert_eq!(metadata["nextRunId"], "run-next");
+        assert!(metadata["reason"]
+            .as_str()
+            .is_some_and(|reason| reason.contains("error sending request for url")));
     }
 
     #[test]

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -1806,6 +1806,66 @@ Used for prompt assembly coverage.
     }
 
     #[test]
+    fn convert_history_messages_skips_run_event_messages() {
+        let messages = vec![
+            MessageRecord {
+                id: "msg-user".to_string(),
+                thread_id: "thread-1".to_string(),
+                run_id: None,
+                role: "user".to_string(),
+                content_markdown: "Please continue.".to_string(),
+                parts_json: None,
+                message_type: "plain_message".to_string(),
+                status: "completed".to_string(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: String::new(),
+            },
+            MessageRecord {
+                id: "msg-retry".to_string(),
+                thread_id: "thread-1".to_string(),
+                run_id: Some("run-next".to_string()),
+                role: "system".to_string(),
+                content_markdown: "正在重试请求（1/5）…".to_string(),
+                parts_json: None,
+                message_type: "run_event".to_string(),
+                status: "completed".to_string(),
+                metadata_json: Some(
+                    serde_json::json!({
+                        "kind": "run_retrying",
+                        "attempt": 1,
+                        "maxAttempts": 5,
+                        "reason": "Provider error: error sending request for url"
+                    })
+                    .to_string(),
+                ),
+                attachments_json: None,
+                created_at: String::new(),
+            },
+            MessageRecord {
+                id: "msg-assistant".to_string(),
+                thread_id: "thread-1".to_string(),
+                run_id: Some("run-next".to_string()),
+                role: "assistant".to_string(),
+                content_markdown: "Done.".to_string(),
+                parts_json: None,
+                message_type: "plain_message".to_string(),
+                status: "completed".to_string(),
+                metadata_json: None,
+                attachments_json: None,
+                created_at: String::new(),
+            },
+        ];
+
+        let history =
+            convert_history_messages(&messages, &[], &sample_resolved_model_role("primary").model);
+
+        assert_eq!(history.len(), 2);
+        assert_eq!(message_text(&history[0]), "Please continue.");
+        assert_eq!(message_text(&history[1]), "Done.");
+    }
+
+    #[test]
     fn convert_history_messages_uses_effective_prompt_for_command_messages() {
         let messages = vec![MessageRecord {
             id: "msg-command".to_string(),

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-metadata.test.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-metadata.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRunEventMetadata } from "./runtime-thread-surface-metadata";
+
+describe("parseRunEventMetadata", () => {
+  it("parses persisted run retrying metadata", () => {
+    expect(
+      parseRunEventMetadata({
+        kind: "run_retrying",
+        attempt: 2,
+        maxAttempts: 5,
+        delayMs: 4000,
+        reason: "Provider error: error sending request for url",
+        previousRunId: "run-previous",
+        nextRunId: "run-next",
+      }),
+    ).toEqual({
+      kind: "run_retrying",
+      attempt: 2,
+      maxAttempts: 5,
+      delayMs: 4000,
+      reason: "Provider error: error sending request for url",
+      previousRunId: "run-previous",
+      nextRunId: "run-next",
+    });
+  });
+
+  it("returns null for non-object metadata", () => {
+    expect(parseRunEventMetadata(null)).toBeNull();
+    expect(parseRunEventMetadata("run_retrying")).toBeNull();
+  });
+});

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-metadata.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-metadata.ts
@@ -221,6 +221,31 @@ export function parseSummaryMarkerMetadata(value: unknown): {
   };
 }
 
+export function parseRunEventMetadata(value: unknown): {
+  attempt: number | null;
+  delayMs: number | null;
+  kind: string | null;
+  maxAttempts: number | null;
+  nextRunId: string | null;
+  previousRunId: string | null;
+  reason: string | null;
+} | null {
+  const record = asObjectRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  return {
+    attempt: readNumberField(record, "attempt"),
+    delayMs: readNumberField(record, "delayMs"),
+    kind: readStringField(record, "kind"),
+    maxAttempts: readNumberField(record, "maxAttempts"),
+    nextRunId: readStringField(record, "nextRunId"),
+    previousRunId: readStringField(record, "previousRunId"),
+    reason: readStringField(record, "reason"),
+  };
+}
+
 export function parseClarifyPrompt(value: unknown): ClarifyPrompt | null {
   const record = asObjectRecord(value);
   if (!record) {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -148,6 +148,7 @@ import {
   parseApprovalPromptMetadata,
   parseCommandComposerMetadata,
   parseSummaryMarkerMetadata,
+  parseRunEventMetadata,
   parseClarifyPrompt,
   formatPlanMetadata,
 } from "@/modules/workbench-shell/ui/runtime-thread-surface-metadata";
@@ -2460,6 +2461,41 @@ export function RuntimeThreadSurface({
                           </div>
                         </MessageContent>
                       </Message>
+                    </div>
+                  );
+                }
+
+                if (message.messageType === "run_event") {
+                  const runEvent = parseRunEventMetadata(message.metadata);
+                  const isRetryEvent = runEvent?.kind === "run_retrying";
+                  const retryLabel = isRetryEvent && runEvent.attempt !== null && runEvent.maxAttempts !== null
+                    ? t("run.retrying", {
+                        attempt: String(runEvent.attempt),
+                        maxAttempts: String(runEvent.maxAttempts),
+                      })
+                    : message.content;
+                  const delayLabel = isRetryEvent && runEvent.delayMs !== null && runEvent.delayMs > 0
+                    ? `${Math.round(runEvent.delayMs / 1000)}s delay`
+                    : null;
+
+                  return (
+                    <div className={spacingClass} key={entry.key}>
+                      <div className="flex justify-center py-1">
+                        <div className="max-w-[min(720px,100%)] rounded-full border border-app-border/24 bg-app-surface/40 px-3 py-1.5 text-xs text-app-muted shadow-sm">
+                          <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
+                            <RefreshCcwIcon className="size-3.5 text-app-subtle" />
+                            <span>{retryLabel}</span>
+                            {delayLabel ? (
+                              <span className="text-app-subtle">{delayLabel}</span>
+                            ) : null}
+                          </div>
+                          {runEvent?.reason ? (
+                            <div className="mt-1 max-w-[680px] truncate text-center text-[11px] text-app-subtle">
+                              {runEvent.reason}
+                            </div>
+                          ) : null}
+                        </div>
+                      </div>
                     </div>
                   );
                 }

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -273,6 +273,7 @@ export type MessageType =
   | "reasoning"
   | "tool_request"
   | "tool_result"
+  | "run_event"
   | "approval_prompt"
   | "sources"
   | "summary_marker";


### PR DESCRIPTION
## Summary
- Add run-level retries for transient provider network errors without HTTP status codes, including request send failures, timeouts, DNS issues, and connection resets.
- Persist retry attempts as `run_event` messages so retry activity is visible when a thread is reloaded.
- Render persisted retry events in the thread timeline while keeping them out of LLM history.

## Test Plan
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml retryable_provider_error --lib`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml persist_run_retry_event_message --lib`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml convert_history_messages_skips_run_event_messages --lib`
- [x] `npm run typecheck`
- [x] `npm run test:unit -- runtime-thread-surface-metadata`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
