### PR TITLE
fix(workbench): 🐛 Restore sidebar thread statuses

### DIFF
--- a/src/modules/workbench-shell/model/thread-store.test.ts
+++ b/src/modules/workbench-shell/model/thread-store.test.ts
@@ -224,6 +224,49 @@ describe("batchSetThreadStatuses", () => {
     expect(statuses["thread-2"].status).toBe("idle");
   });
 
+  it("initializes visible sidebar thread statuses from snapshot data", () => {
+    threadStore.reset();
+    batchSetThreadStatuses({
+      "waiting-thread": { status: "waiting_approval", runId: null, source: "snapshot" },
+      "reply-thread": { status: "needs_reply", runId: null, source: "snapshot" },
+      "failed-thread": { status: "failed", runId: null, source: "snapshot" },
+    });
+
+    const statuses = threadStore.getState().threadStatuses;
+    expect(statuses["waiting-thread"]).toMatchObject({
+      status: "waiting_approval",
+      runId: null,
+      source: "snapshot",
+    });
+    expect(statuses["reply-thread"]).toMatchObject({
+      status: "needs_reply",
+      runId: null,
+      source: "snapshot",
+    });
+    expect(statuses["failed-thread"]).toMatchObject({
+      status: "failed",
+      runId: null,
+      source: "snapshot",
+    });
+  });
+
+  it("does not let an idle snapshot overwrite an active pending run in batch", () => {
+    threadStore.reset();
+    setThreadStatus("thread-1", "waiting_approval", {
+      runId: "run-1",
+      source: "stream",
+    });
+
+    batchSetThreadStatuses({
+      "thread-1": { status: "idle", runId: null, source: "snapshot" },
+    });
+
+    const status = threadStore.getState().threadStatuses["thread-1"];
+    expect(status.status).toBe("waiting_approval");
+    expect(status.runId).toBe("run-1");
+    expect(status.source).toBe("stream");
+  });
+
   it("applies same-run updates to advance status forward", () => {
     threadStore.reset();
     setThreadStatus("thread-1", "running", {

--- a/src/modules/workbench-shell/model/workbench-actions.ts
+++ b/src/modules/workbench-shell/model/workbench-actions.ts
@@ -17,7 +17,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { threadCreate, threadDelete, threadList, threadUpdateTitle } from "@/services/bridge/thread-commands";
 import { workspaceRemove, workspaceAdd, workspaceList, workspaceEnsureDefault } from "@/services/bridge/workspace-commands";
-import { threadStore, setThreadStatus } from "./thread-store";
+import { threadStore, setThreadStatus, batchSetThreadStatuses } from "./thread-store";
+import { backendToThreadRunStatus } from "./status-mappings";
 import { projectStore } from "./project-store";
 import { composerStore } from "./composer-store";
 import { uiLayoutStore } from "./ui-layout-store";
@@ -824,6 +825,19 @@ export async function performSidebarSync(options: SidebarSyncOptions): Promise<v
   const threadsByWorkspaceId = Object.fromEntries(
     threadEntries.map(([workspaceId, result]) => [workspaceId, result.threads]),
   );
+  const snapshotStatusUpdates: Parameters<typeof batchSetThreadStatuses>[0] = {};
+  for (const [, result] of threadEntries) {
+    for (const thread of result.threads) {
+      snapshotStatusUpdates[thread.id] = {
+        status: backendToThreadRunStatus(thread.status),
+        runId: null,
+        source: "snapshot",
+      };
+    }
+  }
+  if (Object.keys(snapshotStatusUpdates).length > 0) {
+    batchSetThreadStatuses(snapshotStatusUpdates);
+  }
   const nextHasMoreByWorkspaceId = Object.fromEntries(
     threadEntries.map(([workspaceId, result]) => [workspaceId, result.hasMore]),
   );


### PR DESCRIPTION
## Summary
- Restore sidebar thread status records during workspace sidebar sync from thread list snapshots.
- Keep waiting approval, needs reply, and failed indicators correct after app restart before opening a thread.
- Add unit coverage for snapshot status initialization and idle snapshot downgrade protection.

## Test Plan
- [x] `npm run test:unit -- src/modules/workbench-shell/model/thread-store.test.ts`
- [x] `npm run typecheck`

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
