### PR TITLE
fix(render): 🐛 Preserve artifact results in message flow

### DIFF
--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -284,10 +284,7 @@ impl AgentRunManager {
             }
 
             let (runtime_tx, runtime_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-            let runtime_finish_rx = self
-                .runtime
-                .start_session(spec, runtime_tx, Arc::clone(&self.active_runs))
-                .await?;
+            let runtime_finish_rx = self.runtime.start_session(spec, runtime_tx).await?;
             let event_loop_handle = self.spawn_runtime_event_loop(run_id.clone(), runtime_rx);
             self.spawn_runtime_finish_watchdog(run_id.clone(), runtime_finish_rx);
 

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -474,13 +474,6 @@ pub struct AgentSession {
     pub(crate) abort_signal: tiycore::agent::AbortSignal,
     context_compression_state: Arc<StdMutex<ContextCompressionRuntimeState>>,
     runtime_queue_state: Arc<StdMutex<RuntimeQueueState>>,
-    /// Shared reference to the active-runs map so we can read the in-memory
-    /// `streaming_message_id` without querying the database (avoids race).
-    pub(crate) active_runs: Arc<
-        tokio::sync::Mutex<
-            std::collections::HashMap<String, crate::core::agent_run_manager::ActiveRun>,
-        >,
-    >,
 }
 
 impl AgentSession {
@@ -491,11 +484,6 @@ impl AgentSession {
         event_tx: mpsc::UnboundedSender<ThreadStreamEvent>,
         spec: AgentSessionSpec,
         max_turns: usize,
-        active_runs: Arc<
-            tokio::sync::Mutex<
-                std::collections::HashMap<String, crate::core::agent_run_manager::ActiveRun>,
-            >,
-        >,
     ) -> Arc<Self> {
         Arc::new_cyclic(|weak_self| {
             let agent = Arc::new(Agent::with_model(spec.model_plan.primary.model.clone()));
@@ -526,7 +514,6 @@ impl AgentSession {
                 abort_signal: tiycore::agent::AbortSignal::new(),
                 context_compression_state,
                 runtime_queue_state,
-                active_runs,
             }
         })
     }

--- a/src-tauri/src/core/agent_session_execution.rs
+++ b/src-tauri/src/core/agent_session_execution.rs
@@ -1,9 +1,5 @@
 use std::sync::atomic::Ordering;
 
-use tiycore::agent::AgentToolResult;
-use tiycore::types::{ContentBlock, TextContent};
-
-use crate::core::agent_run_manager::ActiveRun;
 use crate::core::agent_session::{
     standard_tool_timeout, CLARIFY_TOOL_NAME, PLAN_TOOL_NAME, RENDER_TOOL_NAME,
     STANDARD_TOOL_TIMEOUT_SECS, TASK_TOOL_NAMES,
@@ -27,6 +23,8 @@ use crate::core::workspace_paths;
 use crate::ipc::frontend_channels::{ArtifactStatus, ThreadStreamEvent};
 use crate::model::thread::MessageRecord;
 use crate::persistence::repo::{message_repo, tool_call_repo};
+use tiycore::agent::AgentToolResult;
+use tiycore::types::{ContentBlock, TextContent};
 
 use super::agent_session::AgentSession;
 
@@ -65,20 +63,80 @@ fn resolve_helper_tool_task(
     })
 }
 
-fn message_id_from_active_run(run: &ActiveRun) -> Option<String> {
-    if let Some(ref id) = run.streaming_message_id {
-        if !id.is_empty() {
-            let is_reasoning = run.reasoning_message_id.as_ref() == Some(id);
-            if !is_reasoning {
-                return Some(id.clone());
-            }
-        }
-    }
+fn render_chart_part(artifact_id: &str, chart_payload: &serde_json::Value) -> serde_json::Value {
+    serde_json::json!({
+        "type": "chart",
+        "artifactId": artifact_id,
+        "library": chart_payload
+            .get("library")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!("vega-lite")),
+        "spec": chart_payload
+            .get("spec")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({})),
+        "source": chart_payload
+            .get("source")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "title": chart_payload
+            .get("title")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "caption": chart_payload
+            .get("caption")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+        "status": chart_payload
+            .get("status")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!("ready")),
+        "error": chart_payload
+            .get("error")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null),
+    })
+}
 
-    run.last_completed_message_id
-        .as_ref()
-        .filter(|id| !id.is_empty())
-        .cloned()
+fn render_host_message_metadata(
+    tool_call_id: &str,
+    artifact_id: &str,
+    library: &str,
+) -> serde_json::Value {
+    serde_json::json!({
+        "kind": "render_artifact_host",
+        "toolCallId": tool_call_id,
+        "artifactId": artifact_id,
+        "library": library,
+    })
+}
+
+fn render_artifact_host_message(
+    thread_id: &str,
+    run_id: &str,
+    tool_call_id: &str,
+    message_id: &str,
+    artifact_id: &str,
+    library: &str,
+    chart_payload: &serde_json::Value,
+) -> Result<MessageRecord, serde_json::Error> {
+    let chart_part = render_chart_part(artifact_id, chart_payload);
+    let parts_json = serde_json::to_string(&vec![chart_part])?;
+    let metadata = render_host_message_metadata(tool_call_id, artifact_id, library);
+
+    Ok(MessageRecord {
+        id: message_id.to_string(),
+        thread_id: thread_id.to_string(),
+        run_id: Some(run_id.to_string()),
+        role: "assistant".to_string(),
+        content_markdown: String::new(),
+        parts_json: Some(parts_json),
+        message_type: "plain_message".to_string(),
+        status: "completed".to_string(),
+        metadata_json: Some(metadata.to_string()),
+        attachments_json: None,
+        created_at: String::new(),
+    })
 }
 
 impl AgentSession {
@@ -878,16 +936,60 @@ impl AgentSession {
             }
         };
 
-        // Resolve the message to attach the artifact to
-        let target_message_id = {
-            let runs = self.active_runs_message_id().await;
-            runs.unwrap_or_else(|| format!("chart-msg-{}", &artifact_id[..8]))
+        let host_message_id = uuid::Uuid::now_v7().to_string();
+        let host_message = match render_artifact_host_message(
+            &self.spec.thread_id,
+            &self.spec.run_id,
+            tool_call_id,
+            &host_message_id,
+            &artifact_id,
+            &library,
+            &chart_payload,
+        ) {
+            Ok(host_message) => host_message,
+            Err(error) => {
+                let error = format!("failed to serialize render artifact message parts: {error}");
+                let error_json = serde_json::json!({ "error": &error });
+                tool_call_repo::update_result(
+                    &self.pool,
+                    &tool_call_storage_id,
+                    &error_json.to_string(),
+                    "failed",
+                )
+                .await
+                .ok();
+                let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
+                    run_id: self.spec.run_id.clone(),
+                    tool_call_id: tool_call_id.to_string(),
+                    error: error.clone(),
+                });
+                return agent_error_result(error);
+            }
         };
+
+        if let Err(error) = message_repo::insert(&self.pool, &host_message).await {
+            let error = format!("failed to persist render artifact host message: {error}");
+            let error_json = serde_json::json!({ "error": &error });
+            tool_call_repo::update_result(
+                &self.pool,
+                &tool_call_storage_id,
+                &error_json.to_string(),
+                "failed",
+            )
+            .await
+            .ok();
+            let _ = self.event_tx.send(ThreadStreamEvent::ToolFailed {
+                run_id: self.spec.run_id.clone(),
+                tool_call_id: tool_call_id.to_string(),
+                error: error.clone(),
+            });
+            return agent_error_result(error);
+        }
 
         // Emit started event
         let _ = self.event_tx.send(ThreadStreamEvent::ArtifactUpdated {
             run_id: self.spec.run_id.clone(),
-            message_id: target_message_id.clone(),
+            message_id: host_message_id.clone(),
             artifact_id: artifact_id.clone(),
             artifact_type: "chart".to_string(),
             status: ArtifactStatus::Started,
@@ -895,26 +997,10 @@ impl AgentSession {
             error: None,
         });
 
-        // Persist chart artifact into message parts
-        if let Err(error) = message_repo::merge_chart_artifact_part(
-            &self.pool,
-            &target_message_id,
-            &artifact_id,
-            chart_payload.clone(),
-        )
-        .await
-        {
-            tracing::warn!(
-                artifact_id = %artifact_id,
-                error = %error,
-                "failed to persist chart artifact part"
-            );
-        }
-
         // Emit completed event
         let _ = self.event_tx.send(ThreadStreamEvent::ArtifactUpdated {
             run_id: self.spec.run_id.clone(),
-            message_id: target_message_id.clone(),
+            message_id: host_message_id.clone(),
             artifact_id: artifact_id.clone(),
             artifact_type: "chart".to_string(),
             status: ArtifactStatus::Completed,
@@ -926,7 +1012,7 @@ impl AgentSession {
         let result_json = serde_json::json!({
             "success": true,
             "artifactId": artifact_id,
-            "messageId": target_message_id,
+            "messageId": host_message_id,
             "library": library,
             "title": title,
             "caption": caption,
@@ -954,41 +1040,6 @@ impl AgentSession {
             ))],
             details: Some(result_json),
         }
-    }
-
-    /// Get the last streaming/completed message ID for the current run.
-    /// Skips reasoning messages since they cannot host artifact parts.
-    async fn active_runs_message_id(&self) -> Option<String> {
-        // First: check the in-memory message IDs tracked by the run manager —
-        // this is authoritative and avoids the DB race where the message hasn't
-        // been persisted yet by the async event handler.
-        {
-            let runs = self.active_runs.lock().await;
-            if let Some(run) = runs.get(&self.spec.run_id) {
-                if let Some(message_id) = message_id_from_active_run(run) {
-                    return Some(message_id);
-                }
-            }
-        }
-        // Fallback: query DB for the last non-reasoning assistant message in this run
-        let runs = self.active_runs_db_fallback().await;
-        runs.and_then(|id| if id.is_empty() { None } else { Some(id) })
-    }
-
-    /// DB fallback: look for the last completed plain_message in this run from DB.
-    async fn active_runs_db_fallback(&self) -> Option<String> {
-        let messages = message_repo::list_since_last_reset(&self.pool, &self.spec.thread_id)
-            .await
-            .ok()?;
-        messages
-            .iter()
-            .rev()
-            .find(|m| {
-                m.run_id.as_deref() == Some(&self.spec.run_id)
-                    && m.role == "assistant"
-                    && m.message_type != "reasoning"
-            })
-            .map(|m| m.id.clone())
     }
 
     async fn execute_task_tool(
@@ -1162,71 +1213,157 @@ impl AgentSession {
 
 #[cfg(test)]
 mod tests {
-    use super::{message_id_from_active_run, resolve_helper_tool_task, RuntimeOrchestrationTool};
-    use crate::core::agent_run_manager::ActiveRun;
+    use super::{
+        render_artifact_host_message, render_chart_part, render_host_message_metadata,
+        resolve_helper_tool_task, RuntimeOrchestrationTool,
+    };
     use crate::core::subagent::review_contract::{GlobalScanMode, ReviewScope, ReviewTarget};
-    use tokio::sync::broadcast;
-
-    fn active_run(
-        streaming_message_id: Option<&str>,
-        last_completed_message_id: Option<&str>,
-        reasoning_message_id: Option<&str>,
-    ) -> ActiveRun {
-        let (frontend_tx, _) = broadcast::channel(1);
-        ActiveRun {
-            run_id: "run-1".to_string(),
-            thread_id: "thread-1".to_string(),
-            profile_id: None,
-            frontend_tx,
-            lightweight_model_role: None,
-            auxiliary_model_role: None,
-            primary_model_role: None,
-            streaming_message_id: streaming_message_id.map(str::to_string),
-            last_completed_message_id: last_completed_message_id.map(str::to_string),
-            reasoning_message_id: reasoning_message_id.map(str::to_string),
-            cancellation_requested: false,
-        }
-    }
 
     #[test]
-    fn message_id_from_active_run_prefers_non_reasoning_streaming_message() {
-        let run = active_run(Some("streaming-msg"), Some("completed-msg"), None);
-
-        assert_eq!(
-            message_id_from_active_run(&run),
-            Some("streaming-msg".to_string())
-        );
-    }
-
-    #[test]
-    fn message_id_from_active_run_skips_reasoning_streaming_message_and_uses_completed() {
-        let run = active_run(
-            Some("reasoning-msg"),
-            Some("completed-msg"),
-            Some("reasoning-msg"),
+    fn render_chart_part_maps_vega_payload_fields() {
+        let part = render_chart_part(
+            "artifact-1",
+            &serde_json::json!({
+                "library": "vega-lite",
+                "spec": { "mark": "bar" },
+                "title": "Sales",
+                "caption": "Quarterly sales",
+                "status": "ready"
+            }),
         );
 
         assert_eq!(
-            message_id_from_active_run(&run),
-            Some("completed-msg".to_string())
+            part.get("type").and_then(serde_json::Value::as_str),
+            Some("chart")
         );
+        assert_eq!(
+            part.get("artifactId").and_then(serde_json::Value::as_str),
+            Some("artifact-1")
+        );
+        assert_eq!(
+            part.pointer("/spec/mark")
+                .and_then(serde_json::Value::as_str),
+            Some("bar")
+        );
+        assert_eq!(part.get("source"), Some(&serde_json::Value::Null));
+        assert_eq!(part.get("error"), Some(&serde_json::Value::Null));
     }
 
     #[test]
-    fn message_id_from_active_run_uses_completed_when_streaming_is_missing() {
-        let run = active_run(None, Some("completed-msg"), None);
+    fn render_chart_part_maps_html_source_fields() {
+        let part = render_chart_part(
+            "artifact-html",
+            &serde_json::json!({
+                "library": "html",
+                "source": "<div>Hello</div>",
+                "title": "HTML preview",
+                "caption": null,
+                "status": "ready"
+            }),
+        );
 
         assert_eq!(
-            message_id_from_active_run(&run),
-            Some("completed-msg".to_string())
+            part.get("library").and_then(serde_json::Value::as_str),
+            Some("html")
+        );
+        assert_eq!(
+            part.get("source").and_then(serde_json::Value::as_str),
+            Some("<div>Hello</div>")
+        );
+        assert_eq!(part.get("spec"), Some(&serde_json::json!({})));
+    }
+
+    #[test]
+    fn render_host_message_metadata_marks_render_artifact_hosts() {
+        let metadata = render_host_message_metadata("tool-call-1", "artifact-1", "svg");
+
+        assert_eq!(
+            metadata.get("kind").and_then(serde_json::Value::as_str),
+            Some("render_artifact_host")
+        );
+        assert_eq!(
+            metadata
+                .get("toolCallId")
+                .and_then(serde_json::Value::as_str),
+            Some("tool-call-1")
+        );
+        assert_eq!(
+            metadata
+                .get("artifactId")
+                .and_then(serde_json::Value::as_str),
+            Some("artifact-1")
+        );
+        assert_eq!(
+            metadata.get("library").and_then(serde_json::Value::as_str),
+            Some("svg")
         );
     }
 
     #[test]
-    fn message_id_from_active_run_ignores_empty_message_ids() {
-        let run = active_run(Some(""), Some(""), None);
+    fn render_artifact_host_message_contains_persistable_chart_part() {
+        let message = render_artifact_host_message(
+            "thread-1",
+            "run-1",
+            "tool-call-1",
+            "host-msg-1",
+            "artifact-1",
+            "vega-lite",
+            &serde_json::json!({
+                "library": "vega-lite",
+                "spec": { "mark": "line" },
+                "title": "Trend",
+                "caption": "A trend chart",
+                "status": "ready"
+            }),
+        )
+        .expect("render host message should serialize");
 
-        assert_eq!(message_id_from_active_run(&run), None);
+        assert_eq!(message.id, "host-msg-1");
+        assert_eq!(message.thread_id, "thread-1");
+        assert_eq!(message.run_id.as_deref(), Some("run-1"));
+        assert_eq!(message.role, "assistant");
+        assert_eq!(message.message_type, "plain_message");
+        assert_eq!(message.status, "completed");
+        assert!(message.content_markdown.is_empty());
+
+        let parts: Vec<serde_json::Value> = serde_json::from_str(
+            message
+                .parts_json
+                .as_deref()
+                .expect("host should include parts_json"),
+        )
+        .expect("parts_json should parse");
+        assert_eq!(parts.len(), 1);
+        assert_eq!(
+            parts[0]
+                .get("artifactId")
+                .and_then(serde_json::Value::as_str),
+            Some("artifact-1")
+        );
+        assert_eq!(
+            parts[0]
+                .pointer("/spec/mark")
+                .and_then(serde_json::Value::as_str),
+            Some("line")
+        );
+
+        let metadata: serde_json::Value = serde_json::from_str(
+            message
+                .metadata_json
+                .as_deref()
+                .expect("host should include metadata_json"),
+        )
+        .expect("metadata_json should parse");
+        assert_eq!(
+            metadata.get("kind").and_then(serde_json::Value::as_str),
+            Some("render_artifact_host")
+        );
+        assert_eq!(
+            metadata
+                .get("toolCallId")
+                .and_then(serde_json::Value::as_str),
+            Some("tool-call-1")
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -293,11 +293,6 @@ pub(super) mod tests {
         helper_orchestrator: Arc<HelperAgentOrchestrator>,
         event_tx: mpsc::UnboundedSender<ThreadStreamEvent>,
         workspace_path: String,
-        active_runs: Arc<
-            tokio::sync::Mutex<
-                std::collections::HashMap<String, crate::core::agent_run_manager::ActiveRun>,
-            >,
-        >,
     ) -> Arc<AgentSession> {
         let spec = AgentSessionSpec {
             run_id: run_id.to_string(),
@@ -314,15 +309,7 @@ pub(super) mod tests {
             initial_context_calibration: Default::default(),
         };
 
-        AgentSession::new(
-            pool,
-            tool_gateway,
-            helper_orchestrator,
-            event_tx,
-            spec,
-            4,
-            active_runs,
-        )
+        AgentSession::new(pool, tool_gateway, helper_orchestrator, event_tx, spec, 4)
     }
 
     #[tokio::test]
@@ -337,7 +324,6 @@ pub(super) mod tests {
             Arc::clone(&tool_gateway),
         ));
         let (event_tx, _event_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-        let active_runs = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let session = sample_agent_session(
             "run-queue-validation",
             "thread-queue-validation",
@@ -346,7 +332,6 @@ pub(super) mod tests {
             helper_orchestrator,
             event_tx,
             temp_dir.path().to_string_lossy().to_string(),
-            active_runs,
         );
 
         let error = session
@@ -373,7 +358,6 @@ pub(super) mod tests {
             Arc::clone(&tool_gateway),
         ));
         let (event_tx, _event_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-        let active_runs = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let spec = AgentSessionSpec {
             run_id: "run-queue-snapshot".to_string(),
             thread_id: "thread-queue-snapshot".to_string(),
@@ -388,15 +372,7 @@ pub(super) mod tests {
             initial_prompt: None,
             initial_context_calibration: Default::default(),
         };
-        let session = AgentSession::new(
-            pool,
-            tool_gateway,
-            helper_orchestrator,
-            event_tx,
-            spec,
-            4,
-            active_runs,
-        );
+        let session = AgentSession::new(pool, tool_gateway, helper_orchestrator, event_tx, spec, 4);
 
         let enqueue_snapshot = session
             .enqueue_queue_message(
@@ -4555,7 +4531,6 @@ Used for prompt assembly coverage.
             Arc::clone(&tool_gateway),
         ));
         let (event_tx, _event_rx) = mpsc::unbounded_channel::<ThreadStreamEvent>();
-        let active_runs = Arc::new(tokio::sync::Mutex::new(std::collections::HashMap::new()));
         let spec = AgentSessionSpec {
             run_id: "run-cancel-consistency".to_string(),
             thread_id: "thread-cancel-consistency".to_string(),
@@ -4570,15 +4545,7 @@ Used for prompt assembly coverage.
             initial_prompt: None,
             initial_context_calibration: Default::default(),
         };
-        let session = AgentSession::new(
-            pool,
-            tool_gateway,
-            helper_orchestrator,
-            event_tx,
-            spec,
-            4,
-            active_runs,
-        );
+        let session = AgentSession::new(pool, tool_gateway, helper_orchestrator, event_tx, spec, 4);
 
         // Enqueue a follow-up message.
         let first_snapshot = session

--- a/src-tauri/src/core/built_in_agent_runtime.rs
+++ b/src-tauri/src/core/built_in_agent_runtime.rs
@@ -55,11 +55,6 @@ impl BuiltInAgentRuntime {
         &self,
         spec: AgentSessionSpec,
         event_tx: mpsc::UnboundedSender<ThreadStreamEvent>,
-        active_runs: Arc<
-            tokio::sync::Mutex<
-                std::collections::HashMap<String, crate::core::agent_run_manager::ActiveRun>,
-            >,
-        >,
     ) -> Result<watch::Receiver<RuntimeSessionFinishState>, AppError> {
         let max_turns =
             crate::core::agent_runtime_limits::desktop_agent_max_turns(&self.pool).await;
@@ -70,7 +65,6 @@ impl BuiltInAgentRuntime {
             event_tx,
             spec.clone(),
             max_turns,
-            active_runs,
         );
         let run_task = Arc::clone(&session).start();
         let (finish_state_tx, finish_state_rx) = watch::channel(RuntimeSessionFinishState::Running);

--- a/src/modules/workbench-shell/ui/merge-artifact-part.test.ts
+++ b/src/modules/workbench-shell/ui/merge-artifact-part.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  mergeArtifactEventIntoMessages,
   mergeArtifactPartIntoMessage,
   type ArtifactEvent,
   type SurfaceMessage,
@@ -25,6 +26,8 @@ function makeEvent(overrides: Partial<ArtifactEvent> = {}): ArtifactEvent {
   return {
     artifactId: "art-1",
     artifactType: "chart",
+    messageId: "msg-1",
+    runId: "run-1",
     kind: "completed",
     payload: { library: "vega-lite", spec: { mark: "line" } },
     ...overrides,
@@ -174,5 +177,91 @@ describe("mergeArtifactPartIntoMessage", () => {
     const original = { ...msg, parts: [...msg.parts] };
     mergeArtifactPartIntoMessage(msg, makeEvent());
     expect(msg.parts).toEqual(original.parts);
+  });
+});
+
+describe("mergeArtifactEventIntoMessages", () => {
+  it("creates a render artifact host message when no non-reasoning message exists", () => {
+    const result = mergeArtifactEventIntoMessages(
+      [],
+      makeEvent({ messageId: "host-msg", runId: "run-host", kind: "started" }),
+      "2026-01-02T00:00:00Z",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      id: "host-msg",
+      createdAt: "2026-01-02T00:00:00Z",
+      messageType: "plain_message",
+      role: "assistant",
+      runId: "run-host",
+      content: "",
+      status: "streaming",
+    });
+    expect(result[0].parts).toHaveLength(1);
+    expect(result[0].parts[0]).toMatchObject({
+      type: "chart",
+      artifactId: "art-1",
+      status: "loading",
+    });
+  });
+
+  it("updates the same host chart part from started to completed", () => {
+    const started = mergeArtifactEventIntoMessages(
+      [],
+      makeEvent({ messageId: "host-msg", runId: "run-host", kind: "started" }),
+      "2026-01-02T00:00:00Z",
+    );
+    const completed = mergeArtifactEventIntoMessages(
+      started,
+      makeEvent({ messageId: "host-msg", runId: "run-host", kind: "completed" }),
+      "2026-01-02T00:00:01Z",
+    );
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0].id).toBe("host-msg");
+    expect(completed[0].status).toBe("completed");
+    expect(completed[0].parts).toHaveLength(1);
+    expect(completed[0].parts[0]).toMatchObject({
+      type: "chart",
+      artifactId: "art-1",
+      status: "ready",
+    });
+  });
+
+  it("does not attach artifacts to reasoning messages and creates a host instead", () => {
+    const reasoning = makeMessage({
+      id: "reasoning-msg",
+      messageType: "reasoning",
+      content: "thinking",
+      parts: [{ type: "text", text: "thinking" }],
+    });
+
+    const result = mergeArtifactEventIntoMessages(
+      [reasoning],
+      makeEvent({ messageId: "host-msg", runId: "run-1" }),
+      "2026-01-02T00:00:00Z",
+    );
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(reasoning);
+    expect(result[0].parts).toEqual([{ type: "text", text: "thinking" }]);
+    expect(result[1]).toMatchObject({
+      id: "host-msg",
+      messageType: "plain_message",
+      role: "assistant",
+    });
+    expect(result[1].parts[0]).toMatchObject({ type: "chart", artifactId: "art-1" });
+  });
+
+  it("returns messages unchanged for non-chart artifacts", () => {
+    const messages = [makeMessage()];
+    const result = mergeArtifactEventIntoMessages(
+      messages,
+      makeEvent({ artifactType: "unknown" }),
+      "2026-01-02T00:00:00Z",
+    );
+
+    expect(result).toBe(messages);
   });
 });

--- a/src/modules/workbench-shell/ui/merge-artifact-part.test.ts
+++ b/src/modules/workbench-shell/ui/merge-artifact-part.test.ts
@@ -229,9 +229,30 @@ describe("mergeArtifactEventIntoMessages", () => {
     });
   });
 
+  it("keeps host messages streaming while artifact deltas arrive", () => {
+    const started = mergeArtifactEventIntoMessages(
+      [],
+      makeEvent({ messageId: "host-msg", runId: "run-host", kind: "started" }),
+      "2026-01-02T00:00:00Z",
+    );
+    const delta = mergeArtifactEventIntoMessages(
+      started,
+      makeEvent({ messageId: "host-msg", runId: "run-host", kind: "delta" }),
+      "2026-01-02T00:00:01Z",
+    );
+
+    expect(delta).toHaveLength(1);
+    expect(delta[0].status).toBe("streaming");
+    expect(delta[0].parts[0]).toMatchObject({
+      type: "chart",
+      artifactId: "art-1",
+      status: "ready",
+    });
+  });
+
   it("does not attach artifacts to reasoning messages and creates a host instead", () => {
     const reasoning = makeMessage({
-      id: "reasoning-msg",
+      id: "host-msg",
       messageType: "reasoning",
       content: "thinking",
       parts: [{ type: "text", text: "thinking" }],
@@ -252,6 +273,27 @@ describe("mergeArtifactEventIntoMessages", () => {
       role: "assistant",
     });
     expect(result[1].parts[0]).toMatchObject({ type: "chart", artifactId: "art-1" });
+  });
+
+  it("does not treat non-chart non-text messages as artifact hosts", () => {
+    const existing = makeMessage({
+      id: "host-msg",
+      content: "",
+      parts: [{ type: "data-custom", data: { ok: true } }],
+      status: "completed",
+    });
+
+    const result = mergeArtifactEventIntoMessages(
+      [existing],
+      makeEvent({ messageId: "host-msg", runId: "run-1", kind: "started" }),
+      "2026-01-02T00:00:00Z",
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0].status).toBe("completed");
+    expect(result[0].parts).toHaveLength(2);
+    expect(result[0].parts[0]).toEqual({ type: "data-custom", data: { ok: true } });
+    expect(result[0].parts[1]).toMatchObject({ type: "chart", artifactId: "art-1" });
   });
 
   it("returns messages unchanged for non-chart artifacts", () => {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -572,6 +572,8 @@ export function appendOrReplaceMessage(
 export type ArtifactEvent = {
   artifactId: string;
   artifactType: string;
+  messageId?: string;
+  runId?: string;
   payload?: unknown;
   error?: string;
   kind: "started" | "delta" | "completed" | "failed";
@@ -627,6 +629,62 @@ export function mergeArtifactPartIntoMessage(
     ...message,
     parts: nextParts,
   };
+}
+
+export function createArtifactHostMessage(
+  event: ArtifactEvent & { messageId: string; runId: string },
+  createdAt: string,
+): SurfaceMessage {
+  return {
+    createdAt,
+    id: event.messageId,
+    messageType: "plain_message",
+    metadata: null,
+    attachments: [],
+    role: "assistant",
+    runId: event.runId,
+    content: "",
+    parts: [],
+    status: event.kind === "started" ? "streaming" : event.kind === "failed" ? "failed" : "completed",
+  };
+}
+
+export function mergeArtifactEventIntoMessages(
+  messages: Array<SurfaceMessage>,
+  event: ArtifactEvent,
+  createdAt: string,
+): Array<SurfaceMessage> {
+  if (event.artifactType !== "chart" || !event.messageId || !event.runId) {
+    return messages;
+  }
+
+  const existingIndex = messages.findIndex(
+    (message) => message.id === event.messageId && message.messageType !== "reasoning",
+  );
+
+  if (existingIndex !== -1) {
+    const nextMessages = [...messages];
+    const existing = nextMessages[existingIndex];
+    const merged = mergeArtifactPartIntoMessage(existing, event);
+    const isArtifactHost = existing.role === "assistant"
+      && existing.content.trim().length === 0
+      && existing.parts.every(
+        (part) => part.type !== "text" || ("text" in part && part.text.trim().length === 0),
+      );
+    nextMessages[existingIndex] = {
+      ...merged,
+      status: isArtifactHost
+        ? event.kind === "started" ? "streaming" : event.kind === "failed" ? "failed" : "completed"
+        : existing.status,
+    };
+    return nextMessages;
+  }
+
+  const hostMessage = createArtifactHostMessage(
+    { ...event, messageId: event.messageId, runId: event.runId },
+    createdAt,
+  );
+  return [...messages, mergeArtifactPartIntoMessage(hostMessage, event)];
 }
 
 export function prependOlderMessages(

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -645,7 +645,11 @@ export function createArtifactHostMessage(
     runId: event.runId,
     content: "",
     parts: [],
-    status: event.kind === "started" ? "streaming" : event.kind === "failed" ? "failed" : "completed",
+    status: event.kind === "started" || event.kind === "delta"
+      ? "streaming"
+      : event.kind === "failed"
+        ? "failed"
+        : "completed",
   };
 }
 
@@ -669,12 +673,17 @@ export function mergeArtifactEventIntoMessages(
     const isArtifactHost = existing.role === "assistant"
       && existing.content.trim().length === 0
       && existing.parts.every(
-        (part) => part.type !== "text" || ("text" in part && part.text.trim().length === 0),
+        (part) => part.type === "chart"
+          || (part.type === "text" && "text" in part && part.text.trim().length === 0),
       );
     nextMessages[existingIndex] = {
       ...merged,
       status: isArtifactHost
-        ? event.kind === "started" ? "streaming" : event.kind === "failed" ? "failed" : "completed"
+        ? event.kind === "started" || event.kind === "delta"
+          ? "streaming"
+          : event.kind === "failed"
+            ? "failed"
+            : "completed"
         : existing.status,
     };
     return nextMessages;

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -129,7 +129,7 @@ import {
   mapSnapshotMessage,
   mapRecordedUserMessage,
   mapSnapshotTool,
-  mergeArtifactPartIntoMessage,
+  mergeArtifactEventIntoMessages,
   mergeSnapshotMessages,
   mergeSnapshotTools,
   prependOlderMessages,
@@ -372,44 +372,6 @@ export function RuntimeThreadSurface({
   const conversationContextRef = useRef<StickToBottomContext | null>(null);
   const lastOptimisticUserIdRef = useRef<string | null>(null);
 
-  // Buffer for artifact events that arrive before their target message exists
-  // in React state. Keyed by messageId → array of pending artifact events.
-  type PendingArtifactEntry = { artifactId: string; artifactType: string; payload?: unknown; error?: string; kind: "started" | "delta" | "completed" | "failed"; runId?: string };
-  const pendingArtifactsRef = useRef<Map<string, Array<PendingArtifactEntry>>>(new Map());
-
-  /**
-   * Drain orphaned artifacts from the same run that were buffered under a
-   * synthetic/mismatched messageId (e.g. when the render tool executed before
-   * the assistant message existed). Mutates pendingArtifactsRef in place and
-   * returns the updated messages array with artifacts merged in.
-   */
-  function drainOrphanedArtifacts(
-    messages: SurfaceMessage[],
-    runId: string | undefined,
-    targetMessageId: string,
-  ): SurfaceMessage[] {
-    if (!runId || pendingArtifactsRef.current.size === 0) return messages;
-    let result = messages;
-    const keysToDelete: string[] = [];
-    for (const [key, entries] of pendingArtifactsRef.current.entries()) {
-      if (key === targetMessageId) continue;
-      if (entries.length > 0 && entries[0].runId === runId) {
-        keysToDelete.push(key);
-        for (const artifact of entries) {
-          result = result.map((message) => (
-            message.id === targetMessageId
-              ? mergeArtifactPartIntoMessage(message, artifact)
-              : message
-          ));
-        }
-      }
-    }
-    for (const key of keysToDelete) {
-      pendingArtifactsRef.current.delete(key);
-    }
-    return result;
-  }
-
   // --- Delayed auto-collapse infrastructure ---
   const userManuallyOpenedIds = useRef<Set<string>>(new Set());
 
@@ -547,8 +509,7 @@ export function RuntimeThreadSurface({
       setSnapshotReady(true);
       setSnapshotThreadId(null);
       setThinkingPlaceholder(null);
-      pendingArtifactsRef.current.clear();
-      
+
       return;
     }
 
@@ -777,7 +738,6 @@ export function RuntimeThreadSurface({
     clearScheduledThinkingPhase();
     setThinkingPlaceholder(null);
     setTools([]);
-    pendingArtifactsRef.current.clear();
     void loadSnapshot();
   }, [clearScheduledThinkingPhase, loadSnapshot, threadId]);
 
@@ -933,22 +893,6 @@ export function RuntimeThreadSurface({
             parts: [{ type: "text" as const, text: accumulatedText }, ...nonTextParts],
             status: "streaming",
           });
-          // Drain any buffered artifacts targeting this message
-          const pending = pendingArtifactsRef.current.get(event.messageId);
-          if (pending && pending.length > 0) {
-            pendingArtifactsRef.current.delete(event.messageId);
-            for (const artifact of pending) {
-              result = result.map((message) => (
-                message.id === event.messageId
-                  ? mergeArtifactPartIntoMessage(message, artifact)
-                  : message
-              ));
-            }
-          }
-          // Run-aware sweep: drain orphaned artifacts from the same run that
-          // were buffered under a synthetic/mismatched messageId (e.g. when
-          // the render tool executed before this assistant message existed).
-          result = drainOrphanedArtifacts(result, event.runId, event.messageId);
           return result;
         });
         return;
@@ -957,7 +901,7 @@ export function RuntimeThreadSurface({
       setMessages((current) => {
         const existing = current.find((entry) => entry.id === event.messageId);
         const nonTextParts = existing?.parts.filter((p) => p.type !== "text") ?? [];
-        let result = appendOrReplaceMessage(current, {
+        const result = appendOrReplaceMessage(current, {
           createdAt: existing?.createdAt ?? new Date().toISOString(),
           id: event.messageId,
           messageType: "plain_message",
@@ -968,20 +912,6 @@ export function RuntimeThreadSurface({
           parts: [{ type: "text" as const, text: event.content ?? "" }, ...nonTextParts],
           status: "completed",
         });
-        // Drain any buffered artifacts targeting this message
-        const pending = pendingArtifactsRef.current.get(event.messageId);
-        if (pending && pending.length > 0) {
-          pendingArtifactsRef.current.delete(event.messageId);
-          for (const artifact of pending) {
-            result = result.map((message) => (
-              message.id === event.messageId
-                ? mergeArtifactPartIntoMessage(message, artifact)
-                : message
-            ));
-          }
-        }
-        // Run-aware sweep: drain orphaned artifacts from the same run
-        result = drainOrphanedArtifacts(result, event.runId, event.messageId);
         return result;
       });
 
@@ -1031,29 +961,7 @@ export function RuntimeThreadSurface({
     });
 
     stream.onArtifact = withActiveStream((event) => {
-      setMessages((current) => {
-        // Only attach to non-reasoning messages directly; reasoning messages
-        // should not host chart artifacts since the UI won't render them there.
-        const hasMatch = current.some(
-          (message) => message.id === event.messageId && message.messageType !== "reasoning",
-        );
-        if (hasMatch) {
-          return current.map((message) => (
-            message.id === event.messageId
-              ? mergeArtifactPartIntoMessage(message, event)
-              : message
-          ));
-        }
-        // No matching non-reasoning message yet — buffer the artifact for later attachment
-        console.warn(
-          `[onArtifact] No non-reasoning message found for artifact ${event.artifactId} (messageId: ${event.messageId}). Buffering for later.`,
-        );
-        const pending = pendingArtifactsRef.current;
-        const existing = pending.get(event.messageId) ?? [];
-        existing.push(event);
-        pending.set(event.messageId, existing);
-        return current;
-      });
+      setMessages((current) => mergeArtifactEventIntoMessages(current, event, new Date().toISOString()));
     });
 
     stream.onQueue = withActiveStream((event: QueueEvent) => {


### PR DESCRIPTION
## Summary
- Persist successful render results as dedicated artifact-host assistant messages.
- Render artifact events now target the host message instead of nearby text or reasoning messages.
- Add frontend host-message upsert logic and tests so artifact-only render output appears in the thread flow.

## Test Plan
- [x] `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] `cargo test --locked --manifest-path src-tauri/Cargo.toml agent_session_execution`
- [x] `npm run typecheck`
- [x] `npm run test:unit -- merge-artifact-part`
- [x] `agent_review` final pass

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
