### PR TITLE
feat(agent): ✨ Add tiycore request retry handling

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6179,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.7-rc.0"
+version = "0.2.7-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63135dc660a9316d27586cf91b2236ee310b44a2932ac82f48a66859b1b028df"
+checksum = "dbb18cb3a3612591b1a14e53eab963dfee0ccc23f082518aacd92762b43a6075"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6179,9 +6179,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.7-rc.1"
+version = "0.2.7-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb18cb3a3612591b1a14e53eab963dfee0ccc23f082518aacd92762b43a6075"
+checksum = "39dfd4f92ce069e256ad1c989b49ca013a87329573a4459f0832e49cb5ebc368"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.7-rc.1"
+tiycore = "0.2.7-rc.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,7 +54,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.7-rc.0"
+tiycore = "0.2.7-rc.1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 smappservice-rs = "0.1.3"

--- a/src-tauri/src/commands/git.rs
+++ b/src-tauri/src/commands/git.rs
@@ -15,6 +15,7 @@ use crate::core::app_state::AppState;
 use crate::core::policy_engine::{PolicyEngine, PolicyVerdict};
 use crate::core::tiycode_default_headers;
 use crate::core::tiycode_url_policy;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::ipc::frontend_channels::GitStreamEvent;
 use crate::model::errors::{AppError, ErrorCategory, ErrorSource};
 use crate::model::git::{
@@ -1189,6 +1190,7 @@ async fn generate_with_lite_model(
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         security: Some(tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy())),
+        max_retries: Some(TIYCORE_REQUEST_MAX_RETRIES),
         ..TiyStreamOptions::default()
     };
 

--- a/src-tauri/src/commands/thread.rs
+++ b/src-tauri/src/commands/thread.rs
@@ -22,6 +22,7 @@ use crate::core::agent_session::{
 use crate::core::app_state::AppState;
 use crate::core::tiycode_default_headers;
 use crate::core::tiycode_url_policy;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::thread::{
     AddMessageInput, MessageDto, MessageRecord, ThreadSnapshotDto, ThreadSummaryDto,
@@ -243,6 +244,7 @@ pub async fn thread_regenerate_title(
             security: Some(
                 tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy()),
             ),
+            max_retries: Some(TIYCORE_REQUEST_MAX_RETRIES),
             ..TiyStreamOptions::default()
         };
 

--- a/src-tauri/src/core/agent_run_event_handler.rs
+++ b/src-tauri/src/core/agent_run_event_handler.rs
@@ -119,6 +119,7 @@ pub(crate) fn sidebar_status_for_runtime_event(
     match event {
         ThreadStreamEvent::RunStarted { .. }
         | ThreadStreamEvent::RunRetrying { .. }
+        | ThreadStreamEvent::RequestRetrying { .. }
         | ThreadStreamEvent::ApprovalResolved { .. }
         | ThreadStreamEvent::ClarifyResolved { .. } => Some(RunStatus::Running),
 
@@ -210,6 +211,9 @@ impl AgentRunManager {
                 thread_repo::update_status(&self.pool, &thread_id, &ThreadStatus::Running).await?;
             }
             ThreadStreamEvent::RunRetrying { .. } => {
+                run_repo::update_status(&self.pool, run_id, RunStatus::Running).await?;
+            }
+            ThreadStreamEvent::RequestRetrying { .. } => {
                 run_repo::update_status(&self.pool, run_id, RunStatus::Running).await?;
             }
             ThreadStreamEvent::MessageDelta {
@@ -733,6 +737,7 @@ pub(crate) fn should_complete_reasoning_for_event(event: &ThreadStreamEvent) -> 
         event,
         ThreadStreamEvent::RunStarted { .. }
             | ThreadStreamEvent::RunRetrying { .. }
+            | ThreadStreamEvent::RequestRetrying { .. }
             | ThreadStreamEvent::ReasoningUpdated { .. }
             | ThreadStreamEvent::ThreadUsageUpdated { .. }
             | ThreadStreamEvent::RunCheckpointed { .. }

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -1,6 +1,6 @@
 //! Manages the lifecycle of agent runs backed by the built-in Rust runtime.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -20,7 +20,7 @@ use crate::core::plan_checkpoint::{
 use crate::core::sleep_manager::SleepManager;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
-use crate::model::thread::{MessageAttachmentDto, MessageRecord, RunStatus, ThreadStatus};
+use crate::model::thread::{MessageAttachmentDto, MessageRecord, RunStatus};
 use crate::persistence::repo::{message_repo, run_repo, thread_repo, workspace_repo};
 
 pub(crate) use crate::core::agent_run_event_handler::build_orphaned_run_terminal_event;
@@ -45,13 +45,6 @@ pub(crate) const TITLE_CONTEXT_MAX_CHARS: usize = 1_200;
 /// derived budget collapses to zero.
 pub(crate) const SUMMARY_HISTORY_MIN_CHARS: usize = 8_000;
 pub(crate) const FRONTEND_EVENT_BUFFER_SIZE: usize = 2048;
-
-/// Maximum number of automatic retries for retryable provider errors
-/// (HTTP 408/429/500/502/503/504) at the run level.
-const PROVIDER_ERROR_MAX_RETRIES: usize = 5;
-
-/// Base delay for exponential back-off between run-level retries (2 s).
-const PROVIDER_ERROR_RETRY_BASE_DELAY: Duration = Duration::from_secs(2);
 
 pub(crate) struct ActiveRun {
     pub(crate) run_id: String,
@@ -83,21 +76,6 @@ struct ContextResetMessageBundle {
     persisted_messages: Vec<MessageRecord>,
 }
 
-/// Returned by `spawn_runtime_event_loop` when a run ends with a retryable
-/// provider error so the caller can decide whether to retry.
-struct RetryContext {
-    error: String,
-}
-
-/// Returns `true` when the error string looks like a retryable HTTP server /
-/// rate-limit error. Auth errors (401, 403) are intentionally excluded.
-fn is_retryable_provider_error(error: &str) -> bool {
-    const RETRYABLE_CODES: &[&str] = &[
-        "HTTP 408", "HTTP 429", "HTTP 500", "HTTP 502", "HTTP 503", "HTTP 504",
-    ];
-    RETRYABLE_CODES.iter().any(|code| error.contains(code))
-}
-
 async fn mark_thread_run_cancellation_requested(
     active_runs: &Mutex<HashMap<String, ActiveRun>>,
     thread_id: &str,
@@ -114,9 +92,6 @@ pub struct AgentRunManager {
     pub(crate) runtime: Arc<BuiltInAgentRuntime>,
     pub(crate) sleep_manager: Arc<SleepManager>,
     pub(crate) active_runs: Arc<Mutex<HashMap<String, ActiveRun>>>,
-    /// Thread IDs with an in-progress retry loop that the user has requested to
-    /// cancel.  Checked by `spawn_provider_error_retry_loop` between attempts.
-    retry_cancellations: Arc<Mutex<HashSet<String>>>,
 }
 
 impl AgentRunManager {
@@ -132,7 +107,6 @@ impl AgentRunManager {
             runtime,
             sleep_manager,
             active_runs: Arc::new(Mutex::new(HashMap::new())),
-            retry_cancellations: Arc::new(Mutex::new(HashSet::new())),
         }
     }
 
@@ -195,10 +169,6 @@ impl AgentRunManager {
         let (frontend_tx, frontend_rx) =
             broadcast::channel::<ThreadStreamEvent>(FRONTEND_EVENT_BUFFER_SIZE);
         let run_id = uuid::Uuid::now_v7().to_string();
-
-        // Clear any stale retry-cancellation signal left over from a
-        // previous run so it doesn't suppress retries for the new one.
-        self.retry_cancellations.lock().await.remove(thread_id);
 
         {
             let mut runs = self.active_runs.lock().await;
@@ -302,24 +272,12 @@ impl AgentRunManager {
             let event_loop_handle = self.spawn_runtime_event_loop(run_id.clone(), runtime_rx);
             self.spawn_runtime_finish_watchdog(run_id.clone(), runtime_finish_rx);
 
-            Ok::<_, AppError>((event_loop_handle, frontend_tx.clone()))
+            Ok::<_, AppError>(event_loop_handle)
         }
         .await;
 
         match start_result {
-            Ok((event_loop_handle, frontend_tx)) => {
-                // Spawn background retry wrapper that monitors the event loop
-                // and automatically retries on retryable provider errors.
-                self.spawn_provider_error_retry_loop(
-                    run_id.clone(),
-                    thread_id.to_string(),
-                    workspace_path,
-                    run_mode.to_string(),
-                    model_plan.clone(),
-                    frontend_tx,
-                    event_loop_handle,
-                );
-            }
+            Ok(_event_loop_handle) => {}
             Err(error) => {
                 self.remove_active_run(&run_id).await;
                 return Err(error);
@@ -461,10 +419,6 @@ impl AgentRunManager {
         let Some(run_id) =
             mark_thread_run_cancellation_requested(&self.active_runs, thread_id).await
         else {
-            // No active run — but a retry loop may be sleeping between
-            // attempts. Signal it to stop before the next retry.
-            let mut cancels = self.retry_cancellations.lock().await;
-            cancels.insert(thread_id.to_string());
             return Ok(false);
         };
 
@@ -676,25 +630,10 @@ impl AgentRunManager {
         self: &Arc<Self>,
         run_id: String,
         mut event_rx: mpsc::UnboundedReceiver<ThreadStreamEvent>,
-    ) -> tokio::task::JoinHandle<Option<RetryContext>> {
+    ) -> tokio::task::JoinHandle<()> {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
-            let mut retry_context: Option<RetryContext> = None;
-
             while let Some(event) = event_rx.recv().await {
-                // Capture retryable errors before forwarding to the handler
-                // (which will clean up the run). We only capture the *first*
-                // terminal RunFailed with a retryable error string.
-                if retry_context.is_none() {
-                    if let ThreadStreamEvent::RunFailed { ref error, .. } = event {
-                        if is_retryable_provider_error(error) {
-                            retry_context = Some(RetryContext {
-                                error: error.clone(),
-                            });
-                        }
-                    }
-                }
-
                 if let Err(error) = manager.handle_runtime_event(&run_id, event).await {
                     tracing::error!(run_id = %run_id, error = %error, "failed to handle runtime event");
                 }
@@ -707,8 +646,6 @@ impl AgentRunManager {
                     "failed to reconcile run after runtime event channel closed"
                 );
             }
-
-            retry_context
         })
     }
 
@@ -747,264 +684,6 @@ impl AgentRunManager {
                 );
             }
         });
-    }
-
-    /// Monitors the event loop of the current run and, if it ends with a
-    /// retryable provider error, automatically starts a new run attempt
-    /// (up to `PROVIDER_ERROR_MAX_RETRIES` times) with exponential back-off.
-    ///
-    /// The retry loop reuses the same `frontend_tx` broadcast channel so the
-    /// frontend subscriber receives `RunRetrying` + subsequent `RunStarted`
-    /// events seamlessly.
-    fn spawn_provider_error_retry_loop(
-        self: &Arc<Self>,
-        initial_run_id: String,
-        thread_id: String,
-        workspace_path: String,
-        run_mode: String,
-        model_plan: serde_json::Value,
-        frontend_tx: broadcast::Sender<ThreadStreamEvent>,
-        initial_event_loop_handle: tokio::task::JoinHandle<Option<RetryContext>>,
-    ) {
-        let manager = Arc::clone(self);
-        tokio::spawn(async move {
-            let mut event_loop_handle = initial_event_loop_handle;
-            let mut last_run_id = initial_run_id;
-
-            for attempt in 1..=PROVIDER_ERROR_MAX_RETRIES {
-                // Wait for the current run's event loop to finish.
-                let retry_ctx = match event_loop_handle.await {
-                    Ok(Some(ctx)) => ctx,
-                    // No retryable error or task panicked — stop.
-                    _ => return,
-                };
-
-                // Check whether the run was cancelled — if so, don't retry.
-                // (cancellation_requested is cleared after remove_active_run,
-                // so we check the DB run status instead)
-                if let Ok(Some(status)) =
-                    run_repo::find_status_by_id(&manager.pool, &last_run_id).await
-                {
-                    if status == RunStatus::Cancelled.as_str() {
-                        return;
-                    }
-                }
-
-                // Also check if a cancellation was requested during the gap
-                // between runs (i.e. the user clicked cancel while no ActiveRun
-                // existed). The flag is set by cancel_run_if_active.
-                {
-                    let mut cancels = manager.retry_cancellations.lock().await;
-                    if cancels.remove(&thread_id) {
-                        tracing::info!(
-                            thread_id = %thread_id,
-                            "retry loop cancelled by user between attempts"
-                        );
-                        return;
-                    }
-                }
-
-                // Discard any failed streaming messages left by the previous
-                // run so they don't pollute the LLM history on retry.
-                if let Err(e) =
-                    message_repo::discard_failed_messages_for_run(&manager.pool, &last_run_id).await
-                {
-                    tracing::warn!(
-                        run_id = %last_run_id,
-                        error = %e,
-                        "failed to discard failed messages before retry; aborting retry loop"
-                    );
-                    // Cannot safely retry with polluted history — the LLM
-                    // would see stale partial messages. Abort the retry loop
-                    // entirely; the last RunFailed has already been broadcast.
-                    return;
-                }
-
-                let delay_ms =
-                    PROVIDER_ERROR_RETRY_BASE_DELAY.as_millis() as u64 * (1u64 << (attempt - 1));
-
-                // Emit RunRetrying to frontend via the shared broadcast channel
-                let new_run_id = uuid::Uuid::now_v7().to_string();
-                let _ = frontend_tx.send(ThreadStreamEvent::RunRetrying {
-                    run_id: new_run_id.clone(),
-                    attempt,
-                    max_attempts: PROVIDER_ERROR_MAX_RETRIES,
-                    delay_ms,
-                    reason: retry_ctx.error.clone(),
-                });
-
-                tracing::info!(
-                    thread_id = %thread_id,
-                    prev_run_id = %last_run_id,
-                    new_run_id = %new_run_id,
-                    attempt,
-                    delay_ms,
-                    reason = %retry_ctx.error,
-                    "retrying run after retryable provider error"
-                );
-
-                sleep(Duration::from_millis(delay_ms)).await;
-
-                // Re-check cancellation after the delay — the user may have
-                // requested a cancel while we were sleeping.
-                {
-                    let mut cancels = manager.retry_cancellations.lock().await;
-                    if cancels.remove(&thread_id) {
-                        tracing::info!(
-                            thread_id = %thread_id,
-                            "retry loop cancelled by user during back-off delay"
-                        );
-                        return;
-                    }
-                }
-
-                // Create a new run attempt — reuse the same frontend_tx.
-                let retry_result = manager
-                    .start_retry_run(
-                        &new_run_id,
-                        &thread_id,
-                        &workspace_path,
-                        &run_mode,
-                        &model_plan,
-                        &frontend_tx,
-                    )
-                    .await;
-
-                match retry_result {
-                    Ok(handle) => {
-                        last_run_id = new_run_id;
-                        event_loop_handle = handle;
-                    }
-                    Err(e) => {
-                        tracing::error!(
-                            thread_id = %thread_id,
-                            attempt,
-                            error = %e,
-                            "failed to start retry run"
-                        );
-                        // Emit RunFailed so the frontend can exit the
-                        // "retrying" placeholder state and show the error.
-                        let _ = frontend_tx.send(ThreadStreamEvent::RunFailed {
-                            run_id: new_run_id,
-                            error: format!("Retry failed: {e}"),
-                        });
-                        return;
-                    }
-                }
-            }
-
-            // Exhausted all retries — the last RunFailed has already been emitted
-            // by the event loop, so the frontend will show the error.
-            tracing::warn!(
-                thread_id = %thread_id,
-                last_run_id = %last_run_id,
-                "exhausted all provider error retries"
-            );
-        });
-    }
-
-    /// Creates a new run attempt for the retry loop, reusing the existing
-    /// `frontend_tx` broadcast channel. Returns the event-loop join handle.
-    async fn start_retry_run(
-        self: &Arc<Self>,
-        run_id: &str,
-        thread_id: &str,
-        workspace_path: &str,
-        run_mode: &str,
-        model_plan: &serde_json::Value,
-        frontend_tx: &broadcast::Sender<ThreadStreamEvent>,
-    ) -> Result<tokio::task::JoinHandle<Option<RetryContext>>, AppError> {
-        // Insert new active run entry with the shared broadcast channel.
-        {
-            let mut runs = self.active_runs.lock().await;
-            if runs.values().any(|r| r.thread_id == thread_id) {
-                return Err(AppError::recoverable(
-                    ErrorSource::Thread,
-                    "thread.run.already_active",
-                    "A run is already active for this thread",
-                ));
-            }
-            runs.insert(
-                run_id.to_string(),
-                ActiveRun {
-                    run_id: run_id.to_string(),
-                    thread_id: thread_id.to_string(),
-                    profile_id: None,
-                    frontend_tx: frontend_tx.clone(),
-                    lightweight_model_role: None,
-                    auxiliary_model_role: None,
-                    primary_model_role: None,
-                    streaming_message_id: None,
-                    last_completed_message_id: None,
-                    reasoning_message_id: None,
-                    cancellation_requested: false,
-                },
-            );
-        }
-        self.sleep_manager.set_has_active_runs(true).await;
-
-        let inner = async {
-            // Update thread status back to running
-            thread_repo::update_status(&self.pool, thread_id, &ThreadStatus::Running).await?;
-
-            // Insert a new run record
-            run_repo::insert(
-                &self.pool,
-                &run_repo::RunInsert {
-                    id: run_id.to_string(),
-                    thread_id: thread_id.to_string(),
-                    profile_id: None,
-                    run_mode: run_mode.to_string(),
-                    provider_id: None,
-                    model_id: None,
-                    effective_model_plan_json: Some(model_plan.to_string()),
-                    status: "created".to_string(),
-                },
-            )
-            .await?;
-
-            // Build session spec from current DB state (failed messages are now
-            // discarded, so the history is clean).
-            let spec = build_session_spec(
-                &self.pool,
-                run_id,
-                thread_id,
-                workspace_path,
-                run_mode,
-                model_plan,
-            )
-            .await?;
-
-            {
-                let mut runs = self.active_runs.lock().await;
-                if let Some(run) = runs.get_mut(run_id) {
-                    run.lightweight_model_role = spec.model_plan.lightweight.clone();
-                    run.auxiliary_model_role = spec.model_plan.auxiliary.clone();
-                    run.primary_model_role = Some(spec.model_plan.primary.clone());
-                }
-            }
-
-            let (runtime_tx, runtime_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-            let runtime_finish_rx = self
-                .runtime
-                .start_session(spec, runtime_tx, Arc::clone(&self.active_runs))
-                .await?;
-            let event_loop_handle = self.spawn_runtime_event_loop(run_id.to_string(), runtime_rx);
-            self.spawn_runtime_finish_watchdog(run_id.to_string(), runtime_finish_rx);
-
-            Ok::<_, AppError>(event_loop_handle)
-        }
-        .await;
-
-        match inner {
-            Ok(handle) => Ok(handle),
-            Err(e) => {
-                // Clean up the ActiveRun we inserted above so the thread is not
-                // permanently blocked from starting future runs.
-                self.remove_active_run(run_id).await;
-                Err(e)
-            }
-        }
     }
 
     pub(crate) async fn get_thread_id(&self, run_id: &str) -> String {

--- a/src-tauri/src/core/agent_run_manager_tests.rs
+++ b/src-tauri/src/core/agent_run_manager_tests.rs
@@ -170,6 +170,14 @@ pub(super) mod tests {
                 run_id: "run-1".to_string(),
                 run_mode: "default".to_string(),
             },
+            ThreadStreamEvent::RequestRetrying {
+                run_id: "run-1".to_string(),
+                attempt: 2,
+                max_retries: 5,
+                delay_ms: 750,
+                reason: "stream disconnected".to_string(),
+                status: None,
+            },
             ThreadStreamEvent::MessageDelta {
                 run_id: "run-1".to_string(),
                 message_id: "message-1".to_string(),
@@ -308,6 +316,14 @@ pub(super) mod tests {
             ThreadStreamEvent::RunStarted {
                 run_id: "run-1".to_string(),
                 run_mode: "default".to_string(),
+            },
+            ThreadStreamEvent::RequestRetrying {
+                run_id: "run-1".to_string(),
+                attempt: 1,
+                max_retries: 3,
+                delay_ms: 500,
+                reason: "HTTP 503".to_string(),
+                status: Some(503),
             },
             ThreadStreamEvent::ReasoningUpdated {
                 run_id: "run-1".to_string(),
@@ -1761,6 +1777,14 @@ pub(super) mod tests {
                 max_attempts: 3,
                 delay_ms: 500,
                 reason: "retry".to_string(),
+            },
+            ThreadStreamEvent::RequestRetrying {
+                run_id: "r".to_string(),
+                attempt: 1,
+                max_retries: 3,
+                delay_ms: 500,
+                reason: "HTTP 503".to_string(),
+                status: Some(503),
             },
             ThreadStreamEvent::ApprovalRequired {
                 run_id: "r".to_string(),

--- a/src-tauri/src/core/agent_run_summary.rs
+++ b/src-tauri/src/core/agent_run_summary.rs
@@ -9,6 +9,7 @@ use crate::core::agent_session::{normalize_profile_response_language, ResolvedMo
 use crate::core::plan_checkpoint::{PlanApprovalAction, PlanMessageMetadata};
 use crate::core::tiycode_default_headers;
 use crate::core::tiycode_url_policy;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::thread::MessageRecord;
 
@@ -250,6 +251,7 @@ pub(crate) async fn execute_summary_llm_call(
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         security: Some(tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy())),
+        max_retries: Some(TIYCORE_REQUEST_MAX_RETRIES),
         ..TiyStreamOptions::default()
     };
 

--- a/src-tauri/src/core/agent_run_title.rs
+++ b/src-tauri/src/core/agent_run_title.rs
@@ -13,6 +13,7 @@ use crate::core::agent_session::{
 };
 use crate::core::tiycode_default_headers;
 use crate::core::tiycode_url_policy;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::thread::MessageRecord;
@@ -227,6 +228,7 @@ pub(crate) async fn generate_thread_title(
         headers: Some(tiycode_default_headers()),
         on_payload: build_provider_options_payload_hook(model_role.provider_options.clone()),
         security: Some(tiycore::types::SecurityConfig::default().with_url(tiycode_url_policy())),
+        max_retries: Some(TIYCORE_REQUEST_MAX_RETRIES),
         ..TiyStreamOptions::default()
     };
 

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc;
 use crate::core::prompt;
 use crate::core::subagent::HelperAgentOrchestrator;
 use crate::core::tool_gateway::ToolGateway;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::extensions::ExtensionsManager;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
@@ -155,6 +156,7 @@ impl AgentSession {
                 ContextCompressionRuntimeState::new(spec.initial_context_calibration),
             ));
             agent.set_max_turns(max_turns);
+            agent.set_max_retries(Some(TIYCORE_REQUEST_MAX_RETRIES));
             configure_agent(
                 &agent,
                 &spec,

--- a/src-tauri/src/core/agent_session_events.rs
+++ b/src-tauri/src/core/agent_session_events.rs
@@ -58,6 +58,22 @@ pub(crate) fn handle_agent_event(
                         delta: delta.clone(),
                     });
                 }
+                AssistantMessageEvent::Retrying {
+                    attempt,
+                    max_retries,
+                    delay_ms,
+                    reason,
+                    status,
+                } => {
+                    let _ = event_tx.send(ThreadStreamEvent::RequestRetrying {
+                        run_id: run_id.to_string(),
+                        attempt: *attempt,
+                        max_retries: *max_retries,
+                        delay_ms: *delay_ms,
+                        reason: reason.clone(),
+                        status: *status,
+                    });
+                }
                 AssistantMessageEvent::ThinkingStart { .. } => {
                     reset_reasoning_state(current_reasoning_message_id, reasoning_buffer);
                 }

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -1043,6 +1043,63 @@ Used for prompt assembly coverage.
     }
 
     #[test]
+    fn request_retrying_message_update_emits_request_retry_notice() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let current_message_id = StdMutex::new(None::<String>);
+        let last_completed_message_id = StdMutex::new(None::<String>);
+        let current_reasoning_message_id = StdMutex::new(None::<String>);
+        let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        let reasoning_buffer = StdMutex::new(String::new());
+        let current_turn_index = StdMutex::new(None::<usize>);
+
+        handle_agent_event(
+            "run-request-retry",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &AgentEvent::MessageUpdate {
+                turn_index: 0,
+                message: AgentMessage::Assistant(sample_partial_assistant_message()),
+                assistant_event: Box::new(AssistantMessageEvent::Retrying {
+                    attempt: 2,
+                    max_retries: 5,
+                    delay_ms: 750,
+                    reason: "stream disconnected before completion".to_string(),
+                    status: None,
+                }),
+            },
+        );
+
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        assert!(matches!(
+            events.as_slice(),
+            [ThreadStreamEvent::RequestRetrying {
+                run_id,
+                attempt: 2,
+                max_retries: 5,
+                delay_ms: 750,
+                reason,
+                status: None,
+            }] if run_id == "run-request-retry" && reason.contains("stream disconnected")
+        ));
+        assert!(
+            current_message_id
+                .lock()
+                .expect("current message id lock")
+                .is_none(),
+            "request retrying must not create an assistant message id"
+        );
+    }
+
+    #[test]
     fn message_end_empty_content_no_tool_calls_skips_message_completed() {
         // When a provider error interrupts the stream before any text is
         // generated, MessageEnd arrives with empty text_content() and no

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -38,6 +38,10 @@ pub mod workspace_manager;
 pub mod workspace_paths;
 pub mod worktree_manager;
 
+/// Application-level retry count override for transient LLM requests.
+/// tiycore defaults to 2 when this is not set.
+pub const TIYCORE_REQUEST_MAX_RETRIES: u32 = 5;
+
 /// Returns the default HTTP headers that identify TiyCode in every LLM API request.
 pub fn tiycode_default_headers() -> std::collections::HashMap<String, String> {
     let mut headers = std::collections::HashMap::new();

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -1873,6 +1873,10 @@ mod tests {
             request.options.max_tokens,
             Some(PROVIDER_MODEL_TEST_MIN_MAX_TOKENS)
         );
+        assert_eq!(
+            request.options.max_retries,
+            Some(TIYCORE_REQUEST_MAX_RETRIES)
+        );
         assert_eq!(request.model.max_tokens, 16_384);
         assert_eq!(request.model.context_window, 128_000);
         assert_eq!(

--- a/src-tauri/src/core/settings_manager.rs
+++ b/src-tauri/src/core/settings_manager.rs
@@ -19,6 +19,7 @@ use tiycore::types::{
 };
 
 use crate::core::catalog_model_id_normalizer::NormalizingCatalogMetadataStore;
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::model::provider::{
     AgentProfileInput, AgentProfileRecord, CustomProviderCreateInput, ProviderCatalogEntryDto,
@@ -457,6 +458,7 @@ fn build_provider_model_test_request(
         ),
         on_payload: build_provider_options_payload_hook(model.provider_options_json.as_deref()),
         transport: None,
+        max_retries: Some(TIYCORE_REQUEST_MAX_RETRIES),
         max_retry_delay_ms: None,
         ..TiyStreamOptions::default()
     };

--- a/src-tauri/src/core/subagent/orchestrator.rs
+++ b/src-tauri/src/core/subagent/orchestrator.rs
@@ -16,6 +16,7 @@ use crate::core::subagent::runtime_orchestration::{RuntimeOrchestrationTool, Sub
 use crate::core::tool_gateway::{
     ToolExecutionOptions, ToolExecutionRequest, ToolGateway, ToolGatewayResult,
 };
+use crate::core::TIYCORE_REQUEST_MAX_RETRIES;
 use crate::ipc::frontend_channels::ThreadStreamEvent;
 use crate::model::errors::{AppError, ErrorSource};
 use crate::persistence::repo::{run_helper_repo, tool_call_repo};
@@ -143,6 +144,7 @@ impl HelperAgentOrchestrator {
         let max_turns =
             crate::core::agent_runtime_limits::desktop_agent_max_turns(&self.pool).await;
         agent.set_max_turns(max_turns);
+        agent.set_max_retries(Some(TIYCORE_REQUEST_MAX_RETRIES));
         agent.set_system_prompt(build_helper_system_prompt(
             &request.system_prompt,
             helper_profile,

--- a/src-tauri/src/ipc/frontend_channels.rs
+++ b/src-tauri/src/ipc/frontend_channels.rs
@@ -39,6 +39,15 @@ pub enum ThreadStreamEvent {
         delay_ms: u64,
         reason: String,
     },
+    RequestRetrying {
+        run_id: String,
+        attempt: u32,
+        max_retries: u32,
+        delay_ms: u64,
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        status: Option<u16>,
+    },
     MessageDelta {
         run_id: String,
         message_id: String,

--- a/src-tauri/tests/frontend_integration.rs
+++ b/src-tauri/tests/frontend_integration.rs
@@ -54,6 +54,43 @@ fn test_thread_stream_event_stream_resync_required_serialization() {
 }
 
 #[test]
+fn test_thread_stream_event_request_retrying_serialization() {
+    use tiycode_lib::ipc::frontend_channels::ThreadStreamEvent;
+
+    let event = ThreadStreamEvent::RequestRetrying {
+        run_id: "run-1".into(),
+        attempt: 2,
+        max_retries: 5,
+        delay_ms: 750,
+        reason: "stream disconnected before completion".into(),
+        status: Some(503),
+    };
+
+    let json = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["type"].as_str().unwrap(), "request_retrying");
+    assert_eq!(json["run_id"].as_str().unwrap(), "run-1");
+    assert_eq!(json["attempt"].as_u64().unwrap(), 2);
+    assert_eq!(json["max_retries"].as_u64().unwrap(), 5);
+    assert_eq!(json["delay_ms"].as_u64().unwrap(), 750);
+    assert_eq!(json["status"].as_u64().unwrap(), 503);
+    assert_eq!(
+        json["reason"].as_str().unwrap(),
+        "stream disconnected before completion"
+    );
+
+    let no_status = ThreadStreamEvent::RequestRetrying {
+        run_id: "run-1".into(),
+        attempt: 1,
+        max_retries: 5,
+        delay_ms: 500,
+        reason: "operation timed out".into(),
+        status: None,
+    };
+    let json = serde_json::to_value(&no_status).unwrap();
+    assert!(json.get("status").is_none());
+}
+
+#[test]
 fn test_thread_stream_event_message_delta_serialization() {
     use tiycode_lib::ipc::frontend_channels::ThreadStreamEvent;
 
@@ -357,6 +394,14 @@ fn test_all_events_have_type_field() {
             delay_ms: 500,
             reason: "retry".into(),
         },
+        ThreadStreamEvent::RequestRetrying {
+            run_id: "r".into(),
+            attempt: 1,
+            max_retries: 3,
+            delay_ms: 500,
+            reason: "HTTP 503".into(),
+            status: Some(503),
+        },
         ThreadStreamEvent::MessageDelta {
             run_id: "r".into(),
             message_id: "m".into(),
@@ -515,11 +560,11 @@ fn test_all_events_have_type_field() {
         assert!(!type_val.is_empty(), "Event type should not be empty");
     }
 
-    // Verify total count matches enum variants (29 variants)
+    // Verify total count matches enum variants (30 variants)
     assert_eq!(
         events.len(),
-        29,
-        "Should test all 29 ThreadStreamEvent variants"
+        30,
+        "Should test all 30 ThreadStreamEvent variants"
     );
 }
 

--- a/src-tauri/tests/frontend_integration.rs
+++ b/src-tauri/tests/frontend_integration.rs
@@ -91,6 +91,29 @@ fn test_thread_stream_event_request_retrying_serialization() {
 }
 
 #[test]
+fn test_thread_stream_event_request_retrying_boundary_serialization() {
+    use tiycode_lib::ipc::frontend_channels::ThreadStreamEvent;
+
+    let event = ThreadStreamEvent::RequestRetrying {
+        run_id: "run-1".into(),
+        attempt: 0,
+        max_retries: 0,
+        delay_ms: 0,
+        reason: String::new(),
+        status: Some(0),
+    };
+
+    let json = serde_json::to_value(&event).unwrap();
+    assert_eq!(json["type"].as_str().unwrap(), "request_retrying");
+    assert_eq!(json["run_id"].as_str().unwrap(), "run-1");
+    assert_eq!(json["attempt"].as_u64().unwrap(), 0);
+    assert_eq!(json["max_retries"].as_u64().unwrap(), 0);
+    assert_eq!(json["delay_ms"].as_u64().unwrap(), 0);
+    assert_eq!(json["reason"].as_str().unwrap(), "");
+    assert_eq!(json["status"].as_u64().unwrap(), 0);
+}
+
+#[test]
 fn test_thread_stream_event_message_delta_serialization() {
     use tiycode_lib::ipc::frontend_channels::ThreadStreamEvent;
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -801,7 +801,10 @@ const en: Record<TranslationKey, string> = {
   "worktree.field.selectBranchHint": "Check out this existing branch into a new worktree",
   "worktree.error.selectBranch": "Please select a branch",
   "contextCompressing": "Compressing context…",
-  "run.retrying": "Server error, retry {{attempt}} of {{maxAttempts}}…",
+  "run.retrying": "Regenerating response… {{attempt}}/{{maxAttempts}}",
+  "requestRetry.reconnecting": "Reconnecting… {{attempt}}/{{maxRetries}}",
+  "requestRetry.status": "HTTP {{status}}",
+  "requestRetry.delay": "Retrying in {{seconds}}s",
 
   // ── Artifact Card ─────────────────────────────────────────
   "artifact.collapseCode": "Collapse code",

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -848,6 +848,8 @@ const en: Record<TranslationKey, string> = {
   "fileEditor.htmlPreview": "HTML Preview",
   "fileEditor.editor": "Editor",
   "fileEditor.preview": "Preview",
+  "fileEditor.refresh": "Refresh preview from disk",
+  "fileEditor.refreshDisabledDirty": "Save changes before refreshing",
   "fileEditor.closePreview": "Close preview",
   "fileEditor.binaryFile": "Binary file — cannot edit",
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -886,6 +886,8 @@ const zhCN = {
   "fileEditor.htmlPreview": "HTML 预览",
   "fileEditor.editor": "编辑器",
   "fileEditor.preview": "预览",
+  "fileEditor.refresh": "从磁盘刷新预览",
+  "fileEditor.refreshDisabledDirty": "请先保存修改再刷新",
   "fileEditor.closePreview": "关闭预览",
   "fileEditor.binaryFile": "二进制文件 — 无法编辑",
 

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -839,7 +839,10 @@ const zhCN = {
   "worktree.field.selectBranchHint": "将检出此已有分支到新 worktree",
   "worktree.error.selectBranch": "请选择一个分支",
   "contextCompressing": "正在压缩上下文…",
-  "run.retrying": "服务端错误，第 {{attempt}} 次重试中…",
+  "run.retrying": "正在重新生成当前回复… {{attempt}}/{{maxAttempts}}",
+  "requestRetry.reconnecting": "正在重新连接… {{attempt}}/{{maxRetries}}",
+  "requestRetry.status": "HTTP {{status}}",
+  "requestRetry.delay": "{{seconds}} 秒后重试",
 
   // ── Artifact Card ─────────────────────────────────────────
   "artifact.collapseCode": "收起代码",

--- a/src/modules/workbench-shell/model/run-lifecycle-machine.test.ts
+++ b/src/modules/workbench-shell/model/run-lifecycle-machine.test.ts
@@ -280,6 +280,7 @@ describe("mapStreamEventToMachineEvent", () => {
 
   it("returns null for non-lifecycle events", () => {
     expect(mapStreamEventToMachineEvent("message_delta")).toBeNull();
+    expect(mapStreamEventToMachineEvent("request_retrying")).toBeNull();
     expect(mapStreamEventToMachineEvent("tool_requested")).toBeNull();
     expect(mapStreamEventToMachineEvent("reasoning_updated")).toBeNull();
     expect(mapStreamEventToMachineEvent("unknown_event")).toBeNull();

--- a/src/modules/workbench-shell/model/status-mappings.ts
+++ b/src/modules/workbench-shell/model/status-mappings.ts
@@ -95,6 +95,8 @@ export function streamEventToMachineEvent(
       return "CLARIFY_RESOLVED";
     case "run_retrying":
       return "RUN_RETRYING";
+    case "request_retrying":
+      return null;
     case "run_completed":
       return "RUN_COMPLETED";
     case "run_failed":

--- a/src/modules/workbench-shell/ui/file-editor-view.tsx
+++ b/src/modules/workbench-shell/ui/file-editor-view.tsx
@@ -13,7 +13,7 @@ import { rust } from "@codemirror/lang-rust";
 import { python } from "@codemirror/lang-python";
 import { keymap } from "@codemirror/view";
 import type { ViewUpdate } from "@codemirror/view";
-import { X, Eye, Code2, Save, Loader2, AlertCircle } from "lucide-react";
+import { X, Eye, Code2, Save, Loader2, AlertCircle, RefreshCw } from "lucide-react";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { cn } from "@/shared/lib/utils";
 import { useT } from "@/i18n";
@@ -451,6 +451,16 @@ const EditorToolbar: FC<ToolbarProps> = ({ tab }) => {
         )}
       </div>
       <div className="flex items-center gap-1">
+        <button
+          title={tab.isDirty ? t("fileEditor.refreshDisabledDirty") : t("fileEditor.refresh")}
+          className="rounded p-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:cursor-not-allowed disabled:opacity-45 disabled:hover:text-muted-foreground"
+          disabled={tab.isDirty || tab.isLoading}
+          onClick={() => {
+            void reloadTab(tab.workspaceId, tab.path);
+          }}
+        >
+          <RefreshCw className={cn("size-3.5", tab.isLoading && "animate-spin")} />
+        </button>
         {tab.isDirty && (
           <button
             title={t("fileEditor.saveShortcut")}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.test.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { compareTimelineEntries, type TimelineEntry } from "./runtime-thread-surface-state";
+
+const occurredAt = "2026-05-19T00:00:00.000Z";
+
+type EntryLabel = "user" | "reasoning" | "assistant" | "helper" | "request_retry" | "tool";
+
+function makeMessageEntry(label: "user" | "reasoning" | "assistant"): TimelineEntry {
+  const role = label === "user" ? "user" : "assistant";
+  const messageType = label === "reasoning" ? "reasoning" : "plain_message";
+
+  return {
+    kind: "message",
+    key: `message:${label}`,
+    occurredAt,
+    message: {
+      attachments: [],
+      content: label,
+      createdAt: occurredAt,
+      id: label,
+      messageType,
+      parts: [{ type: "text", text: label }],
+      role,
+      runId: role === "user" ? null : "run-1",
+      status: "completed",
+    },
+  };
+}
+
+function makeEntry(kind: EntryLabel): TimelineEntry {
+  switch (kind) {
+    case "user":
+    case "reasoning":
+    case "assistant":
+      return makeMessageEntry(kind);
+    case "helper":
+      return {
+        kind: "helper",
+        key: "helper:helper-1",
+        occurredAt,
+        helper: {
+          completedSteps: 0,
+          currentAction: null,
+          finishedAt: null,
+          id: "helper-1",
+          inputSummary: null,
+          kind: "helper_explore",
+          latestMessage: undefined,
+          recentActions: [],
+          runId: "run-1",
+          startedAt: occurredAt,
+          status: "running",
+          summary: null,
+          toolCounts: {},
+          totalToolCalls: 0,
+        },
+      };
+    case "request_retry":
+      return {
+        kind: "request_retry",
+        key: "request-retry:run-1",
+        occurredAt,
+        requestRetry: {
+          attempt: 2,
+          createdAt: occurredAt,
+          delayMs: 750,
+          id: "request-retry-run-1",
+          maxRetries: 5,
+          reason: "stream disconnected",
+          runId: "run-1",
+          status: null,
+          updatedAt: occurredAt,
+        },
+      };
+    case "tool":
+      return {
+        kind: "tool",
+        key: "tool:tool-1",
+        occurredAt,
+        tool: {
+          id: "tool-1",
+          name: "read",
+          runId: "run-1",
+          startedAt: occurredAt,
+          state: "input-streaming",
+        },
+      };
+  }
+}
+
+function labelEntry(entry: TimelineEntry) {
+  if (entry.kind === "message") {
+    return entry.message.messageType === "reasoning" ? "reasoning" : entry.message.role;
+  }
+  return entry.kind;
+}
+
+describe("compareTimelineEntries", () => {
+  it("orders request retry between helper and tool for matching timestamps", () => {
+    const entries = [
+      makeEntry("assistant"),
+      makeEntry("tool"),
+      makeEntry("request_retry"),
+      makeEntry("helper"),
+      makeEntry("reasoning"),
+      makeEntry("user"),
+    ];
+
+    expect(entries.sort(compareTimelineEntries).map(labelEntry)).toEqual([
+      "user",
+      "reasoning",
+      "helper",
+      "request_retry",
+      "assistant",
+      "tool",
+    ]);
+  });
+});

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -98,12 +98,30 @@ export type SurfaceToolEntry = {
 
 export type SurfaceHelperEntry = RuntimeSurfaceHelperEntry;
 
+export type SurfaceRequestRetryEntry = {
+  createdAt: string;
+  delayMs: number;
+  id: string;
+  maxRetries: number;
+  attempt: number;
+  reason: string;
+  runId: string;
+  status: number | null;
+  updatedAt: string;
+};
+
 export type TimelineEntry =
   | {
       kind: "message";
       key: string;
       occurredAt: string;
       message: SurfaceMessage;
+    }
+  | {
+      kind: "request_retry";
+      key: string;
+      occurredAt: string;
+      requestRetry: SurfaceRequestRetryEntry;
     }
   | {
       kind: "tool";
@@ -849,8 +867,10 @@ function getTimelineEntryKindOrder(entry: TimelineEntry) {
       return 5;
     case "helper":
       return 3;
-    case "tool":
+    case "request_retry":
       return 4;
+    case "tool":
+      return 5;
   }
 }
 

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -808,8 +808,8 @@ export function RuntimeThreadSurface({
         finalizeReasoningForRun(event.runId);
       }
 
-      // Show retry progress in the thinking placeholder when the backend
-      // is automatically retrying after a retryable provider error.
+      // Show retry progress in the thinking placeholder for turn-level
+      // retries emitted by tiycore as AgentEvent::TurnRetrying.
       if (event.type === "run_retrying") {
         showThinkingPlaceholder(
           event.runId,

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChatStatus } from "ai";
-import { AlertCircleIcon, BotIcon, Info, RefreshCcwIcon, SparklesIcon, WrenchIcon } from "lucide-react";
+import { AlertCircleIcon, BotIcon, ChevronDownIcon, Info, RefreshCcwIcon, SparklesIcon, WrenchIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useT } from "@/i18n";
@@ -135,6 +135,7 @@ import {
   updateTool,
   type SurfaceHelperEntry,
   type SurfaceMessage,
+  type SurfaceRequestRetryEntry,
   type SurfaceRuntimeError,
   type SurfaceToolEntry,
   type SurfaceToolState,
@@ -280,6 +281,8 @@ export function RuntimeThreadSurface({
   const [loadError, setLoadError] = useState<string | null>(null);
   const [messages, setMessages] = useState<Array<SurfaceMessage>>([]);
   const [queueArtifact, setQueueArtifact] = useState<unknown>(null);
+  const [requestRetryEntries, setRequestRetryEntries] = useState<Array<SurfaceRequestRetryEntry>>([]);
+  const [requestRetryOpen, setRequestRetryOpen] = useState<Record<string, boolean>>({});
   const [runtimeError, setRuntimeError] = useState<SurfaceRuntimeError | null>(null);
   const runState = useStore(
     threadStore,
@@ -296,6 +299,8 @@ export function RuntimeThreadSurface({
     if (prevThreadIdRef.current !== threadId) {
       prevThreadIdRef.current = threadId;
       setSelectedRunMode("default");
+      setRequestRetryEntries([]);
+      setRequestRetryOpen({});
       wrapperRefsMap.current.clear();
       userManuallyOpenedIds.current.clear();
     }
@@ -814,6 +819,34 @@ export function RuntimeThreadSurface({
             maxAttempts: String(event.maxAttempts),
           }),
         );
+      }
+
+      if (event.type === "request_retrying") {
+        const now = new Date().toISOString();
+        setRequestRetryEntries((current) => {
+          const existing = current.find((entry) => entry.runId === event.runId);
+          const nextEntry: SurfaceRequestRetryEntry = {
+            createdAt: existing?.createdAt ?? now,
+            delayMs: event.delayMs,
+            id: existing?.id ?? `request-retry-${event.runId}`,
+            maxRetries: event.maxRetries,
+            attempt: event.attempt,
+            reason: event.reason,
+            runId: event.runId,
+            status: event.status,
+            updatedAt: now,
+          };
+
+          if (existing) {
+            return current.map((entry) => entry.runId === event.runId ? nextEntry : entry);
+          }
+
+          return [...current, nextEntry];
+        });
+        setRequestRetryOpen((current) => ({
+          ...current,
+          [`request-retry-${event.runId}`]: event.attempt > 1,
+        }));
       }
 
       if (event.type === "run_started") {
@@ -1565,6 +1598,7 @@ export function RuntimeThreadSurface({
   const hasRuntimeArtifacts =
     Boolean(runtimeError)
     || Boolean(queueArtifact)
+    || requestRetryEntries.length > 0
     || helpers.length > 0
     || visibleTools.length > 0
     || Boolean(taskBoards.activeBoard);
@@ -1583,6 +1617,12 @@ export function RuntimeThreadSurface({
           occurredAt: helper.startedAt,
           helper,
         })),
+        ...requestRetryEntries.map((requestRetry) => ({
+          kind: "request_retry" as const,
+          key: `request-retry:${requestRetry.id}`,
+          occurredAt: requestRetry.createdAt,
+          requestRetry,
+        })),
         ...visibleTools.map((tool) => ({
           kind: "tool" as const,
           key: `tool:${tool.id}`,
@@ -1590,7 +1630,7 @@ export function RuntimeThreadSurface({
           tool,
         })),
       ].sort(compareTimelineEntries),
-    [helpers, messages, visibleTools],
+    [helpers, messages, requestRetryEntries, visibleTools],
   );
   const presentationEntries = timelineEntries;
 
@@ -1630,6 +1670,9 @@ export function RuntimeThreadSurface({
         const isCompleted = entry.helper.status === "completed";
         const isOpen = helperOpen[entry.helper.id] ?? true;
         result.push({ id: entry.helper.id, completed: isCompleted, currentOpen: isOpen });
+      } else if (entry.kind === "request_retry") {
+        const isOpen = requestRetryOpen[entry.requestRetry.id] ?? entry.requestRetry.attempt > 1;
+        result.push({ id: entry.requestRetry.id, completed: true, currentOpen: isOpen });
       } else if (entry.kind === "message" && entry.message.messageType === "reasoning") {
         const isCompleted = entry.message.status !== "streaming";
         const isOpen = reasoningOpen[entry.message.id] ?? true;
@@ -1637,19 +1680,20 @@ export function RuntimeThreadSurface({
       }
     }
     return result;
-  }, [presentationEntries, completedToolOpen, helperOpen, reasoningOpen]);
+  }, [presentationEntries, completedToolOpen, helperOpen, requestRetryOpen, reasoningOpen]);
 
   // Keep a ref to presentationEntries for the viewport collapse callback.
   const presentationEntriesRef = useRef(presentationEntries);
   presentationEntriesRef.current = presentationEntries;
 
   const handleViewportCollapse = useCallback((id: string) => {
-    // Determine whether this id belongs to a tool, helper, or reasoning
+    // Determine whether this id belongs to a tool, helper, request retry, or reasoning
     // and only update the relevant state map.
     const entry = presentationEntriesRef.current.find(
       (e) =>
         (e.kind === "tool" && e.tool.id === id)
         || (e.kind === "helper" && e.helper.id === id)
+        || (e.kind === "request_retry" && e.requestRetry.id === id)
         || (e.kind === "message" && e.message.messageType === "reasoning" && e.message.id === id),
     );
     if (!entry) return;
@@ -1657,6 +1701,8 @@ export function RuntimeThreadSurface({
       setCompletedToolOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
     } else if (entry.kind === "helper") {
       setHelperOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
+    } else if (entry.kind === "request_retry") {
+      setRequestRetryOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
     } else {
       setReasoningOpen((current) => (current[id] === false ? current : { ...current, [id]: false }));
     }
@@ -2696,6 +2742,62 @@ export function RuntimeThreadSurface({
                             );
                           })()
                         )}
+                      </MessageContent>
+                    </Message>
+                  </div>
+                );
+              }
+
+              if (entry.kind === "request_retry") {
+                const { requestRetry } = entry;
+                const open = requestRetryOpen[requestRetry.id] ?? requestRetry.attempt > 1;
+                const detailParts = [
+                  requestRetry.status !== null
+                    ? t("requestRetry.status", { status: String(requestRetry.status) })
+                    : null,
+                  requestRetry.delayMs > 0
+                    ? t("requestRetry.delay", { seconds: (requestRetry.delayMs / 1000).toFixed(1) })
+                    : null,
+                ].filter(Boolean).join(" · ");
+
+                return (
+                  <div className={spacingClass} key={entry.key}>
+                    <Message className="max-w-full" from="assistant">
+                      <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
+                        <div className="text-app-muted">
+                          <button
+                            aria-expanded={open}
+                            className="group inline-flex max-w-full items-center gap-2 text-left text-2xl font-light leading-8 tracking-[-0.02em] text-app-muted/80 transition-colors hover:text-app-foreground"
+                            onClick={() => {
+                              setRequestRetryOpen((current) => ({
+                                ...current,
+                                [requestRetry.id]: !(current[requestRetry.id] ?? requestRetry.attempt > 1),
+                              }));
+                            }}
+                            type="button"
+                          >
+                            <span className="truncate">
+                              {t("requestRetry.reconnecting", {
+                                attempt: String(requestRetry.attempt),
+                                maxRetries: String(requestRetry.maxRetries),
+                              })}
+                            </span>
+                            <ChevronDownIcon
+                              className={cn(
+                                "mt-1 size-5 shrink-0 transition-transform text-app-muted/70",
+                                open ? "rotate-180" : "rotate-0",
+                              )}
+                            />
+                          </button>
+                          {open ? (
+                            <div className="mt-4 max-w-3xl space-y-2 text-2xl font-light leading-9 tracking-[-0.02em] text-app-muted/80">
+                              <p className="whitespace-pre-wrap break-words">{requestRetry.reason}</p>
+                              {detailParts ? (
+                                <p className="text-sm leading-5 text-app-subtle">{detailParts}</p>
+                              ) : null}
+                            </div>
+                          ) : null}
+                        </div>
                       </MessageContent>
                     </Message>
                   </div>

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -2767,7 +2767,7 @@ export function RuntimeThreadSurface({
                         <div className="text-app-muted">
                           <button
                             aria-expanded={open}
-                            className="group inline-flex max-w-full items-center gap-2 text-left text-2xl font-light leading-8 tracking-[-0.02em] text-app-muted/80 transition-colors hover:text-app-foreground"
+                            className="group inline-flex max-w-full items-center gap-2 text-left text-sm font-medium leading-5 text-app-muted transition-colors hover:text-app-foreground"
                             onClick={() => {
                               setRequestRetryOpen((current) => ({
                                 ...current,
@@ -2790,7 +2790,7 @@ export function RuntimeThreadSurface({
                             />
                           </button>
                           {open ? (
-                            <div className="mt-4 max-w-3xl space-y-2 text-2xl font-light leading-9 tracking-[-0.02em] text-app-muted/80">
+                            <div className="mt-2 max-w-3xl space-y-2 text-sm leading-6 text-app-muted">
                               <p className="whitespace-pre-wrap break-words">{requestRetry.reason}</p>
                               {detailParts ? (
                                 <p className="text-sm leading-5 text-app-subtle">{detailParts}</p>

--- a/src/services/bridge/agent-commands.test.ts
+++ b/src/services/bridge/agent-commands.test.ts
@@ -142,4 +142,18 @@ describe("normalizeThreadStreamEvent request_retrying", () => {
 
     expect(result.status).toBeNull();
   });
+
+  it("normalizes malformed request_retrying status to null", () => {
+    const result = normalizeThreadStreamEvent({
+      type: "request_retrying",
+      runId: "run-1",
+      attempt: 1,
+      maxRetries: 3,
+      delayMs: 500,
+      reason: "operation timed out",
+      status: "not-a-number",
+    }) as Extract<ThreadStreamEvent, { type: "request_retrying" }>;
+
+    expect(result.status).toBeNull();
+  });
 });

--- a/src/services/bridge/agent-commands.test.ts
+++ b/src/services/bridge/agent-commands.test.ts
@@ -106,3 +106,40 @@ describe("normalizeThreadStreamEvent artifact_updated", () => {
     warnSpy.mockRestore();
   });
 });
+
+describe("normalizeThreadStreamEvent request_retrying", () => {
+  it("normalizes request_retrying with snake_case retry fields", () => {
+    const result = normalizeThreadStreamEvent({
+      type: "request_retrying",
+      run_id: "run-1",
+      attempt: 2,
+      max_retries: 5,
+      delay_ms: 750,
+      reason: "stream disconnected",
+      status: 503,
+    }) as Extract<ThreadStreamEvent, { type: "request_retrying" }>;
+
+    expect(result).toEqual({
+      type: "request_retrying",
+      runId: "run-1",
+      attempt: 2,
+      maxRetries: 5,
+      delayMs: 750,
+      reason: "stream disconnected",
+      status: 503,
+    });
+  });
+
+  it("normalizes missing request_retrying status to null", () => {
+    const result = normalizeThreadStreamEvent({
+      type: "request_retrying",
+      runId: "run-1",
+      attempt: 1,
+      maxRetries: 3,
+      delayMs: 500,
+      reason: "operation timed out",
+    }) as Extract<ThreadStreamEvent, { type: "request_retrying" }>;
+
+    expect(result.status).toBeNull();
+  });
+});

--- a/src/services/bridge/agent-commands.ts
+++ b/src/services/bridge/agent-commands.ts
@@ -94,6 +94,18 @@ function readValue(
   return event[camelKey] ?? event[snakeKey];
 }
 
+function readNumberOrNull(
+  event: RawThreadStreamEvent,
+  camelKey: string,
+  snakeKey: string,
+) {
+  const value = event[camelKey] ?? event[snakeKey];
+  if (value == null) {
+    return null;
+  }
+  return Number(value);
+}
+
 function readSnapshot(
   event: RawThreadStreamEvent,
   camelKey: string,
@@ -200,6 +212,16 @@ export function normalizeThreadStreamEvent(rawEvent: RawThreadStreamEvent): Thre
         maxAttempts: Number(readValue(rawEvent, "maxAttempts", "max_attempts") ?? 0),
         delayMs: Number(readValue(rawEvent, "delayMs", "delay_ms") ?? 0),
         reason: readRequiredString(rawEvent, "reason", "reason"),
+      };
+    case "request_retrying":
+      return {
+        type: rawEvent.type,
+        runId: readRequiredString(rawEvent, "runId", "run_id"),
+        attempt: Number(readValue(rawEvent, "attempt", "attempt") ?? 0),
+        maxRetries: Number(readValue(rawEvent, "maxRetries", "max_retries") ?? 0),
+        delayMs: Number(readValue(rawEvent, "delayMs", "delay_ms") ?? 0),
+        reason: readRequiredString(rawEvent, "reason", "reason"),
+        status: readNumberOrNull(rawEvent, "status", "status"),
       };
     case "message_delta":
       return {

--- a/src/services/bridge/agent-commands.ts
+++ b/src/services/bridge/agent-commands.ts
@@ -103,7 +103,8 @@ function readNumberOrNull(
   if (value == null) {
     return null;
   }
-  return Number(value);
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
 }
 
 function readSnapshot(

--- a/src/services/thread-stream/thread-stream.test.ts
+++ b/src/services/thread-stream/thread-stream.test.ts
@@ -426,6 +426,20 @@ describe("ThreadStream uncovered events", () => {
     expect(stream.runId).toBe("run-1");
   });
 
+  it("routes request_retrying events", async () => {
+    const stream = new ThreadStream();
+    const onRunStateChange = vi.fn();
+    stream.onRunStateChange = onRunStateChange;
+
+    threadStartRunMock.mockImplementationOnce(emit([
+      { type: "request_retrying", runId: "run-1", attempt: 2, maxRetries: 5, delayMs: 750, reason: "stream disconnected", status: null },
+    ]));
+
+    await stream.startRun("thread-1", { prompt: "hi" });
+    expect(onRunStateChange).toHaveBeenCalledWith("running", "run-1");
+    expect(stream.runId).toBe("run-1");
+  });
+
   it.each(terminalRunEvents)("clears run caches for $type events", async (terminalEvent) => {
     const stream = new ThreadStream();
     const onToolEvent = vi.fn();

--- a/src/services/thread-stream/thread-stream.ts
+++ b/src/services/thread-stream/thread-stream.ts
@@ -440,6 +440,11 @@ export class ThreadStream {
         this.onRunStateChange?.("running", event.runId);
         break;
 
+      case "request_retrying":
+        this.currentRunId = event.runId;
+        this.onRunStateChange?.("running", event.runId);
+        break;
+
       case "message_delta":
         this.onMessage?.({
           kind: "delta",

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -474,6 +474,15 @@ export type ThreadStreamEvent =
       delayMs: number;
       reason: string;
     }
+  | {
+      type: "request_retrying";
+      runId: string;
+      attempt: number;
+      maxRetries: number;
+      delayMs: number;
+      reason: string;
+      status: number | null;
+    }
   | { type: "message_delta"; runId: string; messageId: string; delta: string }
   | {
       type: "artifact_updated";


### PR DESCRIPTION
## Summary
- Upgrade `tiycore` to `0.2.7-rc.1` and surface protocol-level `request_retrying` events from `AssistantMessageEvent::Retrying`.
- Remove TiyCode's run-level provider error retry loop so retry behavior is driven by tiycore events instead of creating new runs.
- Add independent thread timeline UI for `Reconnecting… x/y` with expandable retry reasons, without mixing with DISCARDED message UI.

## Test Plan
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml`
- [ ] Manually smoke test HTTP 429/503 and timeout retry presentation in the desktop app

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
