### PR TITLE
fix(workbench): 🐛 Eliminate RuntimeQueue and TaskHistory layout jumps during streaming

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -3039,29 +3039,48 @@ export function RuntimeThreadSurface({
               </div>
             </div>
 
-            {runtimeQueue ? (
-              <div className={getRoleSpacingClass(queuePreviousRole, "assistant")}>
-                <Message className="max-w-full" from="assistant">
-                  <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
-                    <RuntimeQueueTimeline
-                      queue={runtimeQueue}
-                      onCancelMessage={cancelRuntimeQueueMessage}
-                      cancellingMessageIds={cancellingRuntimeQueueMessageIds}
-                    />
-                  </MessageContent>
-                </Message>
+            {/* Runtime Queue — always in DOM; height transitions smoothly via
+                grid-rows to avoid layout jumps during streaming. */}
+            <div
+              className={`grid transition-[grid-template-rows,opacity] duration-200 ease-in-out ${
+                runtimeQueue
+                  ? "grid-rows-[1fr] opacity-100"
+                  : "grid-rows-[0fr] opacity-0"
+              }`}
+            >
+              <div className="overflow-hidden">
+                <div className={getRoleSpacingClass(queuePreviousRole, "assistant")}>
+                  <Message className="max-w-full" from="assistant">
+                    <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
+                      <RuntimeQueueTimeline
+                        queue={runtimeQueue}
+                        onCancelMessage={cancelRuntimeQueueMessage}
+                        cancellingMessageIds={cancellingRuntimeQueueMessageIds}
+                      />
+                    </MessageContent>
+                  </Message>
+                </div>
               </div>
-            ) : null}
+            </div>
 
-            {hasTaskHistoryTimeline ? (
-              <div className={getRoleSpacingClass(historyPreviousRole, "assistant")}>
-                <Message className="max-w-full" from="assistant">
-                  <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
-                    <TaskHistoryTimeline boards={taskBoards.boards} />
-                  </MessageContent>
-                </Message>
+            {/* Task History — same smooth transition pattern. */}
+            <div
+              className={`grid transition-[grid-template-rows,opacity] duration-200 ease-in-out ${
+                hasTaskHistoryTimeline
+                  ? "grid-rows-[1fr] opacity-100"
+                  : "grid-rows-[0fr] opacity-0"
+              }`}
+            >
+              <div className="overflow-hidden">
+                <div className={getRoleSpacingClass(historyPreviousRole, "assistant")}>
+                  <Message className="max-w-full" from="assistant">
+                    <MessageContent className="w-full max-w-full bg-transparent px-0 py-0 shadow-none">
+                      <TaskHistoryTimeline boards={taskBoards.boards} />
+                    </MessageContent>
+                  </Message>
+                </div>
               </div>
-            ) : null}
+            </div>
 
             {runtimeError ? (
               <div className={getRoleSpacingClass(runtimeErrorPreviousRole, "assistant")}>


### PR DESCRIPTION
## Summary
- Replace conditional rendering (`? : null`) of RuntimeQueueTimeline and TaskHistoryTimeline with always-in-DOM `grid-rows-[0fr/1fr]` + `opacity` transitions
- Eliminates layout jumps during streaming output caused by sudden DOM insertion/removal of these bottom modules
- Follows the same smooth transition pattern already used by the Thinking Indicator in the same file

## Test Plan
- [ ] Start a streaming run and observe RuntimeQueue appears/disappears without layout jump
- [ ] Verify TaskHistory timeline shows/hides smoothly when task boards complete
- [ ] Confirm StickToBottom scroll behavior remains stable during transitions
- [ ] Verify no visual regression when neither module is visible

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
