### PR TITLE
feat(thread): ✨ add hover copy button to user and assistant messages

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -973,6 +973,10 @@ const en: Record<TranslationKey, string> = {
   "artifact.expandCode": "Expand code",
   "artifact.preview": "Preview",
 
+  // ── Message actions ───────────────────────────────────────
+  "message.copy": "Copy message",
+  "message.copied": "Copied",
+
   // ── Long message preview ──────────────────────────────────
   "longMessage.collapseAll": "Collapse",
   "longMessage.expandAll": "Expand",

--- a/src/i18n/locales/zh-CN.ts
+++ b/src/i18n/locales/zh-CN.ts
@@ -1012,6 +1012,10 @@ const zhCN = {
   "artifact.expandCode": "展开代码",
   "artifact.preview": "点击预览",
 
+  // ── Message actions ───────────────────────────────────────
+  "message.copy": "复制消息",
+  "message.copied": "已复制",
+
   // ── Long message preview ──────────────────────────────────
   "longMessage.collapseAll": "收起全文",
   "longMessage.expandAll": "展开全文",

--- a/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface-state.ts
@@ -54,6 +54,50 @@ export type SurfaceMessagePart =
   | SurfaceDataMessagePart
   | SurfaceUnknownMessagePart;
 
+export type GetCopyableMessageTextOptions = {
+  fallbackToContent?: boolean;
+};
+
+export type CopyableCommandComposerMetadata = {
+  kind: "plain" | "command";
+  displayText: string | null;
+  effectivePrompt: string | null;
+} | null;
+
+function isCopyableTextMessagePart(
+  part: SurfaceMessagePart,
+): part is SurfaceTextMessagePart {
+  return part.type === "text";
+}
+
+export function getCopyableMessageText(
+  message: Pick<SurfaceMessage, "content" | "parts" | "status">,
+  options: GetCopyableMessageTextOptions = {},
+): string {
+  const textParts = message.parts.filter(isCopyableTextMessagePart);
+
+  if (textParts.length > 0) {
+    return textParts.map((part) => part.text).join("\n\n").trim();
+  }
+
+  if ((options.fallbackToContent ?? true) && message.parts.length === 0) {
+    return message.content.trim();
+  }
+
+  return "";
+}
+
+export function getCopyableThreadMessageText(
+  message: Pick<SurfaceMessage, "content" | "parts" | "role" | "status">,
+  commandComposer: CopyableCommandComposerMetadata = null,
+): string {
+  if (message.role === "user" && commandComposer?.kind === "command") {
+    return commandComposer.displayText?.trim() || getCopyableMessageText(message);
+  }
+
+  return getCopyableMessageText(message);
+}
+
 export type SurfaceMessage = {
   createdAt: string;
   id: string;

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import { createMachine } from "@/shared/lib/create-machine";
 import { mapSnapshotToRunState, isTaskBoardTool, getDefaultToolOpenState } from "./runtime-thread-surface-logic";
 import { LongMessageBody, shouldRenderTextPartAsPlainText } from "./long-message-body";
-import { mapMessageParts, mapRecordedUserMessage, mapSnapshotMessage, mergeSnapshotMessages, mergeSnapshotTools } from "./runtime-thread-surface-state";
+import { mapMessageParts, mapRecordedUserMessage, mapSnapshotMessage, mergeSnapshotMessages, mergeSnapshotTools, getCopyableMessageText, getCopyableThreadMessageText } from "./runtime-thread-surface-state";
 import type { SurfaceMessage } from "./runtime-thread-surface-state";
 import type { MessageDto, RunStatus, ThreadSnapshotDto } from "@/shared/types/api";
 
@@ -170,6 +170,86 @@ describe("mapSnapshotMessage", () => {
 
     expect(message.content).toBe("legacy body");
     expect(message.parts).toEqual([{ type: "text", text: "structured body" }]);
+  });
+});
+
+describe("copyable message text", () => {
+  it("joins only text parts and filters non-text tool-like artifact parts", () => {
+    const message = mapSnapshotMessage(makeMessage({
+      contentMarkdown: "legacy body should not be copied",
+      parts: [
+        { type: "text", text: "Intro" },
+        { type: "chart", artifactId: "chart-1", library: "vega-lite", spec: { mark: "bar" }, title: "Chart" },
+        { type: "data-tool", data: { input: "should not copy" } },
+        { type: "tool-result", result: "should not copy" } as never,
+        { type: "text", text: "Outro" },
+      ],
+    }));
+
+    expect(getCopyableMessageText(message)).toBe("Intro\n\nOutro");
+  });
+
+  it("falls back to legacy content only when no structured parts exist", () => {
+    expect(getCopyableMessageText({
+      content: "legacy markdown",
+      parts: [],
+      status: "completed",
+    })).toBe("legacy markdown");
+  });
+
+  it("returns an empty string for messages that only contain non-text parts", () => {
+    expect(getCopyableMessageText({
+      content: "legacy chart description",
+      parts: [{
+        artifactId: "chart-only",
+        caption: null,
+        error: null,
+        library: "vega-lite",
+        source: null,
+        spec: { mark: "line" },
+        status: "ready",
+        title: null,
+        type: "chart",
+      }],
+      status: "completed",
+    })).toBe("");
+  });
+
+  it("keeps plain user and assistant messages on the text-part copy path", () => {
+    const plainUserMessage: Pick<SurfaceMessage, "content" | "parts" | "role" | "status"> = {
+      content: "legacy user content",
+      parts: [{ type: "text", text: "plain user text" }],
+      role: "user",
+      status: "completed",
+    };
+    const assistantMessage: Pick<SurfaceMessage, "content" | "parts" | "role" | "status"> = {
+      content: "legacy assistant content",
+      parts: [{ type: "text", text: "assistant **markdown**" }],
+      role: "assistant",
+      status: "completed",
+    };
+
+    expect(getCopyableThreadMessageText(plainUserMessage, {
+      kind: "plain",
+      displayText: "ignored plain display",
+      effectivePrompt: null,
+    })).toBe("plain user text");
+    expect(getCopyableThreadMessageText(assistantMessage)).toBe("assistant **markdown**");
+  });
+
+  it("copies only the original slash command display text for command messages", () => {
+    const message: Pick<SurfaceMessage, "content" | "parts" | "role" | "status"> = {
+      content: "/init",
+      parts: [{ type: "text", text: "/init" }],
+      role: "user",
+      status: "completed",
+    };
+
+    expect(getCopyableThreadMessageText(message, {
+      kind: "command",
+      displayText: "/init --check",
+      effectivePrompt: "Generate or update AGENTS.md with a long internal prompt",
+    })).toBe("/init --check");
   });
 });
 

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ChatStatus } from "ai";
-import { AlertCircleIcon, BotIcon, ChevronDownIcon, Info, RefreshCcwIcon, SparklesIcon, WrenchIcon } from "lucide-react";
+import { AlertCircleIcon, BotIcon, CheckIcon, ChevronDownIcon, CopyIcon, Info, RefreshCcwIcon, SparklesIcon, WrenchIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useT } from "@/i18n";
@@ -13,7 +13,7 @@ import {
 } from "@/components/ai-elements/compact-collapsible";
 import { Conversation, ConversationContent, ConversationEmptyState, ConversationScrollButton } from "@/components/ai-elements/conversation";
 import type { StickToBottomContext } from "use-stick-to-bottom";
-import { Message, MessageContent, MessageResponse } from "@/components/ai-elements/message";
+import { Message, MessageAction, MessageActions, MessageContent, MessageResponse } from "@/components/ai-elements/message";
 import { Plan, PlanContent, PlanDescription, PlanHeader, PlanTitle, PlanTrigger } from "@/components/ai-elements/plan";
 import { Reasoning, ReasoningContent, ReasoningTrigger } from "@/components/ai-elements/reasoning";
 import { Shimmer } from "@/components/ai-elements/shimmer";
@@ -117,6 +117,7 @@ import {
   getApprovalReason,
   getApprovalTagClass,
   getApprovalTagLabel,
+  getCopyableThreadMessageText,
   getLatestVisibleRun,
   getPresentationEntryRole,
   getRoleSpacingClass,
@@ -286,6 +287,8 @@ export function RuntimeThreadSurface({
     [threadId],
   );
   const [approvingPlanMessageId, setApprovingPlanMessageId] = useState<string | null>(null);
+  const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null);
+  const messageCopyResetTimeoutRef = useRef<number>(0);
   const [helpers, setHelpers] = useState<Array<SurfaceHelperEntry>>([]);
   const [helperOpen, setHelperOpen] = useState<Record<string, boolean>>({});
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
@@ -346,6 +349,10 @@ export function RuntimeThreadSurface({
       setCompletedToolOpen({});
       setHelperOpen({});
       setReasoningOpen({});
+      setCopiedMessageId(null);
+      if (typeof window !== "undefined") {
+        window.clearTimeout(messageCopyResetTimeoutRef.current);
+      }
       userManuallyOpenedIds.current.clear();
     }
   }, [defaultAppendMessageKind, threadId]);
@@ -383,6 +390,34 @@ export function RuntimeThreadSurface({
     if (thinkingTimerRef.current !== null) {
       clearTimeout(thinkingTimerRef.current);
       thinkingTimerRef.current = null;
+    }
+  }, []);
+
+  const handleCopyMessage = useCallback(async (messageId: string, text: string) => {
+    if (typeof window === "undefined" || !navigator?.clipboard?.writeText) {
+      return;
+    }
+
+    const normalizedText = text.trim();
+    if (!normalizedText) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(normalizedText);
+      window.clearTimeout(messageCopyResetTimeoutRef.current);
+      setCopiedMessageId(messageId);
+      messageCopyResetTimeoutRef.current = window.setTimeout(() => {
+        setCopiedMessageId((current) => (current === messageId ? null : current));
+      }, 2000);
+    } catch {
+      // Ignore clipboard permission/focus failures; manual selection still works.
+    }
+  }, []);
+
+  useEffect(() => () => {
+    if (typeof window !== "undefined") {
+      window.clearTimeout(messageCopyResetTimeoutRef.current);
     }
   }, []);
 
@@ -2652,6 +2687,20 @@ export function RuntimeThreadSurface({
                   );
                 }
 
+                const commandComposer = message.role === "user"
+                  ? parseCommandComposerMetadata(message.metadata)
+                  : null;
+                const expandedPrompt = commandComposer?.kind === "command"
+                  ? (commandComposer.effectivePrompt?.trim() ?? "")
+                  : "";
+                const copyableText = getCopyableThreadMessageText(message, commandComposer);
+                const canCopyMessage =
+                  (message.role === "user" || message.role === "assistant")
+                  && message.status !== "discarded"
+                  && copyableText.length > 0;
+                const copied = copiedMessageId === message.id;
+                const copyLabel = copied ? t("message.copied") : t("message.copy");
+
                 return (
                   <div className={spacingClass} key={entry.key}>
                     <Message
@@ -2677,49 +2726,59 @@ export function RuntimeThreadSurface({
                             </p>
                           </div>
                         ) : (
-                          (() => {
-                            const commandComposer = message.role === "user"
-                              ? parseCommandComposerMetadata(message.metadata)
-                              : null;
-                            const expandedPrompt = commandComposer?.kind === "command"
-                              ? (commandComposer.effectivePrompt?.trim() ?? "")
-                              : "";
-
-                            return (
-                              <div className="space-y-2">
-                                <ComposerMessageAttachments
-                                  attachments={message.attachments.map((attachment) => ({
-                                    id: attachment.id,
-                                    mediaType: attachment.mediaType ?? undefined,
-                                    name: attachment.name,
-                                    url: attachment.url ?? undefined,
-                                  }))}
-                                />
-                                {<LongMessageBody message={message} t={t} />}
-                                {expandedPrompt && expandedPrompt !== (message.content ?? "").trim() ? (
-                                  <CompactCollapsible defaultOpen={false}>
-                                    <CompactCollapsibleHeader className="items-start gap-3 text-left text-app-subtle hover:text-app-foreground">
-                                      <div className="min-w-0">
-                                        <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-app-subtle">
-                                          Expanded prompt
-                                        </div>
-                                        <div className="truncate text-xs text-app-muted">
-                                          {expandedPrompt}
-                                        </div>
-                                      </div>
-                                    </CompactCollapsibleHeader>
-                                    <CompactCollapsibleContent className="pl-0">
-                                      <div className="whitespace-pre-wrap rounded-xl border border-app-border/25 bg-app-surface/35 px-3 py-2 text-xs leading-5 text-app-muted">
-                                        {expandedPrompt}
-                                      </div>
-                                    </CompactCollapsibleContent>
-                                  </CompactCollapsible>
-                                ) : null}
-                              </div>
-                            );
-                          })()
+                          <div className="space-y-2">
+                            <ComposerMessageAttachments
+                              attachments={message.attachments.map((attachment) => ({
+                                id: attachment.id,
+                                mediaType: attachment.mediaType ?? undefined,
+                                name: attachment.name,
+                                url: attachment.url ?? undefined,
+                              }))}
+                            />
+                            {<LongMessageBody message={message} t={t} />}
+                            {expandedPrompt && expandedPrompt !== (message.content ?? "").trim() ? (
+                              <CompactCollapsible defaultOpen={false}>
+                                <CompactCollapsibleHeader className="items-start gap-3 text-left text-app-subtle hover:text-app-foreground">
+                                  <div className="min-w-0">
+                                    <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-app-subtle">
+                                      Expanded prompt
+                                    </div>
+                                    <div className="truncate text-xs text-app-muted">
+                                      {expandedPrompt}
+                                    </div>
+                                  </div>
+                                </CompactCollapsibleHeader>
+                                <CompactCollapsibleContent className="pl-0">
+                                  <div className="whitespace-pre-wrap rounded-xl border border-app-border/25 bg-app-surface/35 px-3 py-2 text-xs leading-5 text-app-muted">
+                                    {expandedPrompt}
+                                  </div>
+                                </CompactCollapsibleContent>
+                              </CompactCollapsible>
+                            ) : null}
+                          </div>
                         )}
                       </MessageContent>
+                      {canCopyMessage ? (
+                        <MessageActions
+                          className={cn(
+                            "pointer-events-none h-7 opacity-0 transition-opacity duration-150 group-hover:pointer-events-auto group-hover:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
+                            message.role === "user" ? "ml-auto justify-end" : "justify-start",
+                          )}
+                        >
+                          <MessageAction
+                            aria-label={copyLabel}
+                            className={cn(
+                              "size-7 rounded-md border border-transparent bg-transparent text-app-subtle/85 shadow-none hover:bg-app-surface-hover hover:text-app-foreground focus-visible:bg-app-surface-hover",
+                              copied && "bg-app-surface-hover text-app-foreground",
+                            )}
+                            label={copyLabel}
+                            onClick={() => void handleCopyMessage(message.id, copyableText)}
+                            tooltip={copyLabel}
+                          >
+                            {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+                          </MessageAction>
+                        </MessageActions>
+                      ) : null}
                     </Message>
                   </div>
                 );


### PR DESCRIPTION
## Summary
- Add hover-reveal copy button below user and assistant messages in the thread timeline
- Copy text filters out non-text parts (chart, data, tool-like artifacts), only copying plain text content
- Slash command messages copy the original user display text, not the expanded effective prompt
- Discarded messages, system messages, and empty-text messages do not show the copy button

## Test Plan
- [x] `npm run typecheck` passes
- [x] `npm run test:unit` — 46 tests pass including 5 new copyable text helper tests
- [ ] Manual: hover user/assistant message → copy icon appears below
- [ ] Manual: click copy → icon switches to check, paste content matches text only
- [ ] Manual: slash command message copies `/command` display text, not expanded prompt
- [ ] Manual: messages with tool use cards do not include tool input/result in copied text

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
