### PR TITLE
fix(core): 🐛 fix Windows cross-compilation type errors

### DIFF
--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -394,11 +394,9 @@ impl AgentRunManager {
             if billable > 0 {
                 if let Ok(Some(goal)) = goal_repo::find_by_thread_id(&self.pool, thread_id).await {
                     if let Err(error) = goal_repo::account_usage(
-                        &self.pool,
-                        &goal.id,
+                        &self.pool, &goal.id,
                         0, // tokens_delta: planning turns were already counted
-                        billable,
-                        0, // turns_delta
+                        billable, 0, // turns_delta
                     )
                     .await
                     {

--- a/src-tauri/src/core/gateway_supervisor.rs
+++ b/src-tauri/src/core/gateway_supervisor.rs
@@ -292,7 +292,7 @@ fn is_process_alive(pid: u32) -> bool {
         let mut exit_code: u32 = 0;
         let result = GetExitCodeProcess(handle, &mut exit_code);
         CloseHandle(handle);
-        result != 0 && exit_code == STILL_ACTIVE
+        result != 0 && exit_code == STILL_ACTIVE as u32
     }
 }
 

--- a/src-tauri/src/core/terminal_manager.rs
+++ b/src-tauri/src/core/terminal_manager.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+#[cfg(not(target_os = "windows"))]
 use std::ffi::OsString;
 use std::io::{Read, Write};
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary
- Fix `u32 == i32` type mismatch in `gateway_supervisor.rs` (`STILL_ACTIVE` cast)
- Add `#[cfg(not(target_os = "windows"))]` to unused `OsString` import in `terminal_manager.rs`
- Apply cargo fmt formatting in `agent_run_manager.rs`

## Test Plan
- [ ] Verify `cargo fmt --check` passes
- [ ] Verify `npm run typecheck` passes
- [ ] Verify Windows cross-compilation succeeds

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)