### PR TITLE
fix(thread): 🐛 hide custom agent tool calls and display proper names

### DIFF
--- a/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.test.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.test.ts
@@ -69,7 +69,7 @@ describe("formatHelperKind", () => {
   });
 
   it("handles empty slug after prefix gracefully", () => {
-    // helper_custom_ with no slug — should return empty string from capitalizeSlug
+    // helper_custom_ with no slug — capitalizeSlug returns empty string
     expect(formatHelperKind("helper_custom_")).toBe("");
   });
 

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.test.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatHelperKind,
+  formatHelperName,
+  formatHelperSummary,
+} from "./runtime-thread-surface-helpers";
+import type { RuntimeSurfaceHelperEntry } from "./runtime-thread-surface-helpers";
+
+function makeHelper(
+  overrides: Partial<RuntimeSurfaceHelperEntry> = {},
+): RuntimeSurfaceHelperEntry {
+  return {
+    completedSteps: 0,
+    currentAction: null,
+    error: undefined,
+    finishedAt: null,
+    id: "h1",
+    inputSummary: null,
+    kind: "helper_explore",
+    latestMessage: undefined,
+    recentActions: [],
+    runId: "run-1",
+    startedAt: "2026-05-25T00:00:00Z",
+    status: "completed",
+    summary: null,
+    toolCounts: {},
+    totalToolCalls: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// formatHelperKind
+// ---------------------------------------------------------------------------
+
+describe("formatHelperKind", () => {
+  it("returns 'Explore Agent' for helper_explore", () => {
+    expect(formatHelperKind("helper_explore")).toBe("Explore Agent");
+  });
+
+  it("returns 'Review Agent' for helper_review", () => {
+    expect(formatHelperKind("helper_review")).toBe("Review Agent");
+  });
+
+  it("returns custom name from slugToNameMap when slug is present", () => {
+    const map = new Map([["refactor", "Refactor Agent"]]);
+    expect(formatHelperKind("helper_custom_refactor", map)).toBe(
+      "Refactor Agent",
+    );
+  });
+
+  it("falls back to capitalized slug when slug is not in map", () => {
+    expect(formatHelperKind("helper_custom_code-review")).toBe(
+      "Code Review",
+    );
+  });
+
+  it("falls back to capitalized single-word slug", () => {
+    expect(formatHelperKind("helper_custom_refactor")).toBe("Refactor");
+  });
+
+  it("returns raw kind for non-custom unknown kinds", () => {
+    expect(formatHelperKind("helper_unknown")).toBe("helper_unknown");
+  });
+
+  it("returns raw kind for unrelated strings", () => {
+    expect(formatHelperKind("anything_else")).toBe("anything_else");
+  });
+
+  it("handles empty slug after prefix gracefully", () => {
+    // helper_custom_ with no slug — should return empty string from capitalizeSlug
+    expect(formatHelperKind("helper_custom_")).toBe("");
+  });
+
+  it("prefers map name over capitalized slug", () => {
+    const map = new Map([["my-agent", "My Custom Name"]]);
+    expect(formatHelperKind("helper_custom_my-agent", map)).toBe(
+      "My Custom Name",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHelperName
+// ---------------------------------------------------------------------------
+
+describe("formatHelperName", () => {
+  it("delegates to formatHelperKind without slugToNameMap", () => {
+    const helper = makeHelper({ kind: "helper_explore" });
+    expect(formatHelperName(helper)).toBe("Explore Agent");
+  });
+
+  it("passes slugToNameMap through to formatHelperKind", () => {
+    const map = new Map([["refactor", "Refactor Helper"]]);
+    const helper = makeHelper({ kind: "helper_custom_refactor" });
+    expect(formatHelperName(helper, map)).toBe("Refactor Helper");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatHelperSummary
+// ---------------------------------------------------------------------------
+
+describe("formatHelperSummary", () => {
+  it("joins name and detail summary with middle dot", () => {
+    const helper = makeHelper({
+      kind: "helper_explore",
+      inputSummary: "scanning files",
+      totalToolCalls: 3,
+    });
+    expect(formatHelperSummary(helper)).toBe(
+      "Explore Agent · scanning files · 3 tool calls",
+    );
+  });
+
+  it("includes custom name from slugToNameMap", () => {
+    const map = new Map([["refactor", "Refactor Agent"]]);
+    const helper = makeHelper({
+      kind: "helper_custom_refactor",
+      inputSummary: "restructuring module",
+      totalToolCalls: 1,
+    });
+    expect(formatHelperSummary(helper, map)).toBe(
+      "Refactor Agent · restructuring module · 1 tool call",
+    );
+  });
+
+  it("omits inputSummary when null", () => {
+    const helper = makeHelper({
+      kind: "helper_review",
+      inputSummary: null,
+      totalToolCalls: 5,
+    });
+    expect(formatHelperSummary(helper)).toBe(
+      "Review Agent · 5 tool calls",
+    );
+  });
+
+  it("returns only name when no detail summary parts", () => {
+    const helper = makeHelper({
+      kind: "helper_explore",
+      inputSummary: null,
+      totalToolCalls: 0,
+    });
+    expect(formatHelperSummary(helper)).toBe("Explore Agent");
+  });
+});

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
@@ -95,13 +95,30 @@ export function applyHelperSnapshot(
   };
 }
 
-export function formatHelperKind(kind: string) {
+const CUSTOM_PREFIX = "helper_custom_";
+
+function capitalizeSlug(slug: string) {
+  return slug
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function formatHelperKind(
+  kind: string,
+  slugToNameMap?: ReadonlyMap<string, string>,
+) {
   switch (kind) {
     case "helper_explore":
       return "Explore Agent";
     case "helper_review":
       return "Review Agent";
     default:
+      if (kind.startsWith(CUSTOM_PREFIX)) {
+        const slug = kind.slice(CUSTOM_PREFIX.length);
+        const customName = slugToNameMap?.get(slug);
+        return customName ?? capitalizeSlug(slug);
+      }
       return kind;
   }
 }
@@ -110,15 +127,21 @@ export function formatToolCallCount(count: number) {
   return `${count} tool call${count === 1 ? "" : "s"}`;
 }
 
-export function formatHelperSummary(helper: RuntimeSurfaceHelperEntry) {
+export function formatHelperSummary(
+  helper: RuntimeSurfaceHelperEntry,
+  slugToNameMap?: ReadonlyMap<string, string>,
+) {
   return [
-    formatHelperName(helper),
+    formatHelperName(helper, slugToNameMap),
     formatHelperDetailSummary(helper),
   ].filter(Boolean).join(" · ");
 }
 
-export function formatHelperName(helper: RuntimeSurfaceHelperEntry) {
-  return formatHelperKind(helper.kind);
+export function formatHelperName(
+  helper: RuntimeSurfaceHelperEntry,
+  slugToNameMap?: ReadonlyMap<string, string>,
+) {
+  return formatHelperKind(helper.kind, slugToNameMap);
 }
 
 export function formatHelperDetailSummary(helper: RuntimeSurfaceHelperEntry) {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-helpers.ts
@@ -100,6 +100,7 @@ const CUSTOM_PREFIX = "helper_custom_";
 function capitalizeSlug(slug: string) {
   return slug
     .split("-")
+    .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 }

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -1,5 +1,6 @@
 import type { TranslationKey } from "@/i18n";
 import { isHelperOwnedTool } from "@/modules/workbench-shell/model/helpers";
+import { isRuntimeOrchestrationToolName } from "@/shared/constants/tool-names";
 import type {
   ChartMessagePartDto,
   DataMessagePartDto,
@@ -922,13 +923,6 @@ export function getApprovalTagClass(tool: SurfaceToolEntry) {
   return "border-app-success/24 bg-app-success/10 text-app-success";
 }
 
-function isRuntimeOrchestrationTool(toolName: string) {
-  return (
-    toolName === "agent_explore"
-    || toolName === "agent_review"
-  );
-}
-
 export function isVisibleTimelineTool(
   tool: SurfaceToolEntry,
   helperIds: ReadonlySet<string>,
@@ -937,7 +931,7 @@ export function isVisibleTimelineTool(
     return tool.state === "clarify-requested";
   }
 
-  return !isHelperOwnedTool(tool.id, helperIds) && !isRuntimeOrchestrationTool(tool.name);
+  return !isHelperOwnedTool(tool.id, helperIds) && !isRuntimeOrchestrationToolName(tool.name);
 }
 
 export function compareTimelineEntries(left: TimelineEntry, right: TimelineEntry) {

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -247,6 +247,10 @@ export function RuntimeThreadSurface({
   const globalAgentProfileId = useStore(settingsStore, (s) => s.activeAgentProfileId);
   const agentProfiles = useStore(settingsStore, (s) => s.agentProfiles);
   const customSubagents = useStore(settingsStore, (s) => s.customSubagents, shallowEqual);
+  const customAgentSlugToName = useMemo(
+    () => new Map(customSubagents.map((a) => [a.slug, a.name])),
+    [customSubagents],
+  );
   const providers = useStore(settingsStore, (s) => s.providers);
   const defaultAppendMessageKind = useStore(settingsStore, (s) => s.general.defaultAppendMessageKind);
   const isNewThreadMode = useStore(threadStore, (s) => s.isNewThreadMode);
@@ -2783,9 +2787,9 @@ export function RuntimeThreadSurface({
 
               if (entry.kind === "helper") {
                 const { helper } = entry;
-                const helperName = formatHelperName(helper);
+                const helperName = formatHelperName(helper, customAgentSlugToName);
                 const helperDetailSummary = formatHelperDetailSummary(helper);
-                const helperSummary = formatHelperSummary(helper);
+                const helperSummary = formatHelperSummary(helper, customAgentSlugToName);
                 const helperToolCounts = formatHelperToolCounts(helper.toolCounts);
                 const executionSummary = formatExecutionSummary({
                   elapsedText: formatElapsedSeconds(getHelperElapsedSeconds(helper)),

--- a/src/shared/constants/tool-names.test.ts
+++ b/src/shared/constants/tool-names.test.ts
@@ -16,6 +16,15 @@ describe("isRuntimeOrchestrationToolName", () => {
     }
   });
 
+  it("returns true for custom agent tool names", () => {
+    expect(isRuntimeOrchestrationToolName("agent_refactor")).toBe(true);
+    expect(isRuntimeOrchestrationToolName("agent_custom_helper")).toBe(true);
+  });
+
+  it("returns true for bare prefix (agent_)", () => {
+    expect(isRuntimeOrchestrationToolName("agent_")).toBe(true);
+  });
+
   it("returns false for non-orchestration tool names", () => {
     expect(isRuntimeOrchestrationToolName("read")).toBe(false);
     expect(isRuntimeOrchestrationToolName("edit")).toBe(false);
@@ -27,12 +36,6 @@ describe("isRuntimeOrchestrationToolName", () => {
     expect(isRuntimeOrchestrationToolName("")).toBe(false);
     expect(isRuntimeOrchestrationToolName("AGENT_EXPLORE")).toBe(false);
     expect(isRuntimeOrchestrationToolName("Agent_Explore")).toBe(false);
-  });
-
-  it("returns false for partial or extended matches", () => {
-    expect(isRuntimeOrchestrationToolName("agent_")).toBe(false);
-    expect(isRuntimeOrchestrationToolName("agent_explore_extra")).toBe(false);
-    expect(isRuntimeOrchestrationToolName("agent_review_v2")).toBe(false);
   });
 });
 

--- a/src/shared/constants/tool-names.test.ts
+++ b/src/shared/constants/tool-names.test.ts
@@ -21,8 +21,8 @@ describe("isRuntimeOrchestrationToolName", () => {
     expect(isRuntimeOrchestrationToolName("agent_custom_helper")).toBe(true);
   });
 
-  it("returns true for bare prefix (agent_)", () => {
-    expect(isRuntimeOrchestrationToolName("agent_")).toBe(true);
+  it("returns false for bare prefix (agent_)", () => {
+    expect(isRuntimeOrchestrationToolName("agent_")).toBe(false);
   });
 
   it("returns false for non-orchestration tool names", () => {

--- a/src/shared/constants/tool-names.ts
+++ b/src/shared/constants/tool-names.ts
@@ -29,7 +29,10 @@ export const DEFAULT_COLLAPSED_TOOLS = [
 ] as const;
 
 export function isRuntimeOrchestrationToolName(toolName: string): boolean {
-  return toolName.startsWith(RUNTIME_ORCHESTRATION_TOOL_PREFIX);
+  return (
+    toolName.startsWith(RUNTIME_ORCHESTRATION_TOOL_PREFIX)
+    && toolName.length > RUNTIME_ORCHESTRATION_TOOL_PREFIX.length
+  );
 }
 
 export function isTaskBoardTool(toolName: string): boolean {

--- a/src/shared/constants/tool-names.ts
+++ b/src/shared/constants/tool-names.ts
@@ -11,6 +11,9 @@ export const RUNTIME_ORCHESTRATION_TOOLS = [
   "agent_review",
 ] as const;
 
+/** The prefix shared by all runtime orchestration tool names (built-in and custom). */
+export const RUNTIME_ORCHESTRATION_TOOL_PREFIX = "agent_";
+
 /** Task board tools. */
 export const TASK_BOARD_TOOLS = [
   "create_task",
@@ -26,7 +29,7 @@ export const DEFAULT_COLLAPSED_TOOLS = [
 ] as const;
 
 export function isRuntimeOrchestrationToolName(toolName: string): boolean {
-  return (RUNTIME_ORCHESTRATION_TOOLS as ReadonlyArray<string>).includes(toolName);
+  return toolName.startsWith(RUNTIME_ORCHESTRATION_TOOL_PREFIX);
 }
 
 export function isTaskBoardTool(toolName: string): boolean {


### PR DESCRIPTION
## Summary
- Fix custom agent `agent_{slug}` tool calls leaking into the timeline alongside helper cards
- Display user-defined custom agent names instead of raw `helper_custom_{slug}` strings
- Unify `isRuntimeOrchestrationToolName` to use `startsWith("agent_")` pattern, eliminating duplicate implementations

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` passes (752 tests)
- [ ] Create a custom agent (e.g. slug=refactor, name="Refactor Agent"), trigger a call, verify timeline no longer shows a duplicate `agent_refactor` tool card
- [ ] Verify the helper card displays the custom agent's user-defined name

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
