### PR TITLE
fix(workbench-shell): 🐛 Context window bar uses current model and shows exceeded warning

### DIFF
--- a/src/modules/workbench-shell/ui/dashboard-workbench-logic.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench-logic.ts
@@ -136,22 +136,29 @@ export function buildThreadContextBadgeData(options: {
   runtimeUsage: ThreadContextUsage | null;
 }) {
   const contextWindow =
-    parseTokenCount(options.runtimeUsage?.contextWindow) ??
-    parseTokenCount(options.fallbackContextWindow);
+    parseTokenCount(options.fallbackContextWindow) ??
+    parseTokenCount(options.runtimeUsage?.contextWindow);
   const totalTokens = options.runtimeUsage?.totalTokens ?? 0;
   const inputTokens = options.runtimeUsage?.inputTokens ?? 0;
   const outputTokens = options.runtimeUsage?.outputTokens ?? 0;
   const cacheReadTokens = options.runtimeUsage?.cacheReadTokens ?? 0;
   const cacheWriteTokens = options.runtimeUsage?.cacheWriteTokens ?? 0;
+  const rawUsedPercent =
+    contextWindow && contextWindow > 0
+      ? Math.round((totalTokens / contextWindow) * 100)
+      : 0;
   const usageRatio =
     contextWindow && contextWindow > 0
       ? Math.min(totalTokens / contextWindow, 1)
       : 0;
   const usedPercent =
     contextWindow && contextWindow > 0
-      ? Math.min(Math.round((totalTokens / contextWindow) * 100), 100)
+      ? Math.min(rawUsedPercent, 100)
       : 0;
-  const leftPercent = Math.max(0, 100 - usedPercent);
+  const leftPercent = Math.max(0, 100 - rawUsedPercent);
+  const isExceeded = Boolean(
+    contextWindow && contextWindow > 0 && totalTokens > contextWindow,
+  );
 
   return {
     contextWindow,
@@ -159,10 +166,13 @@ export function buildThreadContextBadgeData(options: {
     outputTokens,
     cacheReadTokens,
     cacheWriteTokens,
+    isExceeded,
     leftPercent,
     modelDisplayName:
+      options.fallbackModelDisplayName ??
       options.runtimeUsage?.modelDisplayName ??
-      options.fallbackModelDisplayName,
+      null,
+    rawUsedPercent,
     totalTokens,
     usageRatio,
     usedLabel: formatCompactTokenCount(totalTokens),

--- a/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { resolveThreadProfileId, resolveActiveThreadWorkbenchProfileId } from "./dashboard-workbench-logic";
+import {
+  buildThreadContextBadgeData,
+  resolveThreadProfileId,
+  resolveActiveThreadWorkbenchProfileId,
+} from "./dashboard-workbench-logic";
+import type { ThreadContextUsage } from "@/modules/workbench-shell/model/thread-store";
 
 describe("resolveThreadProfileId", () => {
   const globalActive = "p-global";
@@ -38,5 +43,81 @@ describe("resolveActiveThreadWorkbenchProfileId", () => {
 
   it("falls back to global active profile when thread profile is an empty string", () => {
     expect(resolveActiveThreadWorkbenchProfileId("", globalActive)).toBe(globalActive);
+  });
+});
+
+describe("buildThreadContextBadgeData", () => {
+  function makeRuntimeUsage(
+    overrides: Partial<ThreadContextUsage> = {},
+  ): ThreadContextUsage {
+    return {
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+      contextWindow: "8k",
+      inputTokens: 1_200,
+      modelDisplayName: "Old Runtime Model",
+      outputTokens: 300,
+      runId: "run-1",
+      totalTokens: 1_500,
+      ...overrides,
+    };
+  }
+
+  it("uses the selected model context window before stale runtime usage", () => {
+    const badge = buildThreadContextBadgeData({
+      fallbackContextWindow: "16000",
+      fallbackModelDisplayName: "Selected Model",
+      runtimeUsage: makeRuntimeUsage({
+        contextWindow: "4000",
+        modelDisplayName: "Old Runtime Model",
+      }),
+    });
+
+    expect(badge.contextWindow).toBe(16_000);
+    expect(badge.modelDisplayName).toBe("Selected Model");
+    expect(badge.totalTokens).toBe(1_500);
+    expect(badge.isExceeded).toBe(false);
+  });
+
+  it("falls back to runtime context window when the selected model has none", () => {
+    const badge = buildThreadContextBadgeData({
+      fallbackContextWindow: null,
+      fallbackModelDisplayName: null,
+      runtimeUsage: makeRuntimeUsage({
+        contextWindow: "32000",
+        modelDisplayName: "Runtime Model",
+      }),
+    });
+
+    expect(badge.contextWindow).toBe(32_000);
+    expect(badge.modelDisplayName).toBe("Runtime Model");
+    expect(badge.totalLabel).toBe("32K");
+  });
+
+  it("marks usage as exceeded when used tokens are over the current context window", () => {
+    const badge = buildThreadContextBadgeData({
+      fallbackContextWindow: "1000",
+      fallbackModelDisplayName: "Small Model",
+      runtimeUsage: makeRuntimeUsage({ totalTokens: 1_250 }),
+    });
+
+    expect(badge.isExceeded).toBe(true);
+    expect(badge.rawUsedPercent).toBe(125);
+    expect(badge.usedPercent).toBe(100);
+    expect(badge.leftPercent).toBe(0);
+    expect(badge.usageRatio).toBe(1);
+  });
+
+  it("does not exceed when no valid context window is available", () => {
+    const badge = buildThreadContextBadgeData({
+      fallbackContextWindow: null,
+      fallbackModelDisplayName: "Selected Model",
+      runtimeUsage: makeRuntimeUsage({ contextWindow: null }),
+    });
+
+    expect(badge.contextWindow).toBeNull();
+    expect(badge.isExceeded).toBe(false);
+    expect(badge.rawUsedPercent).toBe(0);
+    expect(badge.totalLabel).toBe("N/A");
   });
 });

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -1016,25 +1016,51 @@ const drawerWidth = useStore(uiLayoutStore, (s) => s.drawerWidth);
                           <div className="group/context-window relative shrink-0">
                             <span
                               tabIndex={0}
-                              className="relative inline-flex overflow-hidden rounded-full border border-app-border bg-app-surface-muted text-[11px] text-app-muted outline-none"
+                              className={cn(
+                                "relative inline-flex overflow-hidden rounded-full border bg-app-surface-muted text-[11px] text-app-muted outline-none",
+                                contextBadge.isExceeded
+                                  ? "border-red-500/45 bg-red-500/10"
+                                  : "border-app-border",
+                              )}
                             >
                               <span
-                                className="pointer-events-none absolute inset-y-0 left-0 rounded-full bg-primary/12"
+                                className={cn(
+                                  "pointer-events-none absolute inset-y-0 left-0 rounded-full",
+                                  contextBadge.isExceeded
+                                    ? "bg-red-500/25"
+                                    : "bg-primary/12",
+                                )}
                                 style={{
                                   width: `${contextBadge.usageRatio * 100}%`,
                                 }}
                               />
                               <span className="relative inline-flex items-center gap-1.5 px-2 py-0.5">
                                 <span className="text-app-subtle">Context</span>
-                                <span className="font-semibold text-app-foreground">
+                                <span
+                                  className={cn(
+                                    "font-semibold",
+                                    contextBadge.isExceeded
+                                      ? "text-red-600 dark:text-red-400"
+                                      : "text-app-foreground",
+                                  )}
+                                >
                                   {contextBadge.usedLabel} /{" "}
                                   {contextBadge.totalLabel}
                                 </span>
                               </span>
                             </span>
                             <div className="pointer-events-none absolute left-1/2 top-[calc(100%+0.5rem)] z-20 w-max min-w-[190px] -translate-x-1/2 translate-y-1 rounded-xl border border-app-border bg-app-menu px-3 py-2 text-center opacity-0 shadow-[0_14px_32px_rgba(15,23,42,0.14)] transition-[opacity,transform] duration-150 group-hover/context-window:translate-y-0 group-hover/context-window:opacity-100 group-focus-within/context-window:translate-y-0 group-focus-within/context-window:opacity-100 dark:shadow-[0_16px_36px_rgba(0,0,0,0.38)]">
-                              <p className="whitespace-nowrap text-[11px] font-semibold text-app-foreground">
-                                {contextBadge.usedPercent}% used
+                              <p
+                                className={cn(
+                                  "whitespace-nowrap text-[11px] font-semibold",
+                                  contextBadge.isExceeded
+                                    ? "text-red-600 dark:text-red-400"
+                                    : "text-app-foreground",
+                                )}
+                              >
+                                {contextBadge.isExceeded
+                                  ? `${contextBadge.rawUsedPercent}% used · over limit`
+                                  : `${contextBadge.usedPercent}% used`}
                                 <span className="font-normal text-app-subtle">
                                   {" "}
                                   ({contextBadge.leftPercent}% left)


### PR DESCRIPTION
## Summary
- Context window bar now uses the currently selected profile/model's context window instead of stale runtime usage, so switching profiles or models immediately updates the capacity display
- Added `isExceeded` and `rawUsedPercent` fields to context badge data; when used tokens exceed the current context window, the bar turns red with an "over limit" text indicator
- Token usage (input/output/cache) is preserved from runtime — only the window size and model name follow the current selection

## Test Plan
- [x] `npm run test:unit -- src/modules/workbench-shell/ui/dashboard-workbench.test.ts` — 12 tests pass (4 new `buildThreadContextBadgeData` cases)
- [x] `npm run typecheck` — no errors
- [ ] Manual: open a thread with existing token usage, switch to a profile with a different context window — verify the bar updates immediately
- [ ] Manual: switch to a smaller model where used > window — verify red danger style and "over limit" tooltip
- [ ] Manual: switch back to a larger model — verify red indicator clears

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
