### PR TITLE
feat(composer): ✨ Add profile quick edit controls

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -78,6 +78,7 @@ const en: Record<TranslationKey, string> = {
   "composer.activeProfileLabel": "Active Profile",
   "composer.editProfiles": "Edit profiles in Settings",
   "composer.profileDetailsTitle": "Profile details",
+  "composer.profileQuickEditFailed": "Failed to update profile.",
   "composer.profileThinkingLevel": "Thinking level",
   "composer.profileAgentTeam": "Agent Team",
   "composer.profileAgentTeamDesc": "Agents this profile can delegate to.",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -76,6 +76,7 @@ const zhCN = {
   "composer.activeProfileLabel": "当前 Profile",
   "composer.editProfiles": "在设置中编辑 Profile",
   "composer.profileDetailsTitle": "Profile 详情",
+  "composer.profileQuickEditFailed": "更新 Profile 失败。",
   "composer.profileThinkingLevel": "推理级别",
   "composer.profileAgentTeam": "Agent 团队",
   "composer.profileAgentTeamDesc": "此 Profile 可以委派工作的 Agent。",

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -25,7 +25,7 @@ import type { ComposerSubmission } from "@/modules/workbench-shell/model/compose
 import { useSettingsInit } from "@/modules/settings-center/model/use-settings-init";
 import { settingsStore } from "@/modules/settings-center/model/settings-store";
 import type { SettingsCategory } from "@/modules/settings-center/model/types";
-import { setActiveAgentProfile } from "@/modules/settings-center/model/settings-ipc-actions";
+import { setActiveAgentProfile, updateAgentProfile } from "@/modules/settings-center/model/settings-ipc-actions";
 import { useAppUpdater } from "@/modules/workbench-shell/hooks/use-app-updater";
 import {
   DEFAULT_TERMINAL_COLLAPSED,
@@ -980,6 +980,7 @@ const drawerWidth = useStore(uiLayoutStore, (s) => s.drawerWidth);
                             onErrorMessageChange={setComposerError}
                             onOpenProfileSettings={() => handleOpenSettings("profiles")}
                             onSelectAgentProfile={handleSelectAgentProfileForThread}
+                            onUpdateAgentProfile={updateAgentProfile}
                             onStop={() => undefined}
                             onSubmit={handleComposerSubmit}
                             placeholder={t("composer.placeholder")}

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -60,6 +60,7 @@ import {
 } from "@/modules/workbench-shell/model/run-event-dispatcher";
 import { composerStore, setDraft, getDraft, type SerializableAttachment } from "@/modules/workbench-shell/model/composer-store";
 import { settingsStore } from "@/modules/settings-center/model/settings-store";
+import { updateAgentProfile } from "@/modules/settings-center/model/settings-ipc-actions";
 import { threadUpdateProfile } from "@/services/bridge";
 import { getInvokeErrorMessage } from "@/shared/lib/invoke-error";
 import { Button } from "@/shared/ui/button";
@@ -3147,6 +3148,7 @@ export function RuntimeThreadSurface({
               uiLayoutStore.setState({ activeOverlay: "settings", activeSettingsCategory: "profiles" });
             }}
             onRuntimeQueueSubmitModeChange={setRuntimeQueueSubmitMode}
+            onUpdateAgentProfile={updateAgentProfile}
             onSelectAgentProfile={async (profileId: string) => {
               // In new-thread mode, just update the global active profile.
               if (isNewThreadMode || !threadId) {

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
@@ -3,8 +3,10 @@ import type { ProviderEntry } from "@/modules/settings-center/model/types";
 
 import {
   getAvailableProfileModelOptions,
+  getModelSelectValue,
   getProfileTierPatch,
   markAndShouldRestoreInitialAttachmentData,
+  parseModelSelectValue,
   type ComposerInitialAttachmentRestoreState,
 } from "./workbench-prompt-composer";
 
@@ -90,6 +92,27 @@ describe("profile quick edit helpers", () => {
     expect(getProfileTierPatch("lite", "", "")).toEqual({
       liteProviderId: "",
       liteModelId: "",
+    });
+  });
+
+  it("serializes model select values and falls back to none for incomplete selections", () => {
+    expect(getModelSelectValue("provider-a", "model-a")).toBe('["provider-a","model-a"]');
+    expect(getModelSelectValue("", "model-a")).toBe("__none__");
+    expect(getModelSelectValue("provider-a", "")).toBe("__none__");
+  });
+
+  it("parses model select values defensively", () => {
+    expect(parseModelSelectValue('["provider-a","model-a"]')).toEqual({
+      providerId: "provider-a",
+      modelRecordId: "model-a",
+    });
+    expect(parseModelSelectValue("__none__")).toEqual({ providerId: "", modelRecordId: "" });
+    expect(parseModelSelectValue("not json")).toEqual({ providerId: "", modelRecordId: "" });
+    expect(parseModelSelectValue('["provider-a"]')).toEqual({ providerId: "", modelRecordId: "" });
+    expect(parseModelSelectValue('["provider-a", 42]')).toEqual({ providerId: "", modelRecordId: "" });
+    expect(parseModelSelectValue('{"providerId":"provider-a","modelRecordId":"model-a"}')).toEqual({
+      providerId: "",
+      modelRecordId: "",
     });
   });
 

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { ProviderEntry } from "@/modules/settings-center/model/types";
 
 import {
+  getAvailableProfileModelOptions,
+  getProfileTierPatch,
   markAndShouldRestoreInitialAttachmentData,
   type ComposerInitialAttachmentRestoreState,
 } from "./workbench-prompt-composer";
@@ -11,6 +14,43 @@ const attachment = {
   mediaType: "image/png",
   name: "image.png",
 };
+
+function provider(overrides: Partial<ProviderEntry> = {}): ProviderEntry {
+  return {
+    id: "provider-1",
+    kind: "builtin",
+    providerKey: "openai",
+    providerType: "openai",
+    displayName: "OpenAI",
+    baseUrl: "https://example.test/v1",
+    apiKey: "",
+    hasApiKey: false,
+    lockedMapping: false,
+    customHeaders: {},
+    enabled: true,
+    models: [
+      {
+        id: "model-gpt-5",
+        modelId: "gpt-5",
+        sortIndex: 0,
+        displayName: "GPT-5",
+        enabled: true,
+        capabilityOverrides: {},
+        providerOptions: {},
+      },
+      {
+        id: "model-disabled",
+        modelId: "disabled-model",
+        sortIndex: 1,
+        displayName: "Disabled model",
+        enabled: false,
+        capabilityOverrides: {},
+        providerOptions: {},
+      },
+    ],
+    ...overrides,
+  };
+}
 
 describe("markAndShouldRestoreInitialAttachmentData", () => {
   it("marks empty initial data as already restored", () => {
@@ -34,5 +74,54 @@ describe("markAndShouldRestoreInitialAttachmentData", () => {
 
     expect(markAndShouldRestoreInitialAttachmentData(state, undefined)).toBe(false);
     expect(state.hasRestored).toBe(true);
+  });
+});
+
+describe("profile quick edit helpers", () => {
+  it("builds tier-specific profile patches", () => {
+    expect(getProfileTierPatch("primary", "provider-a", "model-a")).toEqual({
+      primaryProviderId: "provider-a",
+      primaryModelId: "model-a",
+    });
+    expect(getProfileTierPatch("assistant", "provider-b", "model-b")).toEqual({
+      assistantProviderId: "provider-b",
+      assistantModelId: "model-b",
+    });
+    expect(getProfileTierPatch("lite", "", "")).toEqual({
+      liteProviderId: "",
+      liteModelId: "",
+    });
+  });
+
+  it("collects only enabled provider models for quick selection", () => {
+    const options = getAvailableProfileModelOptions([
+      provider(),
+      provider({
+        id: "provider-disabled",
+        displayName: "Disabled Provider",
+        enabled: false,
+        models: [
+          {
+            id: "model-hidden",
+            modelId: "hidden-model",
+            sortIndex: 0,
+            displayName: "Hidden",
+            enabled: true,
+            capabilityOverrides: {},
+            providerOptions: {},
+          },
+        ],
+      }),
+    ]);
+
+    expect(options).toEqual([
+      {
+        providerId: "provider-1",
+        providerName: "OpenAI",
+        modelRecordId: "model-gpt-5",
+        modelId: "gpt-5",
+        displayName: "GPT-5",
+      },
+    ]);
   });
 });

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1384,13 +1384,13 @@ function QuickThinkingLevelControl({
           </span>
         </div>
       </div>
-      <div className="relative mt-4 px-1">
-        <div className="absolute left-4 right-4 top-2 h-px bg-app-border/70" />
+      <div className="relative mt-4">
+        <div className="absolute left-[8.333333%] right-[8.333333%] top-2 h-px bg-app-border/70" />
         <div
-          className="absolute left-4 top-2 h-px bg-app-info/70 transition-all"
-          style={{ width: selectedIndex > 0 ? `calc((100% - 2rem) * ${selectedIndex / (THINKING_LEVEL_OPTIONS.length - 1)})` : 0 }}
+          className="absolute left-[8.333333%] top-2 h-px bg-app-info/70 transition-all"
+          style={{ width: selectedIndex > 0 ? `calc((100% - 16.666667%) * ${selectedIndex / (THINKING_LEVEL_OPTIONS.length - 1)})` : 0 }}
         />
-        <div className="relative grid grid-cols-6 gap-1">
+        <div className="relative grid grid-cols-6">
           {THINKING_LEVEL_OPTIONS.map((option) => {
             const isSelected = option === value;
             return (

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1697,6 +1697,7 @@ function ProfileDetailsPanel({
   }
 
   const canQuickEdit = Boolean(onUpdateAgentProfile);
+  const isQuickEditDisabled = !canQuickEdit || Boolean(pendingProfilePatchKey);
   const tiers: Array<{ label: string; tier: ProfileModelTier }> = [
     { label: t("composer.profileTier.primary"), tier: "primary" },
     { label: t("composer.profileTier.auxiliary"), tier: "assistant" },
@@ -1745,7 +1746,7 @@ function ProfileDetailsPanel({
           />
           <div className="sm:col-span-2">
             <QuickThinkingLevelControl
-              disabled={!canQuickEdit}
+              disabled={isQuickEditDisabled}
               isPending={pendingProfilePatchKey === "thinkingLevel"}
               onChange={(thinkingLevel) => {
                 void runQuickEdit("thinkingLevel", { thinkingLevel });
@@ -1763,7 +1764,7 @@ function ProfileDetailsPanel({
 
           return (
             <QuickTierModelSelect
-              disabled={!canQuickEdit}
+              disabled={isQuickEditDisabled}
               isPending={pendingProfilePatchKey === `model:${tier}`}
               key={tier}
               label={label}

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1395,11 +1395,16 @@ function QuickThinkingLevelControl({
             const isSelected = option === value;
             return (
               <button
+                aria-current={isSelected ? "true" : undefined}
                 aria-label={`${t("composer.profileThinkingLevel")}: ${getThinkingLevelLabel(option, t)}`}
                 className="group flex min-w-0 flex-col items-center gap-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={disabled || isPending || isSelected}
+                disabled={disabled || isPending}
                 key={option}
-                onClick={() => onChange(option)}
+                onClick={() => {
+                  if (!isSelected) {
+                    onChange(option);
+                  }
+                }}
                 title={getThinkingLevelDescription(option, t)}
                 type="button"
               >
@@ -1718,7 +1723,7 @@ function ProfileDetailsPanel({
       await onUpdateAgentProfile(targetProfileId, patch);
     } catch (error) {
       if (activeProfileIdRef.current === targetProfileId && quickEditRequestIdRef.current === requestId) {
-        setQuickEditError(error instanceof Error ? error.message : t("sourceControl.requestFailed"));
+        setQuickEditError(error instanceof Error ? error.message : t("composer.profileQuickEditFailed"));
       }
     } finally {
       if (activeProfileIdRef.current === targetProfileId && quickEditRequestIdRef.current === requestId) {

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1366,39 +1366,58 @@ function QuickThinkingLevelControl({
   value,
 }: QuickThinkingLevelControlProps) {
   const t = useT();
+  const selectedIndex = THINKING_LEVEL_OPTIONS.indexOf(value);
 
   return (
     <div className="rounded-xl border border-app-border/65 bg-app-surface-muted/55 px-3 py-2.5">
-      <div className="flex min-w-0 items-center justify-between gap-2">
+      <div className="flex min-w-0 items-center justify-between gap-3">
         <div className="flex min-w-0 items-center gap-2">
           <Brain className="size-3.5 shrink-0 text-app-info" />
           <span className="truncate text-[10px] font-medium uppercase tracking-[0.12em] text-app-subtle">
             {t("composer.profileThinkingLevel")}
           </span>
         </div>
-        {isPending ? <LoaderCircle className="size-3.5 shrink-0 animate-spin text-app-subtle" /> : null}
+        <div className="flex shrink-0 items-center gap-1.5">
+          {isPending ? <LoaderCircle className="size-3.5 animate-spin text-app-subtle" /> : null}
+          <span className="max-w-32 truncate text-[11px] font-semibold text-app-info">
+            {getThinkingLevelLabel(value, t)}
+          </span>
+        </div>
       </div>
-      <div className="mt-2 grid grid-cols-3 gap-1.5">
-        {THINKING_LEVEL_OPTIONS.map((option) => {
-          const isSelected = option === value;
-          return (
-            <button
-              className={cn(
-                "rounded-lg border px-2 py-1.5 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-info/45 disabled:cursor-not-allowed disabled:opacity-60",
-                isSelected
-                  ? "border-app-info/55 bg-app-info/12 text-app-info"
-                  : "border-app-border/60 bg-app-surface/55 text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
-              )}
-              disabled={disabled || isPending || isSelected}
-              key={option}
-              onClick={() => onChange(option)}
-              title={getThinkingLevelDescription(option, t)}
-              type="button"
-            >
-              {getThinkingLevelLabel(option, t)}
-            </button>
-          );
-        })}
+      <div className="relative mt-4 px-1">
+        <div className="absolute left-4 right-4 top-2 h-px bg-app-border/70" />
+        <div
+          className="absolute left-4 top-2 h-px bg-app-info/70 transition-all"
+          style={{ width: selectedIndex > 0 ? `calc((100% - 2rem) * ${selectedIndex / (THINKING_LEVEL_OPTIONS.length - 1)})` : 0 }}
+        />
+        <div className="relative grid grid-cols-6 gap-1">
+          {THINKING_LEVEL_OPTIONS.map((option) => {
+            const isSelected = option === value;
+            return (
+              <button
+                aria-label={`${t("composer.profileThinkingLevel")}: ${getThinkingLevelLabel(option, t)}`}
+                className="group flex min-w-0 flex-col items-center gap-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={disabled || isPending || isSelected}
+                key={option}
+                onClick={() => onChange(option)}
+                title={getThinkingLevelDescription(option, t)}
+                type="button"
+              >
+                <span
+                  className={cn(
+                    "relative z-10 size-4 rounded-full border bg-app-surface transition-all group-hover:border-app-info/55 group-hover:bg-app-info/12",
+                    isSelected
+                      ? "scale-110 border-app-info bg-app-info shadow-[0_0_0_4px_rgba(59,130,246,0.14)]"
+                      : "border-app-border",
+                  )}
+                />
+                <span className={cn("truncate text-[10px] leading-4", isSelected ? "font-semibold text-app-info" : "text-app-subtle")}>
+                  {getThinkingLevelLabel(option, t)}
+                </span>
+              </button>
+            );
+          })}
+        </div>
       </div>
       <p className="mt-2 line-clamp-2 text-[11px] leading-4 text-app-muted">
         {getThinkingLevelDescription(value, t)}
@@ -1449,9 +1468,14 @@ function QuickTierModelSelect({
 
   return (
     <div className="rounded-xl border border-app-border/65 bg-app-surface-muted/55 px-3 py-2.5">
-      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-3">
         <span className="truncate text-[10px] font-medium uppercase tracking-[0.12em] text-app-subtle">{label}</span>
-        {isPending ? <LoaderCircle className="size-3.5 shrink-0 animate-spin text-app-subtle" /> : null}
+        <div className="flex min-w-0 shrink-0 items-center gap-1.5">
+          {isPending ? <LoaderCircle className="size-3.5 shrink-0 animate-spin text-app-subtle" /> : null}
+          {selectedModel ? (
+            <span className="max-w-36 truncate text-[11px] font-medium text-app-muted">{selectedModel.providerName}</span>
+          ) : null}
+        </div>
       </div>
       <PromptInputSelect
         disabled={disabled || isPending}
@@ -1513,9 +1537,7 @@ function QuickTierModelSelect({
           ) : null}
         </PromptInputSelectContent>
       </PromptInputSelect>
-      {selectedModel ? (
-        <p className="mt-1.5 truncate text-[11px] text-app-muted">{selectedModel.providerName}</p>
-      ) : models.length === 0 ? (
+      {models.length === 0 ? (
         <p className="mt-1.5 text-[11px] text-app-muted">{t("settings.general.noModelsAvailable")}</p>
       ) : null}
     </div>

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -1263,7 +1263,7 @@ export function getAvailableProfileModelOptions(
 
 const MODEL_SELECT_NONE_VALUE = "__none__";
 
-function getModelSelectValue(providerId: string, modelRecordId: string) {
+export function getModelSelectValue(providerId: string, modelRecordId: string) {
   if (!providerId || !modelRecordId) {
     return MODEL_SELECT_NONE_VALUE;
   }
@@ -1271,7 +1271,7 @@ function getModelSelectValue(providerId: string, modelRecordId: string) {
   return JSON.stringify([providerId, modelRecordId]);
 }
 
-function parseModelSelectValue(value: string) {
+export function parseModelSelectValue(value: string) {
   if (value === MODEL_SELECT_NONE_VALUE) {
     return { providerId: "", modelRecordId: "" };
   }
@@ -1681,9 +1681,13 @@ function ProfileDetailsPanel({
   const t = useT();
   const [pendingProfilePatchKey, setPendingProfilePatchKey] = useState<string | null>(null);
   const [quickEditError, setQuickEditError] = useState<string | null>(null);
+  const activeProfileIdRef = useRef<string | null>(profile?.id ?? null);
+  const quickEditRequestIdRef = useRef(0);
   const availableModels = useMemo(() => getAvailableProfileModelOptions(providers), [providers]);
 
   useEffect(() => {
+    activeProfileIdRef.current = profile?.id ?? null;
+    quickEditRequestIdRef.current += 1;
     setPendingProfilePatchKey(null);
     setQuickEditError(null);
   }, [profile?.id]);
@@ -1703,14 +1707,22 @@ function ProfileDetailsPanel({
       return;
     }
 
+    const targetProfileId = profile.id;
+    const requestId = quickEditRequestIdRef.current + 1;
+    quickEditRequestIdRef.current = requestId;
+
     setQuickEditError(null);
     setPendingProfilePatchKey(key);
     try {
-      await onUpdateAgentProfile(profile.id, patch);
+      await onUpdateAgentProfile(targetProfileId, patch);
     } catch (error) {
-      setQuickEditError(error instanceof Error ? error.message : t("sourceControl.requestFailed"));
+      if (activeProfileIdRef.current === targetProfileId && quickEditRequestIdRef.current === requestId) {
+        setQuickEditError(error instanceof Error ? error.message : t("sourceControl.requestFailed"));
+      }
     } finally {
-      setPendingProfilePatchKey(null);
+      if (activeProfileIdRef.current === targetProfileId && quickEditRequestIdRef.current === requestId) {
+        setPendingProfilePatchKey(null);
+      }
     }
   };
 

--- a/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
+++ b/src/modules/workbench-shell/ui/workbench-prompt-composer.tsx
@@ -66,9 +66,9 @@ import {
 import {
   getProfilePrimaryModelId,
   getProfilePrimaryModelLabel,
-  resolveProfileModelByTier,
 } from "@/modules/workbench-shell/model/ai-elements-task-demo";
 import type { AgentProfile, CommandEntry, CustomSubagent, ProviderEntry } from "@/modules/settings-center/model/types";
+import type { updateAgentProfile as updateAgentProfileAction } from "@/modules/settings-center/model/settings-ipc-actions";
 import { sortAgentProfilesByName } from "@/modules/settings-center/model/profile-utils";
 import { profileSubagentAccessGet } from "@/services/bridge/subagent-commands";
 import type { SkillRecord } from "@/shared/types/extensions";
@@ -124,6 +124,7 @@ type WorkbenchPromptComposerProps = {
   onOpenProfileSettings?: () => void;
   onRuntimeQueueSubmitModeChange?: (mode: RuntimeQueueMessageKind) => void;
   onSelectAgentProfile: (id: string) => void;
+  onUpdateAgentProfile?: typeof updateAgentProfileAction;
   onStop: () => void;
   onSubmit: (submission: ComposerSubmission) => void | Promise<void>;
   placeholder: string;
@@ -1187,7 +1188,24 @@ function ProfileSelectorItem({
   );
 }
 
-type ProfileModelTier = "primary" | "assistant" | "lite";
+export type ProfileModelTier = "primary" | "assistant" | "lite";
+type ProfileQuickEditPatch = Parameters<typeof updateAgentProfileAction>[1];
+export type AvailableProfileModelOption = {
+  providerId: string;
+  providerName: string;
+  modelRecordId: string;
+  modelId: string;
+  displayName: string;
+};
+
+const THINKING_LEVEL_OPTIONS: ReadonlyArray<AgentProfile["thinkingLevel"]> = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+];
 
 function getProfileTierProviderId(profile: AgentProfile, tier: ProfileModelTier) {
   if (tier === "primary") {
@@ -1197,6 +1215,86 @@ function getProfileTierProviderId(profile: AgentProfile, tier: ProfileModelTier)
     return profile.assistantProviderId;
   }
   return profile.liteProviderId;
+}
+
+function getProfileTierModelId(profile: AgentProfile, tier: ProfileModelTier) {
+  if (tier === "primary") {
+    return profile.primaryModelId;
+  }
+  if (tier === "assistant") {
+    return profile.assistantModelId;
+  }
+  return profile.liteModelId;
+}
+
+export function getProfileTierPatch(
+  tier: ProfileModelTier,
+  providerId: string,
+  modelRecordId: string,
+): ProfileQuickEditPatch {
+  if (tier === "primary") {
+    return { primaryProviderId: providerId, primaryModelId: modelRecordId };
+  }
+  if (tier === "assistant") {
+    return { assistantProviderId: providerId, assistantModelId: modelRecordId };
+  }
+  return { liteProviderId: providerId, liteModelId: modelRecordId };
+}
+
+export function getAvailableProfileModelOptions(
+  providers: ReadonlyArray<ProviderEntry>,
+): Array<AvailableProfileModelOption> {
+  return providers.flatMap((provider) => {
+    if (!provider.enabled) {
+      return [];
+    }
+
+    return provider.models
+      .filter((model) => model.enabled)
+      .map((model) => ({
+        providerId: provider.id,
+        providerName: provider.displayName,
+        modelRecordId: model.id,
+        modelId: model.modelId,
+        displayName: model.displayName || model.modelId,
+      }));
+  });
+}
+
+const MODEL_SELECT_NONE_VALUE = "__none__";
+
+function getModelSelectValue(providerId: string, modelRecordId: string) {
+  if (!providerId || !modelRecordId) {
+    return MODEL_SELECT_NONE_VALUE;
+  }
+
+  return JSON.stringify([providerId, modelRecordId]);
+}
+
+function parseModelSelectValue(value: string) {
+  if (value === MODEL_SELECT_NONE_VALUE) {
+    return { providerId: "", modelRecordId: "" };
+  }
+
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    if (
+      Array.isArray(parsed) &&
+      parsed.length === 2 &&
+      typeof parsed[0] === "string" &&
+      typeof parsed[1] === "string"
+    ) {
+      return { providerId: parsed[0], modelRecordId: parsed[1] };
+    }
+  } catch {
+    // Fall through to the empty selection below.
+  }
+
+  return { providerId: "", modelRecordId: "" };
+}
+
+function getShortModelId(modelId: string) {
+  return modelId.split("/").pop() || modelId;
 }
 
 function getResponseStyleLabel(responseStyle: AgentProfile["responseStyle"], t: ReturnType<typeof useT>) {
@@ -1249,6 +1347,176 @@ function ProfileDetailCard({
       <p className="mt-1 truncate text-[12px] font-semibold text-app-foreground">{value}</p>
       {description ? (
         <p className="mt-0.5 line-clamp-2 text-[11px] leading-4 text-app-muted">{description}</p>
+      ) : null}
+    </div>
+  );
+}
+
+type QuickThinkingLevelControlProps = {
+  disabled: boolean;
+  isPending: boolean;
+  onChange: (value: AgentProfile["thinkingLevel"]) => void;
+  value: AgentProfile["thinkingLevel"];
+};
+
+function QuickThinkingLevelControl({
+  disabled,
+  isPending,
+  onChange,
+  value,
+}: QuickThinkingLevelControlProps) {
+  const t = useT();
+
+  return (
+    <div className="rounded-xl border border-app-border/65 bg-app-surface-muted/55 px-3 py-2.5">
+      <div className="flex min-w-0 items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Brain className="size-3.5 shrink-0 text-app-info" />
+          <span className="truncate text-[10px] font-medium uppercase tracking-[0.12em] text-app-subtle">
+            {t("composer.profileThinkingLevel")}
+          </span>
+        </div>
+        {isPending ? <LoaderCircle className="size-3.5 shrink-0 animate-spin text-app-subtle" /> : null}
+      </div>
+      <div className="mt-2 grid grid-cols-3 gap-1.5">
+        {THINKING_LEVEL_OPTIONS.map((option) => {
+          const isSelected = option === value;
+          return (
+            <button
+              className={cn(
+                "rounded-lg border px-2 py-1.5 text-[11px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-info/45 disabled:cursor-not-allowed disabled:opacity-60",
+                isSelected
+                  ? "border-app-info/55 bg-app-info/12 text-app-info"
+                  : "border-app-border/60 bg-app-surface/55 text-app-muted hover:bg-app-surface-hover hover:text-app-foreground",
+              )}
+              disabled={disabled || isPending || isSelected}
+              key={option}
+              onClick={() => onChange(option)}
+              title={getThinkingLevelDescription(option, t)}
+              type="button"
+            >
+              {getThinkingLevelLabel(option, t)}
+            </button>
+          );
+        })}
+      </div>
+      <p className="mt-2 line-clamp-2 text-[11px] leading-4 text-app-muted">
+        {getThinkingLevelDescription(value, t)}
+      </p>
+    </div>
+  );
+}
+
+type QuickTierModelSelectProps = {
+  disabled: boolean;
+  isPending: boolean;
+  label: string;
+  modelRecordId: string;
+  models: ReadonlyArray<AvailableProfileModelOption>;
+  onChange: (providerId: string, modelRecordId: string) => void;
+  providerId: string;
+  tier: ProfileModelTier;
+};
+
+function QuickTierModelSelect({
+  disabled,
+  isPending,
+  label,
+  modelRecordId,
+  models,
+  onChange,
+  providerId,
+  tier,
+}: QuickTierModelSelectProps) {
+  const t = useT();
+  const selectedModel = models.find((model) => model.providerId === providerId && model.modelRecordId === modelRecordId) ?? null;
+  const selectedValue = getModelSelectValue(providerId, modelRecordId);
+  const groupedModels = useMemo(() => {
+    const grouped = new Map<string, { providerId: string; providerName: string; models: Array<AvailableProfileModelOption> }>();
+    for (const model of models) {
+      const group = grouped.get(model.providerId) ?? {
+        providerId: model.providerId,
+        providerName: model.providerName,
+        models: [],
+      };
+      group.models.push(model);
+      grouped.set(model.providerId, group);
+    }
+    return [...grouped.values()];
+  }, [models]);
+  const isPrimary = tier === "primary";
+  const placeholder = modelRecordId ? `${t("composer.profileTier.notConfigured")} · ${modelRecordId}` : t("composer.profileTier.notConfigured");
+
+  return (
+    <div className="rounded-xl border border-app-border/65 bg-app-surface-muted/55 px-3 py-2.5">
+      <div className="mb-2 flex min-w-0 items-center justify-between gap-2">
+        <span className="truncate text-[10px] font-medium uppercase tracking-[0.12em] text-app-subtle">{label}</span>
+        {isPending ? <LoaderCircle className="size-3.5 shrink-0 animate-spin text-app-subtle" /> : null}
+      </div>
+      <PromptInputSelect
+        disabled={disabled || isPending}
+        onValueChange={(nextValue) => {
+          const next = parseModelSelectValue(nextValue);
+          if (isPrimary && (!next.providerId || !next.modelRecordId)) {
+            return;
+          }
+          if (next.providerId === providerId && next.modelRecordId === modelRecordId) {
+            return;
+          }
+          onChange(next.providerId, next.modelRecordId);
+        }}
+        value={selectedValue}
+      >
+        <PromptInputSelectTrigger
+          className={cn(
+            "h-auto min-h-9 w-full justify-between rounded-lg border border-app-border/65 bg-app-surface px-2.5 py-2 text-left text-[12px] text-app-foreground shadow-none hover:bg-app-surface-hover",
+            !selectedModel && "text-app-muted",
+          )}
+        >
+          <PromptInputSelectValue>
+            <span className="flex min-w-0 items-center gap-2">
+              {selectedModel ? (
+                <ModelBrandIcon className="size-4 shrink-0" displayName={selectedModel.displayName} modelId={selectedModel.modelId} />
+              ) : null}
+              <span className="truncate">{selectedModel?.displayName ?? placeholder}</span>
+            </span>
+          </PromptInputSelectValue>
+        </PromptInputSelectTrigger>
+        <PromptInputSelectContent align="end" className="max-h-72 min-w-[320px]">
+          {!isPrimary ? (
+            <PromptInputSelectItem value={MODEL_SELECT_NONE_VALUE}>
+              <span className="text-app-muted">{t("settings.general.notSet")}</span>
+            </PromptInputSelectItem>
+          ) : null}
+          {groupedModels.map((group) => (
+            <div key={group.providerId}>
+              <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-app-subtle">
+                {group.providerName}
+              </div>
+              {group.models.map((model) => (
+                <PromptInputSelectItem key={`${model.providerId}:${model.modelRecordId}`} value={getModelSelectValue(model.providerId, model.modelRecordId)}>
+                  <span className="flex min-w-0 items-center gap-2">
+                    <ModelBrandIcon className="size-4 shrink-0" displayName={model.displayName} modelId={model.modelId} />
+                    <span className="min-w-0 truncate">{model.displayName}</span>
+                    <span className="ml-auto shrink-0 truncate font-mono text-[10px] text-app-subtle">
+                      {getShortModelId(model.modelId)}
+                    </span>
+                  </span>
+                </PromptInputSelectItem>
+              ))}
+            </div>
+          ))}
+          {models.length === 0 ? (
+            <div className="px-3 py-4 text-center text-[12px] text-app-muted">
+              {t("settings.general.noModelsAvailable")}
+            </div>
+          ) : null}
+        </PromptInputSelectContent>
+      </PromptInputSelect>
+      {selectedModel ? (
+        <p className="mt-1.5 truncate text-[11px] text-app-muted">{selectedModel.providerName}</p>
+      ) : models.length === 0 ? (
+        <p className="mt-1.5 text-[11px] text-app-muted">{t("settings.general.noModelsAvailable")}</p>
       ) : null}
     </div>
   );
@@ -1379,31 +1647,59 @@ function AgentTeamSection({
 
 function ProfileDetailsPanel({
   customSubagents,
+  onUpdateAgentProfile,
   profile,
   providers,
 }: {
   customSubagents: ReadonlyArray<CustomSubagent>;
+  onUpdateAgentProfile?: typeof updateAgentProfileAction;
   profile: AgentProfile | null;
   providers: ReadonlyArray<ProviderEntry>;
 }) {
   const t = useT();
+  const [pendingProfilePatchKey, setPendingProfilePatchKey] = useState<string | null>(null);
+  const [quickEditError, setQuickEditError] = useState<string | null>(null);
+  const availableModels = useMemo(() => getAvailableProfileModelOptions(providers), [providers]);
+
+  useEffect(() => {
+    setPendingProfilePatchKey(null);
+    setQuickEditError(null);
+  }, [profile?.id]);
 
   if (!profile) {
     return <p className="px-3 pb-3 pt-2 text-[11px] text-app-muted">{t("composer.noProfileAvailable")}</p>;
   }
 
+  const canQuickEdit = Boolean(onUpdateAgentProfile);
   const tiers: Array<{ label: string; tier: ProfileModelTier }> = [
     { label: t("composer.profileTier.primary"), tier: "primary" },
     { label: t("composer.profileTier.auxiliary"), tier: "assistant" },
     { label: t("composer.profileTier.lightweight"), tier: "lite" },
   ];
+  const runQuickEdit = async (key: string, patch: ProfileQuickEditPatch) => {
+    if (!onUpdateAgentProfile || pendingProfilePatchKey) {
+      return;
+    }
+
+    setQuickEditError(null);
+    setPendingProfilePatchKey(key);
+    try {
+      await onUpdateAgentProfile(profile.id, patch);
+    } catch (error) {
+      setQuickEditError(error instanceof Error ? error.message : t("sourceControl.requestFailed"));
+    } finally {
+      setPendingProfilePatchKey(null);
+    }
+  };
 
   return (
     <div className="max-h-[430px] space-y-3 overflow-y-auto rounded-2xl border border-app-border/65 bg-app-surface/45 p-3 [scrollbar-width:thin]">
       <div>
-        <p className="mb-2 text-[11px] font-medium uppercase tracking-[0.12em] text-app-subtle">
-          {t("composer.profileDetailsTitle")}
-        </p>
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-app-subtle">
+            {t("composer.profileDetailsTitle")}
+          </p>
+        </div>
         <div className="grid gap-2 sm:grid-cols-2">
           <ProfileDetailCard
             label={t("composer.profileResponseStyle")}
@@ -1413,34 +1709,50 @@ function ProfileDetailsPanel({
             label={t("composer.profileResponseLanguage")}
             value={profile.responseLanguage || t("composer.profileTier.notConfigured")}
           />
-          <ProfileDetailCard
-            className="sm:col-span-2"
-            icon={<Brain className="size-3.5" />}
-            label={t("composer.profileThinkingLevel")}
-            value={getThinkingLevelLabel(profile.thinkingLevel, t)}
-            description={getThinkingLevelDescription(profile.thinkingLevel, t)}
-          />
+          <div className="sm:col-span-2">
+            <QuickThinkingLevelControl
+              disabled={!canQuickEdit}
+              isPending={pendingProfilePatchKey === "thinkingLevel"}
+              onChange={(thinkingLevel) => {
+                void runQuickEdit("thinkingLevel", { thinkingLevel });
+              }}
+              value={profile.thinkingLevel}
+            />
+          </div>
         </div>
       </div>
 
       <div className="grid gap-2">
         {tiers.map(({ label, tier }) => {
           const providerId = getProfileTierProviderId(profile, tier);
-          const provider = providers.find((candidate) => candidate.id === providerId) ?? null;
-          const model = resolveProfileModelByTier(tier, profile, providers);
-          const value = model ? model.displayName : t("composer.profileTier.notConfigured");
-          const description = model ? (provider?.displayName ?? providerId) || undefined : undefined;
+          const modelRecordId = getProfileTierModelId(profile, tier);
 
           return (
-            <ProfileDetailCard
+            <QuickTierModelSelect
+              disabled={!canQuickEdit}
+              isPending={pendingProfilePatchKey === `model:${tier}`}
               key={tier}
               label={label}
-              value={value}
-              description={description}
+              modelRecordId={modelRecordId}
+              models={availableModels}
+              onChange={(nextProviderId, nextModelRecordId) => {
+                void runQuickEdit(
+                  `model:${tier}`,
+                  getProfileTierPatch(tier, nextProviderId, nextModelRecordId),
+                );
+              }}
+              providerId={providerId}
+              tier={tier}
             />
           );
         })}
       </div>
+
+      {quickEditError ? (
+        <p className="rounded-lg border border-app-danger/25 bg-app-danger/8 px-3 py-2 text-[11px] leading-4 text-app-danger">
+          {quickEditError}
+        </p>
+      ) : null}
 
       <AgentTeamSection customSubagents={customSubagents} profileId={profile.id} />
     </div>
@@ -1506,6 +1818,7 @@ export function WorkbenchPromptComposer({
   onOpenProfileSettings,
   onRuntimeQueueSubmitModeChange,
   onSelectAgentProfile,
+  onUpdateAgentProfile,
   onStop,
   onSubmit,
   placeholder,
@@ -2291,7 +2604,12 @@ export function WorkbenchPromptComposer({
                             ))}
                           </ModelSelectorGroup>
                         </ModelSelectorList>
-                        <ProfileDetailsPanel customSubagents={customSubagents} profile={activeProfile} providers={providers} />
+                        <ProfileDetailsPanel
+                          customSubagents={customSubagents}
+                          onUpdateAgentProfile={onUpdateAgentProfile}
+                          profile={activeProfile}
+                          providers={providers}
+                        />
                       </div>
                     </ModelSelectorContent>
                   </ModelSelector>


### PR DESCRIPTION
## Summary
- Add inline profile quick edit controls for thinking level and model tiers in the workbench composer.
- Wire profile updates through existing settings IPC actions from both dashboard and runtime thread surfaces.
- Add unit coverage for profile tier patch generation and enabled model option filtering.

## Test Plan
- [ ] Run `npm run typecheck`
- [ ] Run `npm run test:unit -- workbench-prompt-composer`
- [ ] Manually verify profile thinking level and model tier edits from the composer UI

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
