### PR TITLE
fix(prompt-input): 🐛 Deduplicate pasted image attachments

### DIFF
--- a/src/components/ai-elements/prompt-input.test.ts
+++ b/src/components/ai-elements/prompt-input.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createAttachmentFileBatchKey,
+  dedupeAttachmentFileBatch,
+  dedupePastedAttachmentFileBatch,
+  shouldIgnoreDuplicatePasteBatch,
+} from "./prompt-input";
+
+const createFile = ({
+  lastModified = 1,
+  name,
+  size,
+  type,
+}: {
+  lastModified?: number;
+  name: string;
+  size: number;
+  type: string;
+}) =>
+  new File([new Uint8Array(size)], name, {
+    lastModified,
+    type,
+  });
+
+describe("prompt input attachment paste dedupe", () => {
+  it("keeps only the first pasted image flavor from one clipboard batch", () => {
+    const png = createFile({ name: "image.png", size: 12, type: "image/png" });
+    const tiff = createFile({ name: "image.tiff", size: 24, type: "image/tiff" });
+    const text = createFile({ name: "notes.txt", size: 8, type: "text/plain" });
+
+    expect(dedupePastedAttachmentFileBatch([png, tiff, text])).toEqual([png, text]);
+  });
+
+  it("treats empty-type generic clipboard image entries as duplicate image flavors", () => {
+    const emptyType = createFile({ name: "image", size: 10, type: "" });
+    const png = createFile({ name: "image.png", size: 12, type: "image/png" });
+
+    expect(dedupePastedAttachmentFileBatch([emptyType, png])).toEqual([
+      emptyType,
+    ]);
+    expect(dedupePastedAttachmentFileBatch([png, emptyType])).toEqual([png]);
+  });
+
+  it("keeps distinct pasted image files that do not look like alternate clipboard flavors", () => {
+    const first = createFile({ name: "first.png", size: 12, type: "image/png" });
+    const second = createFile({ name: "second.png", size: 16, type: "image/png" });
+
+    expect(dedupePastedAttachmentFileBatch([first, second])).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it("deduplicates repeated files in generic attachment batches without dropping distinct images", () => {
+    const first = createFile({ name: "a.png", size: 12, type: "image/png" });
+    const duplicate = createFile({ name: "a.png", size: 12, type: "image/png" });
+    const second = createFile({ name: "b.png", size: 16, type: "image/png" });
+
+    expect(dedupeAttachmentFileBatch([first, duplicate, second])).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it("detects duplicate paste batches only inside the short guard window", () => {
+    const file = createFile({ name: "image.png", size: 12, type: "image/png" });
+    const batchKey = createAttachmentFileBatchKey([file]);
+    const lastBatch = { key: batchKey, timestamp: 1_000 };
+
+    expect(
+      shouldIgnoreDuplicatePasteBatch({ batchKey, lastBatch, now: 1_500 })
+    ).toBe(true);
+    expect(
+      shouldIgnoreDuplicatePasteBatch({ batchKey, lastBatch, now: 2_000 })
+    ).toBe(false);
+    expect(
+      shouldIgnoreDuplicatePasteBatch({
+        batchKey: `${batchKey}-next`,
+        lastBatch,
+        now: 1_500,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/components/ai-elements/prompt-input.test.ts
+++ b/src/components/ai-elements/prompt-input.test.ts
@@ -63,6 +63,16 @@ describe("prompt input attachment paste dedupe", () => {
     ]);
   });
 
+  it("does not deduplicate files whose old pipe-joined fingerprints would collide", () => {
+    const first = createFile({ name: "a|b", size: 12, type: "c" });
+    const second = createFile({ name: "a", size: 12, type: "b|c" });
+
+    expect(dedupeAttachmentFileBatch([first, second])).toEqual([
+      first,
+      second,
+    ]);
+  });
+
   it("detects duplicate paste batches only inside the short guard window", () => {
     const file = createFile({ name: "image.png", size: 12, type: "image/png" });
     const batchKey = createAttachmentFileBatchKey([file]);

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -174,6 +174,112 @@ const buildSyntheticAttachmentName = (file: File, index: number): string => {
   return `attachment-${timestamp}-${index + 1}${extensionFromType}`;
 };
 
+const PASTE_DUPLICATE_GUARD_MS = 750;
+
+export type PromptInputPasteBatchGuard = {
+  key: string;
+  timestamp: number;
+};
+
+export const getAttachmentFileFingerprint = (file: File): string =>
+  [file.name || "", file.type || "", file.size, file.lastModified || 0].join("|");
+
+export const createAttachmentFileBatchKey = (files: readonly File[]): string =>
+  files.map(getAttachmentFileFingerprint).join("\n");
+
+export const dedupeAttachmentFileBatch = (files: readonly File[]): File[] => {
+  const uniqueFiles: File[] = [];
+  const seenFingerprints = new Set<string>();
+
+  for (const file of files) {
+    const fingerprint = getAttachmentFileFingerprint(file);
+    if (seenFingerprints.has(fingerprint)) {
+      continue;
+    }
+    seenFingerprints.add(fingerprint);
+    uniqueFiles.push(file);
+  }
+
+  return uniqueFiles;
+};
+
+const normalizeAttachmentFileName = (name: string): string =>
+  name.trim().toLowerCase();
+
+const getAttachmentFileNameStem = (name: string): string =>
+  normalizeAttachmentFileName(name).replace(/\.[^.]+$/, "");
+
+const isGenericClipboardImageName = (name: string): boolean => {
+  const normalized = normalizeAttachmentFileName(name);
+  return !normalized || /^(?:clipboard|image)(?:\.[a-z0-9]+)?$/i.test(normalized);
+};
+
+const isPastedImageFlavorCandidate = (file: File): boolean =>
+  file.type.startsWith("image/") ||
+  (file.type === "" && isGenericClipboardImageName(file.name));
+
+const isLikelyAlternatePastedImageFlavor = (first: File, next: File): boolean => {
+  if (
+    !isPastedImageFlavorCandidate(first) ||
+    !isPastedImageFlavorCandidate(next)
+  ) {
+    return false;
+  }
+
+  if (isGenericClipboardImageName(first.name) && isGenericClipboardImageName(next.name)) {
+    return true;
+  }
+
+  const firstStem = getAttachmentFileNameStem(first.name);
+  const nextStem = getAttachmentFileNameStem(next.name);
+  return Boolean(firstStem && firstStem === nextStem && first.type !== next.type);
+};
+
+export const dedupePastedAttachmentFileBatch = (files: readonly File[]): File[] => {
+  const uniqueFiles: File[] = [];
+  const keptImageFiles: File[] = [];
+  const seenFingerprints = new Set<string>();
+
+  for (const file of files) {
+    const fingerprint = getAttachmentFileFingerprint(file);
+    if (seenFingerprints.has(fingerprint)) {
+      continue;
+    }
+    seenFingerprints.add(fingerprint);
+
+    if (
+      keptImageFiles.some((keptImage) =>
+        isLikelyAlternatePastedImageFlavor(keptImage, file)
+      )
+    ) {
+      continue;
+    }
+    if (isPastedImageFlavorCandidate(file)) {
+      keptImageFiles.push(file);
+    }
+
+    uniqueFiles.push(file);
+  }
+
+  return uniqueFiles;
+};
+
+export const shouldIgnoreDuplicatePasteBatch = ({
+  batchKey,
+  lastBatch,
+  now,
+}: {
+  batchKey: string;
+  lastBatch: PromptInputPasteBatchGuard | null;
+  now: number;
+}): boolean =>
+  Boolean(
+    lastBatch &&
+      lastBatch.key === batchKey &&
+      now - lastBatch.timestamp >= 0 &&
+      now - lastBatch.timestamp < PASTE_DUPLICATE_GUARD_MS
+  );
+
 const captureScreenshot = async (): Promise<File | null> => {
   if (
     typeof navigator === "undefined" ||
@@ -342,7 +448,7 @@ export const PromptInputProvider = ({
   const openRef = useRef<() => void>(() => {});
 
   const add = useCallback((files: File[] | FileList) => {
-    const incoming = [...files];
+    const incoming = dedupeAttachmentFileBatch([...files]);
     if (incoming.length === 0) {
       return;
     }
@@ -660,7 +766,7 @@ export const PromptInput = ({
 
   const addLocal = useCallback(
     (fileList: File[] | FileList) => {
-      const incoming = [...fileList];
+      const incoming = dedupeAttachmentFileBatch([...fileList]);
       const accepted = incoming.filter((f) => matchesAccept(f));
       if (incoming.length && accepted.length === 0) {
         onError?.({
@@ -725,7 +831,7 @@ export const PromptInput = ({
   // Wrapper that validates files before calling provider's add
   const addWithProviderValidation = useCallback(
     (fileList: File[] | FileList) => {
-      const incoming = [...fileList];
+      const incoming = dedupeAttachmentFileBatch([...fileList]);
       const accepted = incoming.filter((f) => matchesAccept(f));
       if (incoming.length && accepted.length === 0) {
         onError?.({
@@ -1227,6 +1333,7 @@ export const PromptInputTextarea = ({
   const controller = useOptionalPromptInputController();
   const attachments = usePromptInputAttachments();
   const [isComposing, setIsComposing] = useState(false);
+  const lastPasteBatchRef = useRef<PromptInputPasteBatchGuard | null>(null);
 
   const moveCaretToLineBoundary = useCallback(
     (textarea: HTMLTextAreaElement, key: "Home" | "End", extendSelection: boolean) => {
@@ -1337,24 +1444,35 @@ export const PromptInputTextarea = ({
         return;
       }
 
-      const files: File[] = [];
-      const seenTypes = new Set<string>();
+      const pastedFiles: File[] = [];
 
       for (const item of items) {
-        if (item.kind === "file") {
-          // Deduplicate by MIME type – macOS clipboard may include
-          // multiple DataTransferItems for the same pasted image.
-          if (seenTypes.has(item.type)) continue;
-          seenTypes.add(item.type);
-          const file = item.getAsFile();
-          if (file) {
-            files.push(file);
-          }
+        if (item.kind !== "file") {
+          continue;
+        }
+
+        const file = item.getAsFile();
+        if (file) {
+          pastedFiles.push(file);
         }
       }
 
+      const files = dedupePastedAttachmentFileBatch(pastedFiles);
+
       if (files.length > 0) {
         event.preventDefault();
+        const batchKey = createAttachmentFileBatchKey(files);
+        const now = Date.now();
+        if (
+          shouldIgnoreDuplicatePasteBatch({
+            batchKey,
+            lastBatch: lastPasteBatchRef.current,
+            now,
+          })
+        ) {
+          return;
+        }
+        lastPasteBatchRef.current = { key: batchKey, timestamp: now };
         attachments.add(files);
       }
     },

--- a/src/components/ai-elements/prompt-input.tsx
+++ b/src/components/ai-elements/prompt-input.tsx
@@ -182,7 +182,7 @@ export type PromptInputPasteBatchGuard = {
 };
 
 export const getAttachmentFileFingerprint = (file: File): string =>
-  [file.name || "", file.type || "", file.size, file.lastModified || 0].join("|");
+  JSON.stringify([file.name || "", file.type || "", file.size, file.lastModified || 0]);
 
 export const createAttachmentFileBatchKey = (files: readonly File[]): string =>
   files.map(getAttachmentFileFingerprint).join("\n");

--- a/src/modules/workbench-shell/model/workbench-actions.test.ts
+++ b/src/modules/workbench-shell/model/workbench-actions.test.ts
@@ -125,6 +125,19 @@ function hasTerminalSession(threadId: string): boolean {
   return threadId in terminalStore.getState().sessionsByThreadId;
 }
 
+function setStaleNewThreadAttachmentData() {
+  composerStore.setState({
+    newThreadAttachmentData: [
+      {
+        dataUrl: "data:image/png;base64,AA==",
+        id: "attachment-1",
+        mediaType: "image/png",
+        name: "image.png",
+      },
+    ],
+  });
+}
+
 beforeEach(() => {
   resetAllStores();
   // Set up minimal settingsStore state
@@ -287,6 +300,15 @@ describe("activateWorkspace", () => {
     expect(composerStore.getState().error).toBeNull();
   });
 
+  it("clears stale new-thread attachment data", () => {
+    setStaleNewThreadAttachmentData();
+    threadStore.setState({ isNewThreadMode: false, workspaces: [] });
+
+    activateWorkspace("ws-2", makeProject({ id: "ws-2" }));
+
+    expect(composerStore.getState().newThreadAttachmentData).toEqual([]);
+  });
+
   it("closes workspace menu", () => {
     uiLayoutStore.setState({ activeWorkspaceMenuId: "ws-1" });
     threadStore.setState({ isNewThreadMode: false, workspaces: [] });
@@ -384,12 +406,14 @@ describe("deleteThread", () => {
       selectedProject: makeProject({ id: "ws-1" }),
       recentProjects: [makeProject({ id: "ws-1" })],
     });
+    setStaleNewThreadAttachmentData();
 
     await deleteThread("thread-1", { skipIpc: true });
 
     expect(threadStore.getState().isNewThreadMode).toBe(true);
     expect(threadStore.getState().activeThreadProfileIdOverride).toBeNull();
     expect(composerStore.getState().error).toBeNull();
+    expect(composerStore.getState().newThreadAttachmentData).toEqual([]);
   });
 
   it("cleans terminal collapsed state", async () => {
@@ -473,6 +497,18 @@ describe("removeWorkspace", () => {
 
     expect(projectStore.getState().selectedProject).toBeNull();
   });
+
+  it("clears stale new-thread attachment data when removing the active workspace", async () => {
+    const thread = makeThread("thread-1");
+    const ws1 = makeWorkspace("ws-1", [thread]);
+    threadStore.setState({ activeThreadId: "thread-1", workspaces: [ws1] });
+    setStaleNewThreadAttachmentData();
+
+    await removeWorkspace(ws1 as any);
+
+    expect(threadStore.getState().isNewThreadMode).toBe(true);
+    expect(composerStore.getState().newThreadAttachmentData).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -505,6 +541,14 @@ describe("enterNewThreadMode", () => {
     enterNewThreadMode();
 
     expect(composerStore.getState().error).toBeNull();
+  });
+
+  it("clears stale new-thread attachment data", () => {
+    setStaleNewThreadAttachmentData();
+
+    enterNewThreadMode();
+
+    expect(composerStore.getState().newThreadAttachmentData).toEqual([]);
   });
 
   it("preserves workspaces structure", () => {

--- a/src/modules/workbench-shell/model/workbench-actions.ts
+++ b/src/modules/workbench-shell/model/workbench-actions.ts
@@ -74,6 +74,19 @@ export interface ThreadDeleteOptions {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Clears transient new-thread composer data when entering new-thread mode.
+ * Unlike `clearNewThreadComposer`, this intentionally preserves typed text,
+ * referenced files, and run mode while dropping stale serialized attachments
+ * and errors that should not be restored after a mode transition.
+ */
+const resetNewThreadComposerTransientState = (): void => {
+  composerStore.setState({
+    error: null,
+    newThreadAttachmentData: [],
+  });
+};
+
 /** Pending thread creation promises, keyed by workspace ID. Used for deduplication. */
 const pendingCreations: Record<string, Promise<string>> = {};
 
@@ -265,7 +278,7 @@ export function activateWorkspace(workspaceId: string, project: ProjectOption): 
     activeThreadProfileIdOverride: null,
     editingThreadId: null,
   });
-  composerStore.setState({ error: null });
+  resetNewThreadComposerTransientState();
   projectStore.setState({ terminalBootstrapError: null });
   uiLayoutStore.setState({ activeWorkspaceMenuId: null });
 }
@@ -351,7 +364,7 @@ export async function deleteThread(threadId: string, options?: ThreadDeleteOptio
       activeThreadId: null,
       activeThreadProfileIdOverride: null,
     });
-    composerStore.setState({ error: null });
+    resetNewThreadComposerTransientState();
   }
 }
 
@@ -402,7 +415,7 @@ export async function removeWorkspace(workspace: WorkspaceItem): Promise<void> {
       activeThreadProfileIdOverride: null,
       workspaces: clearActiveThreads(threadStore.getState().workspaces),
     });
-    composerStore.setState({ error: null });
+    resetNewThreadComposerTransientState();
   }
 
   // Update selected project if needed
@@ -724,7 +737,7 @@ export function enterNewThreadMode(): void {
   threadStore.setState((prev) => ({
     workspaces: clearActiveThreads(prev.workspaces),
   }));
-  composerStore.setState({ error: null });
+  resetNewThreadComposerTransientState();
   projectStore.setState({ terminalBootstrapError: null });
 }
 

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  markAndShouldRestoreInitialAttachmentData,
+  type ComposerInitialAttachmentRestoreState,
+} from "./workbench-prompt-composer";
+
+const attachment = {
+  dataUrl: "data:image/png;base64,AA==",
+  id: "attachment-1",
+  mediaType: "image/png",
+  name: "image.png",
+};
+
+describe("markAndShouldRestoreInitialAttachmentData", () => {
+  it("marks empty initial data as already restored", () => {
+    const state: ComposerInitialAttachmentRestoreState = { hasRestored: false };
+
+    expect(markAndShouldRestoreInitialAttachmentData(state, [])).toBe(false);
+    expect(state.hasRestored).toBe(true);
+    expect(markAndShouldRestoreInitialAttachmentData(state, [attachment])).toBe(false);
+  });
+
+  it("restores non-empty initial data only once", () => {
+    const state: ComposerInitialAttachmentRestoreState = { hasRestored: false };
+
+    expect(markAndShouldRestoreInitialAttachmentData(state, [attachment])).toBe(true);
+    expect(state.hasRestored).toBe(true);
+    expect(markAndShouldRestoreInitialAttachmentData(state, [attachment])).toBe(false);
+  });
+
+  it("treats undefined initial data as restored", () => {
+    const state: ComposerInitialAttachmentRestoreState = { hasRestored: false };
+
+    expect(markAndShouldRestoreInitialAttachmentData(state, undefined)).toBe(false);
+    expect(state.hasRestored).toBe(true);
+  });
+});

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -725,6 +725,28 @@ function dataUrlToFile(dataUrl: string, name: string, mediaType: string): File {
   return new File([u8arr], name, { type: mime });
 }
 
+export type ComposerInitialAttachmentRestoreState = {
+  hasRestored: boolean;
+};
+
+/**
+ * Marks initial attachment restoration as attempted and returns whether the
+ * current initial data should be restored. This intentionally mutates `state`
+ * on the first call, including empty initial data, so later draft-sync updates
+ * from the same mounted composer are not treated as initial state.
+ */
+export const markAndShouldRestoreInitialAttachmentData = (
+  state: ComposerInitialAttachmentRestoreState,
+  initialAttachmentData: ReadonlyArray<SerializableAttachment> | undefined,
+): initialAttachmentData is ReadonlyArray<SerializableAttachment> => {
+  if (state.hasRestored) {
+    return false;
+  }
+
+  state.hasRestored = true;
+  return Boolean(initialAttachmentData && initialAttachmentData.length > 0);
+};
+
 /**
  * Restores initial attachment data on mount by converting data URLs
  * into File objects and calling the PromptInput add() API.
@@ -735,13 +757,17 @@ function ComposerInitialStateRestorer({
   initialAttachmentData: ReadonlyArray<SerializableAttachment> | undefined;
 }) {
   const attachments = usePromptInputAttachments();
-  const hasRestoredRef = useRef(false);
+  const restoreStateRef = useRef<ComposerInitialAttachmentRestoreState>({
+    hasRestored: false,
+  });
 
   useEffect(() => {
-    if (hasRestoredRef.current) {
-      return;
-    }
-    if (!initialAttachmentData || initialAttachmentData.length === 0) {
+    if (
+      !markAndShouldRestoreInitialAttachmentData(
+        restoreStateRef.current,
+        initialAttachmentData,
+      )
+    ) {
       return;
     }
 
@@ -755,7 +781,6 @@ function ComposerInitialStateRestorer({
     }
 
     if (files.length > 0) {
-      hasRestoredRef.current = true;
       attachments.add(files);
     }
   }, [attachments, initialAttachmentData]);


### PR DESCRIPTION
## Summary
- Add attachment file fingerprinting and paste-batch deduplication for prompt input image paste handling.
- Handle macOS-style multi-flavor clipboard images, including empty MIME type entries, and guard short duplicate paste batches.
- Add Vitest coverage for pasted image flavor dedupe, generic attachment batch dedupe, and duplicate paste guard behavior.

## Test Plan
- [x] `npm run typecheck`
- [x] `npm run test:unit -- src/components/ai-elements/prompt-input.test.ts`
- [ ] Manually verify macOS screenshot/Preview/browser image paste produces one composer attachment.

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
