### PR TITLE
fix(runtime): 🐛 Consume follow-ups one at a time

### DIFF
--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex as StdMutex, Weak};
 use chrono::{SecondsFormat, Utc};
 use sqlx::SqlitePool;
 use tiycore::agent::{
-    Agent, AgentError, AgentMessage, QueueEvent, QueuedMessageHandle, ToolExecutionMode,
+    Agent, AgentError, AgentMessage, QueueEvent, QueueMode, QueuedMessageHandle, ToolExecutionMode,
 };
 use tiycore::thinking::ThinkingLevel;
 use tiycore::types::{Cost, InputType, Model, Provider, Usage};
@@ -952,6 +952,10 @@ fn configure_agent(
     // Set session ID for prompt caching (used as prompt_cache_key in OpenAI Responses API).
     // Using thread_id ensures the same conversation thread shares a cache across runs.
     agent.set_session_id(&spec.thread_id);
+
+    // Consume at most the oldest follow-up message per turn. Steering keeps
+    // tiycore's default mode because it is configured independently.
+    agent.set_follow_up_mode(QueueMode::OneAtATime);
 
     {
         let run_id = spec.run_id.clone();


### PR DESCRIPTION
## Summary
- Configure follow-up queue consumption to process only the oldest queued message per turn.
- Keep steering queue behavior unchanged because it uses a separate queue mode.

## Test Plan
- [x] Run `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- [x] Review the runtime queue diff for unintended steering changes

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
