### PR TITLE
refactor(thread): ♻️ track cumulative thread elapsed time across runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,20 @@ Around that collaboration model, TiyCode brings together Agent Profiles, workspa
 
 - **AI-first coding collaboration.** TiyCode is designed around the idea that humans express intent through conversation while agents take the lead in execution.
 - **Agent Profiles.** Mix models from different providers, tune response style, language, and custom instructions, and switch profiles flexibly for different kinds of work.
+- **Custom Agents.** Create purpose-built sub-agents in Settings — each with its own name, system prompt, model tier, and allowed tools — then grant per-profile access and delegate work from the composer.
 - **Three-tier model architecture.** Each profile supports a Primary model for core reasoning, an Auxiliary model for helper tasks, and a Lightweight model for fast operations — with automatic fallback chains across tiers.
 - **Multi-provider support.** Connect to 13+ LLM providers out of the box — OpenAI, Anthropic, Google, Ollama, xAI, Groq, OpenRouter, DeepSeek, MiniMax, Kimi, and more — or add any OpenAI-compatible endpoint as a custom provider.
 - **Workspace-centered execution.** Threads stay grounded in the local workspace and connect naturally to code review, version control, repository inspection, Git worktrees, and terminal workflows.
 - **Task-aware execution.** Thread-scoped task boards, plan checkpoints, tool status events, and subagent progress make longer runs easier to follow and review.
+- **Persistent goal management.** Set long-running objectives for agents to pursue across multiple turns, with automatic continuation, budget controls, and progress tracking.
 - **Rich composer inputs.** Prompt input supports text, file/photo attachments, screenshots, slash command structured argument interpolation (`--key=value`, positional args, `{{placeholder}}` templates), and large-paste handling.
+- **Steer & Queue.** While the agent is running, choose to steer the conversation mid-execution or queue a follow-up message for the next round — keeping you in control without interrupting the workflow.
 - **Real-time execution streaming.** A rich thread stream event system delivers live updates — message deltas, tool calls, requested/active statuses, reasoning steps, subagent progress, and plan updates — all rendered through purpose-built AI Elements components.
 - **Operator-friendly experience.** Slash commands with structured argument parsing, smart conversation titles, context compression controls, commit message generation, external terminal handoff including Ghostty, and compact workbench controls help the product feel fast and practical in day-to-day use.
+- **Thread-level elapsed timer.** Track active execution time per thread, excluding pauses, with persistent tracking across sessions.
 - **Bilingual interface.** Full i18n coverage with English and Simplified Chinese, switchable at any time.
 - **ACP Server support.** TiyCode can run as a headless ACP (Agent Client Protocol) server via `tiycode acp --stdio` or `tiycode acp --http <addr>`, letting external tools and IDE plugins drive the agent runtime through a standard JSON-RPC protocol without the desktop GUI.
+- **IM channel gateway.** Connect TiyCode to WeChat or WeCom so you can chat with the agent directly from your messaging app — scan a QR code to log in, send messages and attachments, and receive streaming responses without opening the desktop GUI.
 - **Extensible by design.** Plugins, MCP servers, and Skills are treated as first-class building blocks through the `Extensions Center`.
 - **Built-in runtime path.** The main execution flow is `Frontend -> Rust Core -> BuiltInAgentRuntime -> tiycore -> LLM`.
 
@@ -117,115 +122,6 @@ npm run typecheck
 ```bash
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
-
-## Shell Environment Setup
-
-TiyCode's built-in agent shell may launch as a **non-interactive, non-login** shell. In this mode, only minimal system paths (e.g. `/usr/bin:/bin`) are available. Tools installed via version managers — such as `node`, `npm`, `bun`, `cargo`, or `go` — will not be found unless you configure your shell startup files correctly.
-
-### How Shell Config Files Are Loaded
-
-Different shell invocation modes load different config files. The table below shows which files are sourced in each mode:
-
-**Zsh (macOS default / Linux)**
-
-| File | Non-interactive | Login | Interactive | Interactive + Login |
-|------|:-:|:-:|:-:|:-:|
-| `~/.zshenv` | ✅ | ✅ | ✅ | ✅ |
-| `~/.zprofile` | ❌ | ✅ | ❌ | ✅ |
-| `~/.zshrc` | ❌ | ❌ | ✅ | ✅ |
-
-**Bash (Linux default)**
-
-| File | Non-interactive | Login | Interactive | Interactive + Login |
-|------|:-:|:-:|:-:|:-:|
-| `~/.bashrc` | ❌ | ❌ | ✅ | ❌ ¹ |
-| `~/.bash_profile` | ❌ | ✅ | ❌ | ✅ |
-| `$BASH_ENV` | ✅ | ❌ | ❌ | ❌ |
-
-<sub>¹ Most distros source `~/.bashrc` from `~/.bash_profile`, so in practice it runs for login shells too.</sub>
-
-TiyCode's agent shell falls into the **non-interactive** column — only `~/.zshenv` (zsh) or `$BASH_ENV` (bash) is guaranteed to load.
-
-### Fix: Ensure Environment Variables Load for All Shell Modes
-
-<details>
-<summary><strong>macOS / Linux (Zsh)</strong></summary>
-
-1. **Move all `export` statements and PATH modifications** from `~/.zshrc` into `~/.zprofile`. Keep interactive-only settings (aliases, completions, oh-my-zsh, themes, prompt) in `~/.zshrc`.
-
-2. **Source `~/.zprofile` from `~/.zshenv`** so that non-interactive shells also get the environment:
-
-```bash
-# ~/.zshenv
-if [ -z "$__ZPROFILE_LOADED" ] && [ -f "$HOME/.zprofile" ]; then
-  export __ZPROFILE_LOADED=1
-  source "$HOME/.zprofile"
-fi
-```
-
-The `__ZPROFILE_LOADED` guard prevents double-loading in login + interactive shells.
-
-Common items to move into `~/.zprofile`:
-
-```bash
-# ~/.zprofile — examples
-eval "$(/opt/homebrew/bin/brew shellenv)"           # Homebrew (macOS)
-export NVM_DIR="$HOME/.nvm"                         # nvm (Node.js)
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-export BUN_INSTALL="$HOME/.bun"                     # Bun
-export PATH="$BUN_INSTALL/bin:$PATH"
-. "$HOME/.local/bin/env"                            # Rust / Cargo
-export PATH="/usr/local/go/bin:$PATH"               # Go
-```
-
-</details>
-
-<details>
-<summary><strong>Linux (Bash)</strong></summary>
-
-1. Keep environment variables in `~/.bash_profile` (or `~/.profile`).
-2. Set `BASH_ENV` to point to a file that sources your profile:
-
-```bash
-# ~/.bash_profile — add at the top:
-export BASH_ENV="$HOME/.bash_env"
-```
-
-```bash
-# ~/.bash_env — new file
-if [ -z "$__BASH_PROFILE_LOADED" ] && [ -f "$HOME/.bash_profile" ]; then
-  export __BASH_PROFILE_LOADED=1
-  source "$HOME/.bash_profile"
-fi
-```
-
-</details>
-
-<details>
-<summary><strong>Windows (PowerShell)</strong></summary>
-
-On Windows, TiyCode typically inherits the system and user environment variables set via **System Settings > Environment Variables**. If you installed Node.js, Rust, or other tools via their official installers, they should already be on PATH.
-
-If you use a version manager like **nvm-windows**, **fnm**, or **volta**, make sure the shim directory is added to your **User PATH** in system environment variables — not only in a PowerShell profile.
-
-To verify your current PATH in PowerShell:
-
-```powershell
-$env:PATH -split ';'
-```
-
-</details>
-
-### Verify After Configuration
-
-After updating your shell config files, **restart TiyCode** (a full quit + relaunch, not just a new thread) and ask the agent to run:
-
-```
-echo $PATH
-which <your-tool>   # e.g. node, cargo, go, bun, python ...
-```
-
-If the output includes the expected paths and the tool is found, your environment is correctly configured.
 
 ## Architecture at a Glance
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -2,7 +2,7 @@
   <img src="./public/app-icon.png" alt="TiyCode 标志" width="120" />
   <h1>TiyCode（钛可）</h1>
   <p><strong>一款践行 AI First 理念的 desktop coding agent。</strong></p>
-  <p>面向新一代编码协作范式而设计。人通过对话表达目标、约束与反馈，Agent 主导理解、执行与推进工作。</p>
+  <p>面向新一代编码协作范式而设计。人只需通过对话表达目标、约束与反馈，Agent 主导理解、执行与推进工作。</p>
   <p>
     <a href="./README.md">English</a>
   </p>
@@ -28,15 +28,20 @@ TiyCode 面向的是希望以 AI 时代的方式进行编码协作的用户。�
 
 - **AI First 的编码协作。** TiyCode 围绕"通过对话表达意图，Agent 全面执行"这一理念来设计产品形态。
 - **Agent Profile。** 支持自由组合不同服务商的模型，并可配置回复风格、回复语言、自定义指令等设定，且能在不同 Profile 之间灵活切换。
+- **Custom Agents。** 在设置中心创建专用子 Agent——每个拥有独立的名称、系统提示、模型层级和可用工具——按 Profile 授权后即可从 composer 委派任务。
 - **三层模型架构。** 每个 Profile 支持配置 Primary 主力模型、Auxiliary 辅助模型和 Lightweight 轻量模型三个层级，层级之间具备自动回退链路。
 - **多服务商接入。** 开箱支持 13+ 家 LLM 服务商 —— OpenAI、Anthropic、Google、Ollama、xAI、Groq、OpenRouter、DeepSeek、MiniMax、Kimi 等，也可将任何 OpenAI 兼容端点作为自定义 Provider 接入。
 - **以工作区为中心的执行体验。** 对话线程扎根本地工作区，并与代码审阅、版本控制、仓库状态读取、Git worktree 和 Terminal 工作流自然衔接。
 - **面向任务的执行可观测性。** Thread 级任务板、Plan checkpoint、工具状态事件和子 Agent 进度让长任务更容易跟踪和复查。
+- **持久化目标管理。** 为 Agent 设置跨轮次的长期目标，支持自动延续、预算控制和进度跟踪。
 - **更丰富的输入能力。** Prompt 输入支持文本、文件 / 图片附件、截图、Slash Command 结构化参数插值（`--key=value`、位置参数、`{{placeholder}}` 模板变量）以及大段文本粘贴处理。
+- **Steer 与 Queue。** Agent 运行中可选择「引导」即时插入消息调整方向，或「排队」将消息留待当前运行结束后再发起下一轮——无需中断工作流即可保持掌控。
 - **实时执行流式推送。** 丰富的 Thread Stream 事件体系支撑实时更新 —— 消息增量、工具调用、requested / active 状态、推理步骤、子 Agent 进度与计划更新。
 - **更友好的日常体验。** 支持结构化参数解析的 Slash Command、智能会话标题、上下文压缩、Commit Message 生成、包含 Ghostty 在内的外部终端衔接以及紧凑工作台控件，让协作过程更顺手、更连贯。
+- **线程级别耗时计时器。** 跟踪每个线程的活跃执行时间，排除暂停时间，并支持跨会话持久化跟踪。
 - **双语界面。** 完整的 i18n 支持，覆盖英文和简体中文，随时可切换。
 - **ACP Server 支持。** TiyCode 可作为无头 ACP（Agent Client Protocol）服务器运行，通过 `tiycode acp --stdio` 或 `tiycode acp --http <addr>` 启动，让外部工具和 IDE 插件通过标准 JSON-RPC 协议驱动 Agent 运行时，无需启动桌面 GUI。
+- **IM 通道网关。** 将 TiyCode 接入微信或企业微信，扫码登录后即可在聊天应用中直接与 Agent 对话——发送消息和附件、接收流式回复，无需打开桌面 GUI。
 - **良好的通用扩展能力。** Plugins、MCP Servers 与 Skills 通过 `Extensions Center` 形成统一的扩展入口与产品模型。
 - **内置 Runtime。** 主执行链路 `Frontend -> Rust Core -> BuiltInAgentRuntime -> tiycore -> LLM`。
 
@@ -117,115 +122,6 @@ npm run typecheck
 ```bash
 cargo test --manifest-path src-tauri/Cargo.toml
 ```
-
-## Shell 环境配置
-
-TiyCode 内置的 Agent Shell 可能以 **非交互、非登录** 模式启动。在该模式下，只有最基础的系统路径（如 `/usr/bin:/bin`）可用。通过版本管理器安装的工具（如 `node`、`npm`、`bun`、`cargo`、`go`）将无法被识别，需要正确配置 Shell 启动文件才能解决。
-
-### Shell 配置文件加载规则
-
-不同的 Shell 调用模式会加载不同的配置文件。下表列出了各模式下的加载情况：
-
-**Zsh（macOS 默认 / Linux）**
-
-| 文件 | 非交互 | 登录 | 交互 | 交互 + 登录 |
-|------|:-:|:-:|:-:|:-:|
-| `~/.zshenv` | ✅ | ✅ | ✅ | ✅ |
-| `~/.zprofile` | ❌ | ✅ | ❌ | ✅ |
-| `~/.zshrc` | ❌ | ❌ | ✅ | ✅ |
-
-**Bash（Linux 默认）**
-
-| 文件 | 非交互 | 登录 | 交互 | 交互 + 登录 |
-|------|:-:|:-:|:-:|:-:|
-| `~/.bashrc` | ❌ | ❌ | ✅ | ❌ ¹ |
-| `~/.bash_profile` | ❌ | ✅ | ❌ | ✅ |
-| `$BASH_ENV` | ✅ | ❌ | ❌ | ❌ |
-
-<sub>¹ 大多数发行版会在 `~/.bash_profile` 中 source `~/.bashrc`，因此实际上登录 shell 也会执行它。</sub>
-
-TiyCode 的 Agent Shell 属于 **非交互** 一列 —— 只有 `~/.zshenv`（zsh）或 `$BASH_ENV`（bash）能保证被加载。
-
-### 解决方法：确保所有 Shell 模式都能加载环境变量
-
-<details>
-<summary><strong>macOS / Linux（Zsh）</strong></summary>
-
-1. **将所有 `export` 语句和 PATH 修改** 从 `~/.zshrc` 移到 `~/.zprofile`。仅将交互式配置（alias、补全、oh-my-zsh、主题、提示符）留在 `~/.zshrc` 中。
-
-2. **在 `~/.zshenv` 中 source `~/.zprofile`**，使非交互式 shell 也能获取环境变量：
-
-```bash
-# ~/.zshenv
-if [ -z "$__ZPROFILE_LOADED" ] && [ -f "$HOME/.zprofile" ]; then
-  export __ZPROFILE_LOADED=1
-  source "$HOME/.zprofile"
-fi
-```
-
-`__ZPROFILE_LOADED` 守卫变量可防止在「登录 + 交互」模式下重复加载。
-
-常见需要移入 `~/.zprofile` 的内容：
-
-```bash
-# ~/.zprofile — 示例
-eval "$(/opt/homebrew/bin/brew shellenv)"           # Homebrew（macOS）
-export NVM_DIR="$HOME/.nvm"                         # nvm（Node.js）
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-export BUN_INSTALL="$HOME/.bun"                     # Bun
-export PATH="$BUN_INSTALL/bin:$PATH"
-. "$HOME/.local/bin/env"                            # Rust / Cargo
-export PATH="/usr/local/go/bin:$PATH"               # Go
-```
-
-</details>
-
-<details>
-<summary><strong>Linux（Bash）</strong></summary>
-
-1. 将环境变量保留在 `~/.bash_profile`（或 `~/.profile`）中。
-2. 设置 `BASH_ENV` 指向一个会 source 你的 profile 的文件：
-
-```bash
-# ~/.bash_profile — 在顶部添加：
-export BASH_ENV="$HOME/.bash_env"
-```
-
-```bash
-# ~/.bash_env — 新文件
-if [ -z "$__BASH_PROFILE_LOADED" ] && [ -f "$HOME/.bash_profile" ]; then
-  export __BASH_PROFILE_LOADED=1
-  source "$HOME/.bash_profile"
-fi
-```
-
-</details>
-
-<details>
-<summary><strong>Windows（PowerShell）</strong></summary>
-
-在 Windows 上，TiyCode 通常会继承通过 **系统设置 > 环境变量** 配置的系统和用户环境变量。如果你通过官方安装器安装了 Node.js、Rust 等工具，它们应该已经在 PATH 中。
-
-如果你使用的是版本管理器（如 **nvm-windows**、**fnm** 或 **volta**），请确保 shim 目录已添加到系统环境变量中的 **用户 PATH**，而不是仅在 PowerShell profile 中设置。
-
-验证当前 PATH：
-
-```powershell
-$env:PATH -split ';'
-```
-
-</details>
-
-### 配置后验证
-
-更新 Shell 配置文件后，**重启 TiyCode**（完全退出后重新启动，而非仅开启新会话），然后让 Agent 执行：
-
-```
-echo $PATH
-which <你的工具>   # 例如 node、cargo、go、bun、python ...
-```
-
-如果输出中包含预期的路径且工具能被找到，说明环境配置已生效。
 
 ## 架构速览
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.9-rc.1"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128e58c7b8b3922db4f87494faec867bb5bb81da0fd47ec502e7151eb1b0fc17"
+checksum = "d619c75f2e2f61b57f2fcd81e7ce7e714556b75b2fda8ee932450c657de9ac29"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6571,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "tiycore"
-version = "0.2.9-rc.0"
+version = "0.2.9-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835ea645f6a313e3885394da11338cb8768f4393014686ce7875287115945c80"
+checksum = "128e58c7b8b3922db4f87494faec867bb5bb81da0fd47ec502e7151eb1b0fc17"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.9-rc.1"
+tiycore = "0.2.9"
 
 # Gateway (IM channel support)
 async-trait = "0.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ keepawake = "0.6"
 portable-pty = "0.9"
 git2 = { version = "0.20", features = ["vendored-libgit2", "vendored-openssl"] }
 similar = "2"
-tiycore = "0.2.9-rc.0"
+tiycore = "0.2.9-rc.1"
 
 # Gateway (IM channel support)
 async-trait = "0.1"

--- a/src-tauri/migrations/20260604000000_run_elapsed_tracking.sql
+++ b/src-tauri/migrations/20260604000000_run_elapsed_tracking.sql
@@ -1,0 +1,16 @@
+-- Track cumulative active running time per run, excluding pauses
+-- (waiting_approval, needs_reply, etc.).
+--
+-- elapsed_running_secs: seconds the run has actually been in "running" status.
+-- running_since:        ISO timestamp marking the start of the current running
+--                       segment; NULL when the run is not actively running.
+
+ALTER TABLE thread_runs ADD COLUMN elapsed_running_secs INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE thread_runs ADD COLUMN running_since TEXT;
+
+-- Back-fill: runs that are currently in "running" status were running since
+-- their started_at. This is imprecise (ignores prior pauses) but is the best
+-- approximation for a one-time upgrade.
+UPDATE thread_runs
+   SET running_since = started_at
+ WHERE status = 'running';

--- a/src-tauri/src/core/agent_run_compaction.rs
+++ b/src-tauri/src/core/agent_run_compaction.rs
@@ -293,6 +293,7 @@ impl AgentRunManager {
         let _ = frontend_tx.send(ThreadStreamEvent::RunStarted {
             run_id: run_id.clone(),
             run_mode: "compact".to_string(),
+            started_at_ms: chrono::Utc::now().timestamp_millis(),
         });
         let _ = frontend_tx.send(ThreadStreamEvent::ContextCompressing {
             run_id: run_id.clone(),

--- a/src-tauri/src/core/agent_run_event_handler.rs
+++ b/src-tauri/src/core/agent_run_event_handler.rs
@@ -334,6 +334,16 @@ impl AgentRunManager {
             }
             ThreadStreamEvent::MessageDiscarded { message_id, .. } => {
                 message_repo::update_status(&self.pool, message_id, "discarded").await?;
+                // Clear streaming_message_id when the discarded message is the
+                // one currently being streamed (e.g. request-level retry).
+                // This ensures the next TextDelta triggers
+                // ensure_streaming_message to INSERT a fresh DB row.
+                let mut runs = self.active_runs.lock().await;
+                if let Some(run) = runs.get_mut(run_id) {
+                    if run.streaming_message_id.as_deref() == Some(message_id) {
+                        run.streaming_message_id = None;
+                    }
+                }
             }
             ThreadStreamEvent::ReasoningUpdated {
                 message_id,

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -10,6 +10,7 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::time::{sleep, Instant};
 
 use crate::core::agent_session::{build_session_spec, ResolvedModelRole};
+use crate::core::agent_session_model_plan;
 use crate::core::agent_session_types::{AgentQueueMessageKind, RuntimeQueueSnapshotDto};
 use crate::core::app_event_emitter::AppEventEmitterRef;
 use crate::core::app_state::GoalRuntimeState;
@@ -364,7 +365,7 @@ impl AgentRunManager {
                         "The approved plan is missing its runtime model plan.",
                     )
                 })?;
-        let model_plan_value = serde_json::from_str::<serde_json::Value>(&model_plan_json)
+        let frozen_model_plan = serde_json::from_str::<serde_json::Value>(&model_plan_json)
             .map_err(|error| {
                 AppError::recoverable(
                     ErrorSource::Thread,
@@ -372,6 +373,40 @@ impl AgentRunManager {
                     format!("Failed to parse runtime model plan: {error}"),
                 )
             })?;
+        let (frozen_profile_id, _, _) = extract_run_model_refs(&frozen_model_plan);
+
+        // If the user switched profiles on this thread after the planning run
+        // started, honour the updated profile for the implementation run.
+        let thread_record = thread_repo::find_by_id(&self.pool, thread_id)
+            .await?
+            .ok_or_else(|| AppError::not_found(ErrorSource::Thread, "thread"))?;
+
+        let model_plan_value = if thread_record.profile_id.is_some()
+            && thread_record.profile_id != frozen_profile_id
+        {
+            let current_pid = thread_record.profile_id.as_deref().unwrap();
+            tracing::info!(
+                thread_id = %thread_id,
+                frozen_profile = ?frozen_profile_id,
+                current_profile = %current_pid,
+                "plan approval: thread profile changed since planning run, rebuilding model plan"
+            );
+            match agent_session_model_plan::build_model_plan_from_profile(&self.pool, current_pid)
+                .await
+            {
+                Ok(rebuilt) => rebuilt,
+                Err(error) => {
+                    tracing::warn!(
+                        error = %error,
+                        "failed to rebuild model plan from current profile, falling back to frozen plan"
+                    );
+                    frozen_model_plan
+                }
+            }
+        } else {
+            frozen_model_plan
+        };
+
         let (profile_id, provider_id, model_id) = extract_run_model_refs(&model_plan_value);
 
         // Account the planning run's billable time to the active goal so the

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -381,27 +381,31 @@ impl AgentRunManager {
             .await?
             .ok_or_else(|| AppError::not_found(ErrorSource::Thread, "thread"))?;
 
-        let model_plan_value = if thread_record.profile_id.is_some()
-            && thread_record.profile_id != frozen_profile_id
-        {
-            let current_pid = thread_record.profile_id.as_deref().unwrap();
-            tracing::info!(
-                thread_id = %thread_id,
-                frozen_profile = ?frozen_profile_id,
-                current_profile = %current_pid,
-                "plan approval: thread profile changed since planning run, rebuilding model plan"
-            );
-            match agent_session_model_plan::build_model_plan_from_profile(&self.pool, current_pid)
+        let model_plan_value = if let Some(current_pid) = thread_record.profile_id.as_deref() {
+            if Some(current_pid) != frozen_profile_id.as_deref() {
+                tracing::info!(
+                    thread_id = %thread_id,
+                    frozen_profile = ?frozen_profile_id,
+                    current_profile = %current_pid,
+                    "plan approval: thread profile changed since planning run, rebuilding model plan"
+                );
+                match agent_session_model_plan::build_model_plan_from_profile(
+                    &self.pool,
+                    current_pid,
+                )
                 .await
-            {
-                Ok(rebuilt) => rebuilt,
-                Err(error) => {
-                    tracing::warn!(
-                        error = %error,
-                        "failed to rebuild model plan from current profile, falling back to frozen plan"
-                    );
-                    frozen_model_plan
+                {
+                    Ok(rebuilt) => rebuilt,
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            "failed to rebuild model plan from current profile, falling back to frozen plan"
+                        );
+                        frozen_model_plan
+                    }
                 }
+            } else {
+                frozen_model_plan
             }
         } else {
             frozen_model_plan

--- a/src-tauri/src/core/agent_run_manager.rs
+++ b/src-tauri/src/core/agent_run_manager.rs
@@ -328,6 +328,54 @@ impl AgentRunManager {
         Ok((run_id, frontend_rx))
     }
 
+    /// Resolve the model plan for an implementation run, honouring any profile
+    /// change that occurred on the thread since the planning run.
+    ///
+    /// If the thread's current profile differs from the profile frozen in the
+    /// planning run's model plan, a fresh model plan is rebuilt from the
+    /// current profile so the implementation run uses the updated model
+    /// / credentials.  Falls back to the frozen plan when the rebuild fails.
+    /// When the thread has no profile or the profiles match, the frozen plan
+    /// is used as-is.
+    pub(crate) async fn resolve_implementation_model_plan(
+        pool: &SqlitePool,
+        frozen_model_plan: serde_json::Value,
+        frozen_profile_id: Option<String>,
+        thread_id: &str,
+    ) -> Result<serde_json::Value, AppError> {
+        let thread_record = thread_repo::find_by_id(pool, thread_id)
+            .await?
+            .ok_or_else(|| AppError::not_found(ErrorSource::Thread, "thread"))?;
+
+        let model_plan_value = if let Some(current_pid) = thread_record.profile_id.as_deref() {
+            if Some(current_pid) != frozen_profile_id.as_deref() {
+                tracing::info!(
+                    thread_id = %thread_id,
+                    frozen_profile = ?frozen_profile_id,
+                    current_profile = %current_pid,
+                    "plan approval: thread profile changed since planning run, rebuilding model plan"
+                );
+                match agent_session_model_plan::build_model_plan_from_profile(pool, current_pid)
+                    .await
+                {
+                    Ok(rebuilt) => rebuilt,
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            "failed to rebuild model plan from current profile, falling back to frozen plan"
+                        );
+                        frozen_model_plan
+                    }
+                }
+            } else {
+                frozen_model_plan
+            }
+        } else {
+            frozen_model_plan
+        };
+        Ok(model_plan_value)
+    }
+
     pub async fn execute_approved_plan(
         self: &Arc<Self>,
         thread_id: &str,
@@ -375,41 +423,13 @@ impl AgentRunManager {
             })?;
         let (frozen_profile_id, _, _) = extract_run_model_refs(&frozen_model_plan);
 
-        // If the user switched profiles on this thread after the planning run
-        // started, honour the updated profile for the implementation run.
-        let thread_record = thread_repo::find_by_id(&self.pool, thread_id)
-            .await?
-            .ok_or_else(|| AppError::not_found(ErrorSource::Thread, "thread"))?;
-
-        let model_plan_value = if let Some(current_pid) = thread_record.profile_id.as_deref() {
-            if Some(current_pid) != frozen_profile_id.as_deref() {
-                tracing::info!(
-                    thread_id = %thread_id,
-                    frozen_profile = ?frozen_profile_id,
-                    current_profile = %current_pid,
-                    "plan approval: thread profile changed since planning run, rebuilding model plan"
-                );
-                match agent_session_model_plan::build_model_plan_from_profile(
-                    &self.pool,
-                    current_pid,
-                )
-                .await
-                {
-                    Ok(rebuilt) => rebuilt,
-                    Err(error) => {
-                        tracing::warn!(
-                            error = %error,
-                            "failed to rebuild model plan from current profile, falling back to frozen plan"
-                        );
-                        frozen_model_plan
-                    }
-                }
-            } else {
-                frozen_model_plan
-            }
-        } else {
-            frozen_model_plan
-        };
+        let model_plan_value = Self::resolve_implementation_model_plan(
+            &self.pool,
+            frozen_model_plan,
+            frozen_profile_id,
+            thread_id,
+        )
+        .await?;
 
         let (profile_id, provider_id, model_id) = extract_run_model_refs(&model_plan_value);
 

--- a/src-tauri/src/core/agent_run_manager_tests.rs
+++ b/src-tauri/src/core/agent_run_manager_tests.rs
@@ -1910,4 +1910,115 @@ pub(super) mod tests {
             );
         }
     }
+
+    // ── Plan-approval profile-switching tests ──────────────────────────
+
+    use crate::core::agent_run_manager::AgentRunManager;
+    use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use sqlx::SqlitePool;
+    use std::str::FromStr;
+
+    async fn setup_test_pool() -> SqlitePool {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .expect("invalid sqlite options")
+            .foreign_keys(true);
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .expect("failed to create in-memory pool");
+        crate::persistence::sqlite::run_migrations(&pool)
+            .await
+            .expect("migrations failed");
+        sqlx::query(
+            "INSERT INTO workspaces (id, name, path, canonical_path, display_path,
+                    is_default, is_git, auto_work_tree, status, created_at, updated_at)
+             VALUES ('ws-1', 'ws', '/tmp', '/tmp', '/tmp', 0, 0, 0, 'ready',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .execute(&pool)
+        .await
+        .expect("seed workspace");
+        pool
+    }
+
+    async fn seed_thread(pool: &SqlitePool, thread_id: &str, profile_id: Option<&str>) {
+        sqlx::query(
+            "INSERT INTO threads (id, workspace_id, title, status, profile_id,
+                    created_at, updated_at, last_active_at)
+             VALUES (?, 'ws-1', 'Test Thread', 'idle', ?,
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .bind(thread_id)
+        .bind(profile_id)
+        .execute(pool)
+        .await
+        .expect("seed thread");
+    }
+
+    fn frozen_plan(profile_id: &str) -> serde_json::Value {
+        serde_json::json!({
+            "profileId": profile_id,
+            "primary": { "modelDisplayName": "Frozen Model" }
+        })
+    }
+
+    #[tokio::test]
+    async fn resolve_model_plan_uses_frozen_when_thread_has_no_profile() {
+        let pool = setup_test_pool().await;
+        seed_thread(&pool, "thread-no-profile", None).await;
+
+        let plan = frozen_plan("profile-frozen");
+        let resolved = AgentRunManager::resolve_implementation_model_plan(
+            &pool,
+            plan.clone(),
+            Some("profile-frozen".to_string()),
+            "thread-no-profile",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, plan);
+    }
+
+    #[tokio::test]
+    async fn resolve_model_plan_uses_frozen_when_profiles_match() {
+        let pool = setup_test_pool().await;
+        seed_thread(&pool, "thread-same", Some("profile-1")).await;
+
+        let plan = frozen_plan("profile-1");
+        let resolved = AgentRunManager::resolve_implementation_model_plan(
+            &pool,
+            plan.clone(),
+            Some("profile-1".to_string()),
+            "thread-same",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, plan);
+    }
+
+    #[tokio::test]
+    async fn resolve_model_plan_falls_back_to_frozen_when_rebuild_fails() {
+        let pool = setup_test_pool().await;
+        // Thread references a profile that does not exist — build_model_plan_from_profile
+        // returns an error, and the fallback logic should return the frozen plan.
+        seed_thread(&pool, "thread-different", Some("missing-profile")).await;
+
+        let plan = frozen_plan("profile-frozen");
+        let resolved = AgentRunManager::resolve_implementation_model_plan(
+            &pool,
+            plan.clone(),
+            Some("profile-frozen".to_string()),
+            "thread-different",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, plan);
+    }
 }

--- a/src-tauri/src/core/agent_run_manager_tests.rs
+++ b/src-tauri/src/core/agent_run_manager_tests.rs
@@ -215,6 +215,7 @@ pub(super) mod tests {
             ThreadStreamEvent::RunStarted {
                 run_id: "run-1".to_string(),
                 run_mode: "default".to_string(),
+                started_at_ms: 0,
             },
             ThreadStreamEvent::RequestRetrying {
                 run_id: "run-1".to_string(),
@@ -315,6 +316,7 @@ pub(super) mod tests {
                 &ThreadStreamEvent::RunStarted {
                     run_id: "run-1".to_string(),
                     run_mode: "default".to_string(),
+                    started_at_ms: 0,
                 },
                 false,
             ),
@@ -362,6 +364,7 @@ pub(super) mod tests {
             ThreadStreamEvent::RunStarted {
                 run_id: "run-1".to_string(),
                 run_mode: "default".to_string(),
+                started_at_ms: 0,
             },
             ThreadStreamEvent::RequestRetrying {
                 run_id: "run-1".to_string(),
@@ -860,6 +863,7 @@ pub(super) mod tests {
             &ThreadStreamEvent::RunStarted {
                 run_id: "run-1".into(),
                 run_mode: "default".into(),
+                started_at_ms: 0,
             }
         ));
         assert!(!should_complete_reasoning_for_event(
@@ -1636,6 +1640,7 @@ pub(super) mod tests {
         let event = ThreadStreamEvent::RunStarted {
             run_id: "run-1".to_string(),
             run_mode: "default".to_string(),
+            started_at_ms: 0,
         };
         assert_eq!(
             sidebar_status_for_runtime_event(&event, false),
@@ -1816,6 +1821,7 @@ pub(super) mod tests {
             ThreadStreamEvent::RunStarted {
                 run_id: "r".to_string(),
                 run_mode: "default".to_string(),
+                started_at_ms: 0,
             },
             ThreadStreamEvent::RunRetrying {
                 run_id: "r".to_string(),

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -934,6 +934,7 @@ impl AgentSession {
         let _ = self.event_tx.send(ThreadStreamEvent::RunStarted {
             run_id: self.spec.run_id.clone(),
             run_mode: self.spec.run_mode.clone(),
+            started_at_ms: chrono::Utc::now().timestamp_millis(),
         });
 
         let result = if let Some(prompt) = self.spec.initial_prompt.clone() {

--- a/src-tauri/src/core/agent_session.rs
+++ b/src-tauri/src/core/agent_session.rs
@@ -914,6 +914,8 @@ impl AgentSession {
         let context_compression_state_ref = Arc::clone(&self.context_compression_state);
         let current_turn_index: Arc<StdMutex<Option<usize>>> = Arc::new(StdMutex::new(None));
         let turn_index_ref = Arc::clone(&current_turn_index);
+        let last_text_delta = Arc::new(StdMutex::new(None::<String>));
+        let last_text_delta_ref = Arc::clone(&last_text_delta);
         let unsubscribe = self.agent.subscribe(move |event| {
             handle_agent_event(
                 &run_id,
@@ -925,6 +927,7 @@ impl AgentSession {
                 &context_compression_state_ref,
                 &reasoning_ref,
                 &turn_index_ref,
+                &last_text_delta_ref,
                 &context_window,
                 &model_display_name,
                 event,

--- a/src-tauri/src/core/agent_session_events.rs
+++ b/src-tauri/src/core/agent_session_events.rs
@@ -20,6 +20,7 @@ pub(crate) fn handle_agent_event(
     context_compression_state: &StdMutex<ContextCompressionRuntimeState>,
     reasoning_buffer: &StdMutex<String>,
     current_turn_index: &StdMutex<Option<usize>>,
+    last_text_delta: &StdMutex<Option<String>>,
     context_window: &str,
     model_display_name: &str,
     event: &tiycore::agent::AgentEvent,
@@ -51,6 +52,24 @@ pub(crate) fn handle_agent_event(
             }
             match assistant_event.as_ref() {
                 AssistantMessageEvent::TextDelta { delta, .. } => {
+                    // Skip consecutive identical deltas to defend against
+                    // upstream (tiycore / provider) emitting the same chunk
+                    // twice.  See design doc: this pattern is virtually
+                    // impossible in normal LLM streaming, so the guard won't
+                    // swallow legitimate content.
+                    {
+                        let mut prev =
+                            lock_or_recover(last_text_delta, "TextDelta:last_text_delta");
+                        if prev.as_deref() == Some(delta.as_str()) {
+                            tracing::debug!(
+                                run_id,
+                                "skipping duplicate text delta ({} bytes)",
+                                delta.len()
+                            );
+                            return;
+                        }
+                        *prev = Some(delta.clone());
+                    }
                     let message_id = ensure_message_id(current_message_id);
                     let _ = event_tx.send(ThreadStreamEvent::MessageDelta {
                         run_id: run_id.to_string(),
@@ -65,6 +84,26 @@ pub(crate) fn handle_agent_event(
                     reason,
                     status,
                 } => {
+                    // When a request-level retry occurs (e.g. 503, connection
+                    // drop), any TextDelta events from the failed attempt have
+                    // already been forwarded.  The retry will re-stream from
+                    // scratch, so we must discard the partial message to avoid
+                    // appending duplicate content under the same message_id.
+                    {
+                        let guard =
+                            lock_or_recover(current_message_id, "Retrying:current_message_id");
+                        if guard.is_some() {
+                            let mid = guard.clone().unwrap();
+                            drop(guard);
+                            let _ = event_tx.send(ThreadStreamEvent::MessageDiscarded {
+                                run_id: run_id.to_string(),
+                                message_id: mid,
+                                reason: "request_retrying".to_string(),
+                            });
+                            reset_message_id(current_message_id);
+                            reset_message_id(last_text_delta);
+                        }
+                    }
                     let _ = event_tx.send(ThreadStreamEvent::RequestRetrying {
                         run_id: run_id.to_string(),
                         attempt: *attempt,
@@ -175,6 +214,7 @@ pub(crate) fn handle_agent_event(
                         model_display_name,
                     );
                     reset_message_id(current_message_id);
+                    reset_message_id(last_text_delta);
                     reset_reasoning_state(current_reasoning_message_id, reasoning_buffer);
                     return;
                 }
@@ -199,6 +239,7 @@ pub(crate) fn handle_agent_event(
                 });
             }
 
+            reset_message_id(last_text_delta);
             reset_reasoning_state(current_reasoning_message_id, reasoning_buffer);
         }
         tiycore::agent::AgentEvent::MessageDiscarded { reason, .. } => {

--- a/src-tauri/src/core/agent_session_tests.rs
+++ b/src-tauri/src/core/agent_session_tests.rs
@@ -751,6 +751,7 @@ pub(super) mod tests {
     ) {
         let last_completed_message_id = StdMutex::new(None::<String>);
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
         handle_agent_event(
             run_id,
             event_tx,
@@ -761,6 +762,7 @@ pub(super) mod tests {
             context_compression_state,
             reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             event,
@@ -1344,6 +1346,7 @@ Used for prompt assembly coverage.
         let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
         let assistant = AssistantMessage::builder()
             .api(Api::OpenAICompletions)
             .provider(Provider::OpenAI)
@@ -1370,6 +1373,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::MessageEnd {
@@ -1488,6 +1492,7 @@ Used for prompt assembly coverage.
         let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
 
         handle_agent_event(
             "run-retry",
@@ -1499,6 +1504,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::TurnRetrying {
@@ -1532,6 +1538,7 @@ Used for prompt assembly coverage.
         let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
 
         handle_agent_event(
             "run-request-retry",
@@ -1543,6 +1550,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::MessageUpdate {
@@ -1580,6 +1588,198 @@ Used for prompt assembly coverage.
     }
 
     #[test]
+    fn consecutive_identical_text_deltas_are_deduplicated() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let current_message_id = StdMutex::new(None::<String>);
+        let last_completed_message_id = StdMutex::new(None::<String>);
+        let current_reasoning_message_id = StdMutex::new(None::<String>);
+        let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        let reasoning_buffer = StdMutex::new(String::new());
+        let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
+
+        let make_text_delta = |delta: &str| AgentEvent::MessageUpdate {
+            turn_index: 0,
+            message: AgentMessage::Assistant(sample_partial_assistant_message()),
+            assistant_event: Box::new(AssistantMessageEvent::TextDelta {
+                content_index: 0,
+                delta: delta.to_string(),
+                partial: sample_partial_assistant_message(),
+            }),
+        };
+
+        // First "Hello" should pass through
+        handle_agent_event(
+            "run-dedup",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            &last_text_delta,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &make_text_delta("Hello"),
+        );
+
+        // Second identical "Hello" should be skipped
+        handle_agent_event(
+            "run-dedup",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            &last_text_delta,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &make_text_delta("Hello"),
+        );
+
+        // Different delta " world" should pass through
+        handle_agent_event(
+            "run-dedup",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            &last_text_delta,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &make_text_delta(" world"),
+        );
+
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+        let deltas: Vec<&str> = events
+            .iter()
+            .filter_map(|e| match e {
+                ThreadStreamEvent::MessageDelta { delta, .. } => Some(delta.as_str()),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            deltas,
+            vec!["Hello", " world"],
+            "duplicate consecutive delta should be skipped"
+        );
+    }
+
+    #[test]
+    fn retrying_with_active_streaming_message_emits_discard_and_resets_id() {
+        let (event_tx, mut event_rx) = mpsc::unbounded_channel();
+        let current_message_id = StdMutex::new(None::<String>);
+        let last_completed_message_id = StdMutex::new(None::<String>);
+        let current_reasoning_message_id = StdMutex::new(None::<String>);
+        let last_usage = StdMutex::new(None::<tiycore::types::Usage>);
+        let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
+        let reasoning_buffer = StdMutex::new(String::new());
+        let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
+
+        // First send a TextDelta to create a streaming message_id
+        handle_agent_event(
+            "run-retry-discard",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            &last_text_delta,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &AgentEvent::MessageUpdate {
+                turn_index: 0,
+                message: AgentMessage::Assistant(sample_partial_assistant_message()),
+                assistant_event: Box::new(AssistantMessageEvent::TextDelta {
+                    content_index: 0,
+                    delta: "partial content".to_string(),
+                    partial: sample_partial_assistant_message(),
+                }),
+            },
+        );
+
+        let streaming_mid = current_message_id
+            .lock()
+            .expect("lock")
+            .clone()
+            .expect("should have a streaming message_id after TextDelta");
+
+        // Now send a Retrying event — should discard the streaming message
+        handle_agent_event(
+            "run-retry-discard",
+            &event_tx,
+            &current_message_id,
+            &last_completed_message_id,
+            &current_reasoning_message_id,
+            &last_usage,
+            &context_compression_state,
+            &reasoning_buffer,
+            &current_turn_index,
+            &last_text_delta,
+            TEST_CONTEXT_WINDOW,
+            TEST_MODEL_DISPLAY_NAME,
+            &AgentEvent::MessageUpdate {
+                turn_index: 0,
+                message: AgentMessage::Assistant(sample_partial_assistant_message()),
+                assistant_event: Box::new(AssistantMessageEvent::Retrying {
+                    attempt: 1,
+                    max_retries: 3,
+                    delay_ms: 500,
+                    reason: "503 service unavailable".to_string(),
+                    status: Some(503),
+                }),
+            },
+        );
+
+        // Verify current_message_id was reset
+        assert!(
+            current_message_id.lock().expect("lock").is_none(),
+            "current_message_id must be reset after Retrying"
+        );
+
+        let events = std::iter::from_fn(|| event_rx.try_recv().ok()).collect::<Vec<_>>();
+
+        // Should have: MessageDelta, MessageDiscarded, RequestRetrying
+        let has_discard = events.iter().any(|e| {
+            matches!(
+                e,
+                ThreadStreamEvent::MessageDiscarded {
+                    message_id,
+                    reason,
+                    ..
+                } if *message_id == streaming_mid && reason == "request_retrying"
+            )
+        });
+        assert!(
+            has_discard,
+            "Retrying should emit MessageDiscarded for the active streaming message"
+        );
+
+        let has_retry = events
+            .iter()
+            .any(|e| matches!(e, ThreadStreamEvent::RequestRetrying { attempt: 1, .. }));
+        assert!(
+            has_retry,
+            "Retrying should still emit RequestRetrying after discard"
+        );
+    }
+
+    #[test]
     fn message_end_empty_content_no_tool_calls_skips_message_completed() {
         // When a provider error interrupts the stream before any text is
         // generated, MessageEnd arrives with empty text_content() and no
@@ -1594,6 +1794,7 @@ Used for prompt assembly coverage.
         let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
 
         // Empty assistant: no content blocks, no tool calls.
         let empty_assistant = sample_partial_assistant_message();
@@ -1608,6 +1809,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::MessageEnd {
@@ -1639,6 +1841,7 @@ Used for prompt assembly coverage.
         let context_compression_state = StdMutex::new(ContextCompressionRuntimeState::default());
         let reasoning_buffer = StdMutex::new(String::new());
         let current_turn_index = StdMutex::new(None::<usize>);
+        let last_text_delta = StdMutex::new(None::<String>);
         // Build an assistant message with actual text content so that
         // MessageEnd emits MessageCompleted (empty content is now skipped).
         let assistant = AssistantMessage::builder()
@@ -1661,6 +1864,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::MessageEnd {
@@ -1679,6 +1883,7 @@ Used for prompt assembly coverage.
             &context_compression_state,
             &reasoning_buffer,
             &current_turn_index,
+            &last_text_delta,
             TEST_CONTEXT_WINDOW,
             TEST_MODEL_DISPLAY_NAME,
             &AgentEvent::MessageDiscarded {

--- a/src-tauri/src/core/thread_manager.rs
+++ b/src-tauri/src/core/thread_manager.rs
@@ -41,7 +41,28 @@ impl ThreadManager {
         )
         .await?;
 
-        Ok(records.into_iter().map(ThreadSummaryDto::from).collect())
+        // Backfill the active-run start timestamp and elapsed running seconds
+        // in one round-trip so the frontend workbench header can render
+        // elapsed time without a follow-up IPC per thread.
+        let thread_ids: Vec<String> = records.iter().map(|r| r.id.clone()).collect();
+        let active_started =
+            run_repo::list_active_run_started_at_ms_by_threads(&self.pool, &thread_ids).await?;
+        let active_elapsed =
+            run_repo::list_active_run_elapsed_seconds_by_threads(&self.pool, &thread_ids).await?;
+
+        Ok(records
+            .into_iter()
+            .map(|r| {
+                let mut dto = ThreadSummaryDto::from(r);
+                if let Some(ms) = active_started.get(&dto.id).copied() {
+                    dto.active_run_started_at_ms = Some(ms);
+                }
+                if let Some(secs) = active_elapsed.get(&dto.id).copied() {
+                    dto.active_run_elapsed_seconds = Some(secs);
+                }
+                dto
+            })
+            .collect())
     }
 
     /// Create a new thread under a workspace.

--- a/src-tauri/src/core/thread_manager.rs
+++ b/src-tauri/src/core/thread_manager.rs
@@ -47,8 +47,9 @@ impl ThreadManager {
         let thread_ids: Vec<String> = records.iter().map(|r| r.id.clone()).collect();
         let active_started =
             run_repo::list_active_run_started_at_ms_by_threads(&self.pool, &thread_ids).await?;
-        let active_elapsed =
-            run_repo::list_active_run_elapsed_seconds_by_threads(&self.pool, &thread_ids).await?;
+        let thread_elapsed =
+            run_repo::list_thread_elapsed_running_seconds_by_threads(&self.pool, &thread_ids)
+                .await?;
 
         Ok(records
             .into_iter()
@@ -57,7 +58,7 @@ impl ThreadManager {
                 if let Some(ms) = active_started.get(&dto.id).copied() {
                     dto.active_run_started_at_ms = Some(ms);
                 }
-                if let Some(secs) = active_elapsed.get(&dto.id).copied() {
+                if let Some(secs) = thread_elapsed.get(&dto.id).copied() {
                     dto.active_run_elapsed_seconds = Some(secs);
                 }
                 dto

--- a/src-tauri/src/ipc/frontend_channels.rs
+++ b/src-tauri/src/ipc/frontend_channels.rs
@@ -27,6 +27,10 @@ pub enum ThreadStreamEvent {
     RunStarted {
         run_id: String,
         run_mode: String,
+        /// Wall-clock start time (Unix ms) of this run. Mirrors
+        /// `thread_runs.started_at` so the frontend can derive elapsed time
+        /// from a persisted source of truth (survives app restarts).
+        started_at_ms: i64,
     },
     StreamResyncRequired {
         run_id: String,

--- a/src-tauri/src/model/thread.rs
+++ b/src-tauri/src/model/thread.rs
@@ -197,6 +197,17 @@ pub struct ThreadSummaryDto {
     pub status: ThreadStatus,
     pub last_active_at: String,
     pub created_at: String,
+    /// Wall-clock start time (Unix ms) of the thread's currently active run,
+    /// if any.  Retained as metadata; the workbench header elapsed timer is
+    /// driven by `active_run_elapsed_seconds` which excludes pauses.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_run_started_at_ms: Option<i64>,
+    /// Cumulative seconds the active run has spent in `Running` status,
+    /// excluding waiting_approval / needs_reply pauses.  `None` when no
+    /// active run exists.  If the run is currently running the in-flight
+    /// segment is included.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_run_elapsed_seconds: Option<i64>,
 }
 
 impl From<ThreadRecord> for ThreadSummaryDto {
@@ -209,6 +220,8 @@ impl From<ThreadRecord> for ThreadSummaryDto {
             status: r.status,
             last_active_at: r.last_active_at,
             created_at: r.created_at,
+            active_run_started_at_ms: None,
+            active_run_elapsed_seconds: None,
         }
     }
 }

--- a/src-tauri/src/model/thread.rs
+++ b/src-tauri/src/model/thread.rs
@@ -202,10 +202,11 @@ pub struct ThreadSummaryDto {
     /// driven by `active_run_elapsed_seconds` which excludes pauses.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_run_started_at_ms: Option<i64>,
-    /// Cumulative seconds the active run has spent in `Running` status,
-    /// excluding waiting_approval / needs_reply pauses.  `None` when no
-    /// active run exists.  If the run is currently running the in-flight
-    /// segment is included.
+    /// Thread-level cumulative active running seconds used to seed the
+    /// workbench header timer. This includes historical completed or
+    /// interrupted runs and, when a run is currently running, its in-flight
+    /// `running_since` segment. The legacy field name is kept for API
+    /// compatibility even though the value is no longer active-run-only.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub active_run_elapsed_seconds: Option<i64>,
 }

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -399,6 +399,7 @@ fn extract_primary_model_details(
 mod tests {
     use super::*;
     use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+    use sqlx::Row;
     use std::str::FromStr;
 
     async fn setup_test_pool() -> SqlitePool {
@@ -633,6 +634,134 @@ mod tests {
             .unwrap()
             .expect("should exist");
         assert_eq!(found.status, "waiting_approval");
+    }
+
+    // ── Elapsed-time transition tests ──────────────────────────────────
+
+    #[tokio::test]
+    async fn update_status_entering_running_sets_running_since_when_null() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 0, None).await;
+
+        update_status(&pool, "run-1", RunStatus::Running)
+            .await
+            .unwrap();
+
+        let row = sqlx::query(
+            "SELECT elapsed_running_secs, running_since FROM thread_runs WHERE id = 'run-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.get::<i64, _>("elapsed_running_secs"), 0);
+        assert!(
+            row.get::<Option<String>, _>("running_since").is_some(),
+            "running_since should be set when entering Running from idle"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_status_entering_running_is_idempotent_for_running_since() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 10, Some("2026-01-01T00:00:00Z")).await;
+
+        update_status(&pool, "run-1", RunStatus::Running)
+            .await
+            .unwrap();
+
+        let row = sqlx::query(
+            "SELECT elapsed_running_secs, running_since FROM thread_runs WHERE id = 'run-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.get::<i64, _>("elapsed_running_secs"), 10);
+        assert_eq!(
+            row.get::<String, _>("running_since"),
+            "2026-01-01T00:00:00Z",
+            "running_since should not be overwritten when entering Running again"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_status_leaving_running_accumulates_elapsed_and_clears_running_since() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 15, Some("2026-01-01T00:00:00Z")).await;
+
+        update_status(&pool, "run-1", RunStatus::WaitingApproval)
+            .await
+            .unwrap();
+
+        let row = sqlx::query(
+            "SELECT elapsed_running_secs, running_since FROM thread_runs WHERE id = 'run-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            row.get::<i64, _>("elapsed_running_secs") > 15,
+            "elapsed should accumulate the open running_since segment"
+        );
+        assert!(
+            row.get::<Option<String>, _>("running_since").is_none(),
+            "running_since should be cleared when leaving Running"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_status_non_running_to_terminal_sets_finished_at_and_preserves_elapsed() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 20, None).await;
+
+        update_status(&pool, "run-1", RunStatus::Completed)
+            .await
+            .unwrap();
+
+        let row = sqlx::query(
+            "SELECT elapsed_running_secs, running_since, finished_at FROM thread_runs WHERE id = 'run-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.get::<i64, _>("elapsed_running_secs"),
+            20,
+            "elapsed should not change when no running segment is open"
+        );
+        assert!(row.get::<Option<String>, _>("running_since").is_none());
+        assert!(
+            row.get::<Option<String>, _>("finished_at").is_some(),
+            "finished_at should be set for terminal status"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_status_running_to_terminal_accumulates_elapsed_and_sets_finished_at() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 10, Some("2026-01-01T00:00:00Z")).await;
+
+        update_status(&pool, "run-1", RunStatus::Failed)
+            .await
+            .unwrap();
+
+        let row = sqlx::query(
+            "SELECT elapsed_running_secs, running_since, finished_at, status FROM thread_runs WHERE id = 'run-1'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert!(
+            row.get::<i64, _>("elapsed_running_secs") > 10,
+            "elapsed should include the open running_since segment"
+        );
+        assert!(row.get::<Option<String>, _>("running_since").is_none());
+        assert!(row.get::<Option<String>, _>("finished_at").is_some());
+        assert_eq!(row.get::<String, _>("status"), "failed");
     }
 
     #[tokio::test]

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -498,6 +498,25 @@ mod tests {
             .expect("set finished_at");
     }
 
+    async fn set_run_elapsed_tracking(
+        pool: &SqlitePool,
+        id: &str,
+        elapsed_running_secs: i64,
+        running_since: Option<&str>,
+    ) {
+        sqlx::query(
+            "UPDATE thread_runs
+             SET elapsed_running_secs = ?, running_since = ?
+             WHERE id = ?",
+        )
+        .bind(elapsed_running_secs)
+        .bind(running_since)
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("set elapsed tracking");
+    }
+
     #[tokio::test]
     async fn find_latest_with_prompt_usage_returns_none_when_no_matching_history_exists() {
         let pool = setup_test_pool().await;
@@ -950,6 +969,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_thread_elapsed_running_seconds_includes_terminal_runs() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-completed", "t1", "2026-04-22T09:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-completed", 37, None).await;
+
+        let values =
+            super::list_thread_elapsed_running_seconds_by_threads(&pool, &["t1".to_string()])
+                .await
+                .unwrap();
+
+        assert_eq!(values.get("t1"), Some(&37));
+    }
+
+    #[tokio::test]
+    async fn list_thread_elapsed_running_seconds_sums_multiple_runs() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-1", "t1", "2026-04-22T09:00:00Z", 0).await;
+        insert_run_with_started_at(&pool, "run-2", "t1", "2026-04-22T10:00:00Z", 0).await;
+        insert_run_with_started_at(&pool, "run-other", "t2", "2026-04-22T11:00:00Z", 0).await;
+        set_run_elapsed_tracking(&pool, "run-1", 12, None).await;
+        set_run_elapsed_tracking(&pool, "run-2", 30, None).await;
+        set_run_elapsed_tracking(&pool, "run-other", 999, None).await;
+
+        let values = super::list_thread_elapsed_running_seconds_by_threads(
+            &pool,
+            &["t1".to_string(), "t2".to_string()],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(values.get("t1"), Some(&42));
+        assert_eq!(values.get("t2"), Some(&999));
+    }
+
+    #[tokio::test]
+    async fn list_thread_elapsed_running_seconds_adds_open_running_segment() {
+        let pool = setup_test_pool().await;
+        insert_run_with_started_at(&pool, "run-running", "t1", "2026-04-22T09:00:00Z", 0).await;
+        super::update_status(&pool, "run-running", RunStatus::Running)
+            .await
+            .unwrap();
+        set_run_elapsed_tracking(&pool, "run-running", 20, Some("2026-04-22T09:00:00Z")).await;
+
+        let values =
+            super::list_thread_elapsed_running_seconds_by_threads(&pool, &["t1".to_string()])
+                .await
+                .unwrap();
+        let elapsed = values.get("t1").copied().expect("thread elapsed");
+
+        assert!(
+            elapsed > 20,
+            "expected running segment to be added, got {elapsed}"
+        );
+    }
+
+    #[tokio::test]
     async fn get_active_run_elapsed_seconds_returns_positive_for_running() {
         let pool = setup_test_pool().await;
         // Insert a running run with a past started_at so elapsed > 0
@@ -1102,11 +1177,11 @@ pub async fn list_active_run_started_at_ms_by_threads(
     Ok(rows.into_iter().collect())
 }
 
-/// Batch-query the cumulative **active running seconds** (excluding pauses)
-/// for each thread that has an active (non-terminal) run. If the run is
-/// currently in `running` status the in-flight segment is included via
-/// `now() - running_since`.
-pub async fn list_active_run_elapsed_seconds_by_threads(
+/// Batch-query thread-level cumulative active running seconds (excluding
+/// pauses) for each requested thread. The total includes all historical runs'
+/// `elapsed_running_secs`; if any run is currently running, its open
+/// `running_since` segment is included as `now() - running_since`.
+pub async fn list_thread_elapsed_running_seconds_by_threads(
     pool: &SqlitePool,
     thread_ids: &[String],
 ) -> Result<std::collections::HashMap<String, i64>, AppError> {
@@ -1119,18 +1194,16 @@ pub async fn list_active_run_elapsed_seconds_by_threads(
         .join(",");
     let sql = format!(
         "SELECT thread_id,
-                CASE WHEN running_since IS NOT NULL
-                     THEN elapsed_running_secs + CAST(strftime('%s', 'now') - strftime('%s', running_since) AS INTEGER)
-                     ELSE elapsed_running_secs
-                END AS elapsed_secs
-         FROM (
-             SELECT thread_id, elapsed_running_secs, running_since,
-                    MAX(started_at) AS started_at
-             FROM thread_runs
-             WHERE thread_id IN ({placeholders})
-               AND status NOT IN ('completed','failed','denied','interrupted','cancelled','limit_reached')
-             GROUP BY thread_id
-         )",
+                SUM(
+                    elapsed_running_secs +
+                    CASE WHEN running_since IS NOT NULL
+                         THEN CAST(strftime('%s', 'now') - strftime('%s', running_since) AS INTEGER)
+                         ELSE 0
+                    END
+                ) AS elapsed_secs
+         FROM thread_runs
+         WHERE thread_id IN ({placeholders})
+         GROUP BY thread_id",
     );
     let mut query = sqlx::query_as::<_, (String, i64)>(&sql);
     for id in thread_ids {
@@ -1138,4 +1211,18 @@ pub async fn list_active_run_elapsed_seconds_by_threads(
     }
     let rows = query.fetch_all(pool).await?;
     Ok(rows.into_iter().collect())
+}
+
+/// Batch-query the cumulative **active running seconds** (excluding pauses)
+/// used by the thread header timer. This is intentionally thread-level rather
+/// than active-run-only so completed/interrupted history survives restarts and
+/// later runs continue from the prior thread total.
+#[deprecated(
+    note = "use list_thread_elapsed_running_seconds_by_threads for thread header timer seeds"
+)]
+pub async fn list_active_run_elapsed_seconds_by_threads(
+    pool: &SqlitePool,
+    thread_ids: &[String],
+) -> Result<std::collections::HashMap<String, i64>, AppError> {
+    list_thread_elapsed_running_seconds_by_threads(pool, thread_ids).await
 }

--- a/src-tauri/src/persistence/repo/run_repo.rs
+++ b/src-tauri/src/persistence/repo/run_repo.rs
@@ -62,20 +62,59 @@ pub async fn insert(pool: &SqlitePool, r: &RunInsert) -> Result<(), AppError> {
 }
 
 pub async fn update_status(pool: &SqlitePool, id: &str, status: RunStatus) -> Result<(), AppError> {
-    if status.is_terminal() {
+    let is_entering_running = status == RunStatus::Running;
+    let is_terminal = status.is_terminal();
+
+    if is_terminal {
+        // Terminal: settle any open running segment, set finished_at.
         let now = Utc::now().to_rfc3339();
-        sqlx::query("UPDATE thread_runs SET status = ?, finished_at = ? WHERE id = ?")
-            .bind(status.as_str())
-            .bind(&now)
-            .bind(id)
-            .execute(pool)
-            .await?;
+        sqlx::query(
+            "UPDATE thread_runs SET \
+                status = ?, \
+                elapsed_running_secs = elapsed_running_secs + \
+                    CASE WHEN running_since IS NOT NULL \
+                         THEN CAST(strftime('%s', 'now') - strftime('%s', running_since) AS INTEGER) \
+                         ELSE 0 END, \
+                running_since = NULL, \
+                finished_at = ? \
+             WHERE id = ?",
+        )
+        .bind(status.as_str())
+        .bind(&now)
+        .bind(id)
+        .execute(pool)
+        .await?;
+    } else if is_entering_running {
+        // Entering Running: record running_since if not already set (idempotent).
+        sqlx::query(
+            "UPDATE thread_runs SET \
+                status = ?, \
+                running_since = CASE WHEN running_since IS NULL \
+                                     THEN strftime('%Y-%m-%dT%H:%M:%fZ', 'now') \
+                                     ELSE running_since END \
+             WHERE id = ?",
+        )
+        .bind(status.as_str())
+        .bind(id)
+        .execute(pool)
+        .await?;
     } else {
-        sqlx::query("UPDATE thread_runs SET status = ? WHERE id = ?")
-            .bind(status.as_str())
-            .bind(id)
-            .execute(pool)
-            .await?;
+        // Leaving Running (→ WaitingApproval / NeedsReply / WaitingToolResult etc.)
+        // or non-Running → non-Running: settle any open running segment.
+        sqlx::query(
+            "UPDATE thread_runs SET \
+                status = ?, \
+                elapsed_running_secs = elapsed_running_secs + \
+                    CASE WHEN running_since IS NOT NULL \
+                         THEN CAST(strftime('%s', 'now') - strftime('%s', running_since) AS INTEGER) \
+                         ELSE 0 END, \
+                running_since = NULL \
+             WHERE id = ?",
+        )
+        .bind(status.as_str())
+        .bind(id)
+        .execute(pool)
+        .await?;
     }
 
     Ok(())
@@ -1026,4 +1065,77 @@ pub async fn get_active_run_elapsed_seconds(
     .await?
     .flatten();
     Ok(duration)
+}
+
+/// Bulk-fetch the Unix-millisecond start timestamp of the currently active
+/// (non-terminal) run for each thread in `thread_ids`. Threads without an
+/// active run are simply absent from the returned map. Used by the sidebar
+/// query so the frontend can derive per-thread elapsed time from a source
+/// of truth that survives app restarts (`thread_runs.started_at`).
+pub async fn list_active_run_started_at_ms_by_threads(
+    pool: &SqlitePool,
+    thread_ids: &[String],
+) -> Result<std::collections::HashMap<String, i64>, AppError> {
+    if thread_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    // `IN (?, ?, …)` with a single bind argument per id. Keeps the query
+    // shape easy to read; thread_ids is bounded by the sidebar page size.
+    let placeholders = std::iter::repeat("?")
+        .take(thread_ids.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT thread_id, CAST(strftime('%s', started_at) AS INTEGER) * 1000 AS started_at_ms
+         FROM (
+             SELECT thread_id, MAX(started_at) AS started_at FROM thread_runs
+             WHERE thread_id IN ({placeholders})
+               AND status NOT IN ('completed','failed','denied','interrupted','cancelled','limit_reached')
+             GROUP BY thread_id
+         )",
+    );
+    let mut query = sqlx::query_as::<_, (String, i64)>(&sql);
+    for id in thread_ids {
+        query = query.bind(id);
+    }
+    let rows = query.fetch_all(pool).await?;
+    Ok(rows.into_iter().collect())
+}
+
+/// Batch-query the cumulative **active running seconds** (excluding pauses)
+/// for each thread that has an active (non-terminal) run. If the run is
+/// currently in `running` status the in-flight segment is included via
+/// `now() - running_since`.
+pub async fn list_active_run_elapsed_seconds_by_threads(
+    pool: &SqlitePool,
+    thread_ids: &[String],
+) -> Result<std::collections::HashMap<String, i64>, AppError> {
+    if thread_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders = std::iter::repeat("?")
+        .take(thread_ids.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT thread_id,
+                CASE WHEN running_since IS NOT NULL
+                     THEN elapsed_running_secs + CAST(strftime('%s', 'now') - strftime('%s', running_since) AS INTEGER)
+                     ELSE elapsed_running_secs
+                END AS elapsed_secs
+         FROM (
+             SELECT thread_id, elapsed_running_secs, running_since,
+                    MAX(started_at) AS started_at
+             FROM thread_runs
+             WHERE thread_id IN ({placeholders})
+               AND status NOT IN ('completed','failed','denied','interrupted','cancelled','limit_reached')
+             GROUP BY thread_id
+         )",
+    );
+    let mut query = sqlx::query_as::<_, (String, i64)>(&sql);
+    for id in thread_ids {
+        query = query.bind(id);
+    }
+    let rows = query.fetch_all(pool).await?;
+    Ok(rows.into_iter().collect())
 }

--- a/src-tauri/tests/frontend_integration.rs
+++ b/src-tauri/tests/frontend_integration.rs
@@ -30,6 +30,7 @@ fn test_thread_stream_event_run_started_serialization() {
     let event = ThreadStreamEvent::RunStarted {
         run_id: "run-1".into(),
         run_mode: "default".into(),
+        started_at_ms: 0,
     };
 
     let json = serde_json::to_value(&event).unwrap();
@@ -405,6 +406,7 @@ fn test_all_events_have_type_field() {
         ThreadStreamEvent::RunStarted {
             run_id: "r".into(),
             run_mode: "default".into(),
+            started_at_ms: 0,
         },
         ThreadStreamEvent::StreamResyncRequired {
             run_id: "r".into(),
@@ -671,6 +673,8 @@ fn test_thread_summary_dto_camel_case() {
         status: ThreadStatus::Idle,
         last_active_at: "2026-03-16T00:00:00Z".into(),
         created_at: "2026-03-16T00:00:00Z".into(),
+        active_run_started_at_ms: None,
+        active_run_elapsed_seconds: None,
     };
 
     let json = serde_json::to_value(&dto).unwrap();

--- a/src-tauri/tests/thread.rs
+++ b/src-tauri/tests/thread.rs
@@ -132,6 +132,47 @@ async fn test_thread_list_returns_profile_id() {
 }
 
 #[tokio::test]
+async fn test_thread_list_returns_cumulative_elapsed_running_seconds() {
+    let pool = test_helpers::setup_test_pool().await;
+    test_helpers::seed_workspace(&pool, "ws-elapsed", "/tmp/elapsed").await;
+    test_helpers::seed_thread(&pool, "t-elapsed", "ws-elapsed", None).await;
+    test_helpers::seed_run(&pool, "run-history", "t-elapsed", "completed", "default").await;
+    test_helpers::seed_run(&pool, "run-active", "t-elapsed", "running", "default").await;
+
+    sqlx::query(
+        "UPDATE thread_runs
+         SET elapsed_running_secs = 25, running_since = NULL
+         WHERE id = 'run-history'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "UPDATE thread_runs
+         SET elapsed_running_secs = 10, running_since = '2026-04-22T09:00:00Z'
+         WHERE id = 'run-active'",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let manager = ThreadManager::new(pool.clone());
+    let threads = manager
+        .list("ws-elapsed", None, None)
+        .await
+        .expect("thread list should succeed");
+
+    assert_eq!(threads.len(), 1);
+    let elapsed = threads[0]
+        .active_run_elapsed_seconds
+        .expect("elapsed seconds should be present");
+    assert!(
+        elapsed > 35,
+        "expected historical baseline plus open running segment, got {elapsed}",
+    );
+}
+
+#[tokio::test]
 async fn test_thread_belongs_to_workspace() {
     let pool = test_helpers::setup_test_pool().await;
     test_helpers::seed_workspace(&pool, "ws-own", "/tmp/own").await;

--- a/src/modules/workbench-shell/model/helpers.extra.test.ts
+++ b/src/modules/workbench-shell/model/helpers.extra.test.ts
@@ -7,6 +7,7 @@ import {
   buildWorkspaceItemsFromDtos,
   clearActiveThreads,
   getActiveThread,
+  findThreadById,
   activateThread,
   buildThreadTitle,
   mergeRecentProjects,
@@ -30,6 +31,8 @@ function thread(overrides: Partial<ThreadSummaryDto> = {}): ThreadSummaryDto {
     status: "idle",
     lastActiveAt: "2026-04-25T10:00:00Z",
     createdAt: "2026-04-25T10:00:00Z",
+    activeRunStartedAtMs: null,
+    activeRunElapsedSeconds: null,
     ...overrides,
   };
 }
@@ -126,6 +129,33 @@ describe("helpers: thread & workspace", () => {
 
     expect(updated[0].threads.find((t) => t.id === "t-2")?.active).toBe(true);
     expect(updated[0].threads.find((t) => t.id === "t-1")?.active).toBe(false);
+  });
+});
+
+describe("helpers: findThreadById", () => {
+  it("returns the matching thread across multiple workspaces", () => {
+    const ws1 = workspaceItem("ws-1", [threadItem("t-1", "Thread 1")]);
+    const ws2 = workspaceItem("ws-2", [
+      threadItem("t-2", "Thread 2"),
+      threadItem("t-3", "Thread 3"),
+    ]);
+    const found = findThreadById([ws1, ws2], "t-3");
+    expect(found?.id).toBe("t-3");
+    expect(found?.name).toBe("Thread 3");
+  });
+
+  it("returns null when no thread matches", () => {
+    const ws = workspaceItem("ws-1", [threadItem("t-1", "Thread 1")]);
+    expect(findThreadById([ws], "missing")).toBeNull();
+  });
+
+  it("returns null for a null or empty threadId", () => {
+    const ws = workspaceItem("ws-1", [threadItem("t-1", "Thread 1")]);
+    expect(findThreadById([ws], null)).toBeNull();
+  });
+
+  it("returns null when workspaces is empty", () => {
+    expect(findThreadById([], "t-1")).toBeNull();
   });
 });
 
@@ -321,6 +351,7 @@ describe("helpers: buildWorkspaceThreadItem", () => {
       status: "running",
       lastActiveAt: "2026-04-25T11:59:00Z",
       createdAt: "2026-04-25T10:00:00Z",
+      activeRunStartedAtMs: null, activeRunElapsedSeconds: null,
     };
     const item = buildWorkspaceThreadItem(dto, null, "en");
     expect(item.id).toBe("t1");
@@ -339,6 +370,7 @@ describe("helpers: buildWorkspaceThreadItem", () => {
       status: "idle",
       lastActiveAt: "2026-04-25T11:59:00Z",
       createdAt: "2026-04-25T10:00:00Z",
+      activeRunStartedAtMs: null, activeRunElapsedSeconds: null,
     };
     const item = buildWorkspaceThreadItem(dto, null, "en");
     expect(item.name).toBe("New thread");
@@ -353,6 +385,7 @@ describe("helpers: buildWorkspaceThreadItem", () => {
       status: "idle",
       lastActiveAt: "2026-04-25T11:59:00Z",
       createdAt: "2026-04-25T10:00:00Z",
+      activeRunStartedAtMs: null, activeRunElapsedSeconds: null,
     };
     const item = buildWorkspaceThreadItem(dto, "t1", "en");
     expect(item.active).toBe(true);
@@ -367,6 +400,7 @@ describe("helpers: buildWorkspaceThreadItem", () => {
       status: "idle",
       lastActiveAt: "",
       createdAt: "2026-04-25T10:00:00Z",
+      activeRunStartedAtMs: null, activeRunElapsedSeconds: null,
     };
     const item = buildWorkspaceThreadItem(dto, null, "en");
     // Should use createdAt (a valid date) rather than empty lastActiveAt

--- a/src/modules/workbench-shell/model/helpers.ts
+++ b/src/modules/workbench-shell/model/helpers.ts
@@ -515,6 +515,23 @@ export function getActiveThread(workspaces: ReadonlyArray<WorkspaceItem>): Works
   return null;
 }
 
+/**
+ * Look up a thread by id across all workspaces. Returns `null` when the id is
+ * absent. O(workspaces × threads); intended for sparse lookups (sidebar /
+ * store selectors), not batched hot paths.
+ */
+export function findThreadById(
+  workspaces: ReadonlyArray<WorkspaceItem>,
+  threadId: string | null,
+): WorkspaceThreadItem | null {
+  if (!threadId) return null;
+  for (const workspace of workspaces) {
+    const found = workspace.threads.find((thread) => thread.id === threadId);
+    if (found) return found;
+  }
+  return null;
+}
+
 export function activateThread(workspaces: ReadonlyArray<WorkspaceItem>, threadId: string): Array<WorkspaceItem> {
   return workspaces.map((workspace) => ({
     ...workspace,

--- a/src/modules/workbench-shell/model/run-lifecycle-machine.test.ts
+++ b/src/modules/workbench-shell/model/run-lifecycle-machine.test.ts
@@ -22,6 +22,7 @@ describe("run-lifecycle-machine", () => {
       expect(m.getState()).toBe("idle");
       expect(m.getContext()).toEqual({
         runId: null,
+        startedAtMs: null,
         errorMessage: null,
         retryCount: 0,
       });
@@ -130,7 +131,7 @@ describe("run-lifecycle-machine", () => {
         // We need to get the machine into the target state first.
         // Use reset() to force it for testing.
         const m = makeMachine();
-        m.reset(state, { runId: "old-run", errorMessage: null, retryCount: 0 });
+        m.reset(state, { runId: "old-run", startedAtMs: null, errorMessage: null, retryCount: 0 });
         m.send("RUN_STARTED", { runId: "run-2" });
         expect(m.getState()).toBe("running");
         expect(m.getContext().runId).toBe("run-2");
@@ -198,6 +199,7 @@ describe("run-lifecycle-machine", () => {
       m.send("RUN_STARTED", { runId: "run-1" });
       m.reset("waiting_approval", {
         runId: "snapshot-run",
+        startedAtMs: null,
         errorMessage: null,
         retryCount: 0,
       });

--- a/src/modules/workbench-shell/model/run-lifecycle-machine.ts
+++ b/src/modules/workbench-shell/model/run-lifecycle-machine.ts
@@ -36,6 +36,15 @@ export type RunMachineEvent =
 /** Context data carried alongside the run-lifecycle state. */
 export interface RunMachineContext {
   runId: string | null;
+  /**
+   * Wall-clock start time (Unix ms) of the current run. Mirrors the
+   * `startedAtMs` field on `ThreadStreamEvent::RunStarted` and is
+   * propagated to `ThreadStatusRecord.startedAtMs` for metadata /
+   * debugging.  The workbench header elapsed timer is driven by a
+   * separate frontend `TimerSlot` in `use-thread-elapsed-timer.ts`
+   * that only accumulates active running time.
+   */
+  startedAtMs: number | null;
   errorMessage: string | null;
   retryCount: number;
 }
@@ -43,6 +52,8 @@ export interface RunMachineContext {
 /** Payload shape for run-machine events. */
 export interface RunMachinePayload {
   runId?: string | null;
+  /** Wall-clock start time (Unix ms) attached to a `RUN_STARTED` event. */
+  startedAtMs?: number | null;
   message?: string;
   newRunId?: string;
 }
@@ -56,7 +67,13 @@ const RUN_STARTED_TRANSITION = {
   target: "running" as const,
   action: (ctx: RunMachineContext, payload?: unknown): RunMachineContext => {
     const p = payload as RunMachinePayload | undefined;
-    return { ...ctx, runId: p?.runId ?? null, retryCount: 0, errorMessage: null };
+    return {
+      ...ctx,
+      runId: p?.runId ?? null,
+      startedAtMs: p?.startedAtMs ?? null,
+      retryCount: 0,
+      errorMessage: null,
+    };
   },
 };
 
@@ -92,7 +109,7 @@ export function createRunLifecycleMachine(
     RunMachineContext
   >({
     initial: "idle",
-    context: { runId: null, errorMessage: null, retryCount: 0 },
+    context: { runId: null, startedAtMs: null, errorMessage: null, retryCount: 0 },
     states: {
       idle: {
         on: {
@@ -155,9 +172,10 @@ export function createRunLifecycleMachine(
   machine.subscribe(() => {
     if (!threadId) return;
     const currentState = machine.getState();
-    const runId = machine.getContext().runId;
+    const context = machine.getContext();
     setThreadStatus(threadId, currentState as ThreadRunStatus, {
-      runId,
+      runId: context.runId,
+      startedAtMs: context.startedAtMs,
       source: "stream",
     });
   });

--- a/src/modules/workbench-shell/model/thread-store.ts
+++ b/src/modules/workbench-shell/model/thread-store.ts
@@ -29,6 +29,20 @@ export type ThreadContextUsage = {
 export interface ThreadStatusRecord {
   status: ThreadRunStatus;
   runId: string | null;
+  /**
+   * Wall-clock start time (Unix ms) of the thread's currently active run.
+   * Populated from `run_started` events (live) and from the sidebar list
+   * snapshot (post-restart recovery).  Retained as metadata for debugging
+   * and potential future use; the workbench header elapsed timer is driven
+   * by a separate frontend `TimerSlot` mechanism in
+   * `use-thread-elapsed-timer.ts` that only accumulates active running
+   * time (excluding waiting_approval / needs_reply pauses).
+   */
+  startedAtMs: number | null;
+  /** Backend-computed cumulative active running seconds (excluding pauses).
+   *  Populated from the sidebar snapshot on app start; used to seed the
+   *  frontend `TimerSlot` in `use-thread-elapsed-timer.ts`. */
+  elapsedRunningSeconds: number | null;
   updatedAt: number;
   source: ThreadStatusSource;
 }
@@ -134,6 +148,8 @@ export function setThreadStatus(
   meta: {
     runId?: string | null;
     source?: ThreadStatusSource;
+    startedAtMs?: number | null;
+    elapsedRunningSeconds?: number | null;
   } = {},
 ): void {
   threadStore.setState((prev) => {
@@ -181,12 +197,29 @@ export function setThreadStatus(
       return {};
     }
 
+    // Derive the next startedAtMs. Snapshots are the only place the value
+    // arrives without an associated run_started event; for any other write
+    // we either accept the explicit value or fall back to the existing one
+    // (preserving the timer across status flips like running → waiting_approval
+    // → running within the same run). On terminal status the timer is cleared
+    // because the run is done and the wall-clock value is no longer meaningful.
+    const isTerminal = isTerminalStatus(status);
+    const startedAtMs = isTerminal
+      ? null
+      : meta.startedAtMs !== undefined
+        ? meta.startedAtMs
+        : (existing?.startedAtMs ?? null);
+
     return {
       threadStatuses: {
         ...prev.threadStatuses,
         [threadId]: {
           status,
-          runId: isTerminalStatus(status) ? null : (incomingRunId ?? existing?.runId ?? null),
+          runId: isTerminal ? null : (incomingRunId ?? existing?.runId ?? null),
+          startedAtMs,
+          elapsedRunningSeconds: meta.elapsedRunningSeconds !== undefined
+            ? meta.elapsedRunningSeconds
+            : (existing?.elapsedRunningSeconds ?? null),
           source: meta.source ?? "tauri_event",
           updatedAt: Date.now(),
         },
@@ -198,7 +231,13 @@ export function setThreadStatus(
 export function batchSetThreadStatuses(
   updates: Record<
     string,
-    { status: ThreadRunStatus; runId?: string | null; source?: ThreadStatusSource }
+    {
+      status: ThreadRunStatus;
+      runId?: string | null;
+      source?: ThreadStatusSource;
+      startedAtMs?: number | null;
+      elapsedRunningSeconds?: number | null;
+    }
   >,
 ): void {
   threadStore.setState((prev) => {
@@ -244,9 +283,20 @@ export function batchSetThreadStatuses(
         continue;
       }
 
+      const isTerminal = isTerminalStatus(upd.status);
+      const startedAtMs = isTerminal
+        ? null
+        : upd.startedAtMs !== undefined
+          ? upd.startedAtMs
+          : (existing?.startedAtMs ?? null);
+
       next[threadId] = {
         status: upd.status,
-        runId: isTerminalStatus(upd.status) ? null : (incomingRunId ?? existing?.runId ?? null),
+        runId: isTerminal ? null : (incomingRunId ?? existing?.runId ?? null),
+        startedAtMs,
+        elapsedRunningSeconds: upd.elapsedRunningSeconds !== undefined
+          ? upd.elapsedRunningSeconds ?? null
+          : (existing?.elapsedRunningSeconds ?? null),
         source: upd.source ?? "tauri_event",
         updatedAt: Date.now(),
       };
@@ -283,11 +333,11 @@ export function updateWorkspace(
 }
 
 export function removeWorkspace(workspaceId: string): void {
+  const threadIdsToClean = threadStore
+    .getState()
+    .workspaces.find((w) => w.id === workspaceId)
+    ?.threads.map((t) => t.id) ?? [];
   threadStore.setState((prev) => {
-    const workspace = prev.workspaces.find((w) => w.id === workspaceId);
-    const threadIdsToClean = workspace
-      ? workspace.threads.map((t) => t.id)
-      : [];
     const nextStatuses = { ...prev.threadStatuses };
     for (const tid of threadIdsToClean) {
       delete nextStatuses[tid];

--- a/src/modules/workbench-shell/model/thread-store.ts
+++ b/src/modules/workbench-shell/model/thread-store.ts
@@ -39,9 +39,11 @@ export interface ThreadStatusRecord {
    * time (excluding waiting_approval / needs_reply pauses).
    */
   startedAtMs: number | null;
-  /** Backend-computed cumulative active running seconds (excluding pauses).
-   *  Populated from the sidebar snapshot on app start; used to seed the
-   *  frontend `TimerSlot` in `use-thread-elapsed-timer.ts`. */
+  /** Backend-computed thread-level cumulative active running seconds
+   *  (excluding pauses). Populated from the sidebar snapshot on app start;
+   *  used to seed the frontend `TimerSlot` in
+   *  `use-thread-elapsed-timer.ts`, including completed/interrupted history
+   *  so later runs continue from the prior thread total. */
   elapsedRunningSeconds: number | null;
   updatedAt: number;
   source: ThreadStatusSource;

--- a/src/modules/workbench-shell/model/workbench-actions.ts
+++ b/src/modules/workbench-shell/model/workbench-actions.ts
@@ -32,6 +32,7 @@ import {
   buildProjectOptionFromPath,
   mergeRecentProjects,
   buildWorkspaceItemsFromDtos,
+  findThreadById,
   getActiveThread,
 } from "@/modules/workbench-shell/model/helpers";
 import { isSameWorkspacePath } from "@/shared/lib/workspace-path";
@@ -43,6 +44,7 @@ import {
   resolveThreadProfileId,
   type PendingThreadRun,
 } from "@/modules/workbench-shell/ui/dashboard-workbench-logic";
+import { clearTimerSlot } from "@/modules/workbench-shell/ui/use-thread-elapsed-timer";
 import {
   buildWorkspaceBindings,
   buildWorkspaceBindingsForEntry,
@@ -176,9 +178,7 @@ export function selectThread(threadId: string): void {
   const { selectedProject: currentProject } = projectStore.getState();
   const activeAgentProfileId = settingsStore.getState().activeAgentProfileId;
 
-  const nextActiveThread = workspaces
-    .flatMap((w) => w.threads)
-    .find((t) => t.id === threadId) ?? null;
+  const nextActiveThread = findThreadById(workspaces, threadId);
 
   const resolvedProfileId = resolveThreadProfileId(
     nextActiveThread?.profileId ?? null,
@@ -310,6 +310,10 @@ export async function deleteThread(threadId: string, options?: ThreadDeleteOptio
 
   // Clean up terminal session
   terminalStore.removeSession(threadId);
+
+  // Drop the cached thread-elapsed-timer slot so a recycled threadId
+  // starts from zero rather than inheriting the deleted thread's elapsed.
+  clearTimerSlot(threadId);
 
   // Remove thread from workspaces and clean threadStatuses
   threadStore.setState((prev) => {
@@ -443,6 +447,11 @@ export async function removeWorkspace(workspace: WorkspaceItem): Promise<void> {
       ),
     ),
   }));
+
+  // Drop cached timer slots for all threads in this workspace
+  for (const tid of workspaceThreadIds) {
+    clearTimerSlot(tid);
+  }
 
   // Clean terminal bindings
   projectStore.setState((prev) => ({
@@ -834,6 +843,8 @@ export async function performSidebarSync(options: SidebarSyncOptions): Promise<v
       snapshotStatusUpdates[thread.id] = {
         status: backendToThreadRunStatus(thread.status),
         runId: null,
+        startedAtMs: thread.activeRunStartedAtMs ?? null,
+        elapsedRunningSeconds: thread.activeRunElapsedSeconds ?? null,
         source: "snapshot",
       };
     }

--- a/src/modules/workbench-shell/ui/dashboard-workbench.tsx
+++ b/src/modules/workbench-shell/ui/dashboard-workbench.tsx
@@ -54,8 +54,7 @@ import {
 } from "@/modules/workbench-shell/model/fixtures";
 import {
   buildProjectOptionFromPath,
-  
-  getActiveThread,
+  findThreadById,
 } from "@/modules/workbench-shell/model/helpers";
 import {
   addRemovedWorkspacePath,
@@ -81,6 +80,7 @@ import {
   GitPanel,
 } from "@/modules/workbench-shell/ui/source-control-panels";
 import { ThreadStatusIndicator } from "@/modules/workbench-shell/ui/thread-status-indicator";
+import { useThreadElapsedTimer } from "@/modules/workbench-shell/ui/use-thread-elapsed-timer";
 import { DashboardTerminalOrchestrator } from "@/modules/workbench-shell/ui/dashboard-terminal-orchestrator";
 import { DashboardSidebar } from "@/modules/workbench-shell/ui/dashboard-sidebar";
 import { DashboardOverlays } from "@/modules/workbench-shell/ui/dashboard-overlays";
@@ -315,14 +315,23 @@ const drawerWidth = useStore(uiLayoutStore, (s) => s.drawerWidth);
   const workspaceMenuRef = useRef<HTMLDivElement | null>(null);
   const removedWorkspacePathsRef = useRef<Set<string>>(new Set());
 
-  const activeThread = getActiveThread(workspaces);
+  const activeThreadId = useStore(threadStore, (s) => s.activeThreadId);
+  const activeThread = useMemo(
+    () => findThreadById(workspaces, activeThreadId),
+    [workspaces, activeThreadId],
+  );
   const activeThreadLiveStatus = useStore(
     threadStore,
-    (s) => activeThread?.id ? s.threadStatuses[activeThread.id]?.status as ThreadRunStatus | undefined : undefined,
+    (s) => activeThreadId ? s.threadStatuses[activeThreadId]?.status as ThreadRunStatus | undefined : undefined,
+  );
+  const activeThreadElapsedSeed = useStore(
+    threadStore,
+    (s) => activeThreadId ? s.threadStatuses[activeThreadId]?.elapsedRunningSeconds ?? null : null,
   );
   const activeThreadDisplayStatus = activeThreadLiveStatus
     ? threadRunStatusToDisplayStatus(activeThreadLiveStatus)
     : activeThread?.status ?? "completed";
+  const { elapsedSeconds: threadElapsed, formattedTime: threadElapsedDisplay, isRunning: isThreadTimerRunning } = useThreadElapsedTimer(activeThread?.id, activeThreadLiveStatus, activeThreadElapsedSeed);
   const selectedProjectWorkspaceId = getWorkspaceBindingId(
     terminalWorkspaceBindings,
     selectedProject?.path ?? null,
@@ -1013,6 +1022,17 @@ const drawerWidth = useStore(uiLayoutStore, (s) => s.drawerWidth);
                             </p>
                           </div>
                         </div>
+                        {threadElapsed > 0 && (
+                          <span className="flex shrink-0 items-center gap-1 text-xs tabular-nums text-app-muted">
+                            {isThreadTimerRunning && (
+                              <span
+                                aria-hidden
+                                className="h-1.5 w-1.5 rounded-full bg-blue-500 animate-pulse"
+                              />
+                            )}
+                            <span>{threadElapsedDisplay}</span>
+                          </span>
+                        )}
                         <div className="ml-auto flex shrink-0 items-center gap-1.5">
                           <div className="group/context-window relative shrink-0">
                             <span

--- a/src/modules/workbench-shell/ui/goal-status-bar.test.tsx
+++ b/src/modules/workbench-shell/ui/goal-status-bar.test.tsx
@@ -1,79 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import {
-  computeGoalTimerTransition,
-  isGoalTimerRunning,
-} from "./goal-status-bar";
-
 const source = await import("./goal-status-bar?raw").then((module) => module.default as string);
-
-describe("GoalStatusBar timer helpers", () => {
-  it("runs only while the thread is running and the goal is active", () => {
-    expect(isGoalTimerRunning("running", "active")).toBe(true);
-    expect(isGoalTimerRunning("waiting_approval", "active")).toBe(false);
-    expect(isGoalTimerRunning("needs_reply", "active")).toBe(false);
-    expect(isGoalTimerRunning("running", "paused")).toBe(false);
-  });
-
-  it("freezes while waiting for user action and resumes from the frozen elapsed value", () => {
-    const started = computeGoalTimerTransition({
-      isTimerRunning: true,
-      previousElapsedSeconds: 0,
-      previousBaseElapsedSeconds: 0,
-      previousStartedAtMs: null,
-      nowMs: 1_000,
-    });
-    expect(started).toEqual({
-      elapsedSeconds: 0,
-      baseElapsedSeconds: 0,
-      startedAtMs: 1_000,
-    });
-
-    const advanced = computeGoalTimerTransition({
-      isTimerRunning: true,
-      previousElapsedSeconds: started.elapsedSeconds,
-      previousBaseElapsedSeconds: started.baseElapsedSeconds,
-      previousStartedAtMs: started.startedAtMs,
-      nowMs: 3_400,
-    });
-    expect(advanced.elapsedSeconds).toBe(2);
-
-    const frozen = computeGoalTimerTransition({
-      isTimerRunning: false,
-      previousElapsedSeconds: advanced.elapsedSeconds,
-      previousBaseElapsedSeconds: advanced.baseElapsedSeconds,
-      previousStartedAtMs: advanced.startedAtMs,
-      nowMs: 10_000,
-    });
-    expect(frozen).toEqual({
-      elapsedSeconds: 2,
-      baseElapsedSeconds: 2,
-      startedAtMs: null,
-    });
-
-    const resumed = computeGoalTimerTransition({
-      isTimerRunning: true,
-      previousElapsedSeconds: frozen.elapsedSeconds,
-      previousBaseElapsedSeconds: frozen.baseElapsedSeconds,
-      previousStartedAtMs: frozen.startedAtMs,
-      nowMs: 10_000,
-    });
-    expect(resumed).toEqual({
-      elapsedSeconds: 2,
-      baseElapsedSeconds: 2,
-      startedAtMs: 10_000,
-    });
-
-    const resumedAdvanced = computeGoalTimerTransition({
-      isTimerRunning: true,
-      previousElapsedSeconds: resumed.elapsedSeconds,
-      previousBaseElapsedSeconds: resumed.baseElapsedSeconds,
-      previousStartedAtMs: resumed.startedAtMs,
-      nowMs: 12_100,
-    });
-    expect(resumedAdvanced.elapsedSeconds).toBe(4);
-  });
-});
 
 describe("GoalStatusBar layout contract", () => {
   it("keeps the objective as the flexible truncated area and reserves metric space", () => {
@@ -83,5 +10,14 @@ describe("GoalStatusBar layout contract", () => {
     expect(source).toContain("min-w-0 flex-1 truncate text-foreground/80");
     expect(source).toContain("flex shrink-0 items-center gap-3 whitespace-nowrap");
     expect(source).toContain("shrink-0 whitespace-nowrap tabular-nums text-muted-foreground");
+  });
+
+  it("does not render a per-goal elapsed timer (thread header owns that surface)", () => {
+    // The previous refactor deliberately removed the cumulative timer from
+    // this bar; the workbench header is now the single owner of per-thread
+    // elapsed time. Guard against accidentally re-introducing it.
+    expect(source).not.toContain("useThreadElapsedTimer");
+    expect(source).not.toContain("goal.time.elapsed");
+    expect(source).not.toContain("goal.time.hoursMinutes");
   });
 });

--- a/src/modules/workbench-shell/ui/goal-status-bar.tsx
+++ b/src/modules/workbench-shell/ui/goal-status-bar.tsx
@@ -1,181 +1,18 @@
 "use client";
 
-import { useCallback, useState, useEffect } from "react";
+import { useCallback, useState } from "react";
 import { goalGetState, goalPause, goalResume, goalClear } from "@/services/bridge/agent-commands";
 import { threadStore, useStore, shallowEqual } from "@/modules/workbench-shell/model/thread-store";
-import type { ThreadRunStatus } from "@/modules/workbench-shell/model/types";
 import { useT } from "@/i18n";
 
 type Props = {
   threadId: string;
 };
 
-type GoalStatus = "active" | "paused" | "budget_limited" | "complete";
-
-export type GoalTimerTransitionInput = {
-  isTimerRunning: boolean;
-  previousElapsedSeconds: number;
-  previousBaseElapsedSeconds: number;
-  previousStartedAtMs: number | null;
-  nowMs: number;
-};
-
-export type GoalTimerTransition = {
-  elapsedSeconds: number;
-  baseElapsedSeconds: number;
-  startedAtMs: number | null;
-};
-
-export function isGoalTimerRunning(
-  threadStatus: ThreadRunStatus | undefined,
-  goalStatus: GoalStatus | undefined,
-): boolean {
-  return threadStatus === "running" && goalStatus === "active";
-}
-
-export function computeGoalTimerTransition({
-  isTimerRunning,
-  previousElapsedSeconds,
-  previousBaseElapsedSeconds,
-  previousStartedAtMs,
-  nowMs,
-}: GoalTimerTransitionInput): GoalTimerTransition {
-  if (!isTimerRunning) {
-    return {
-      elapsedSeconds: previousElapsedSeconds,
-      baseElapsedSeconds: previousElapsedSeconds,
-      startedAtMs: null,
-    };
-  }
-
-  const startedAtMs = previousStartedAtMs ?? nowMs;
-  const baseElapsedSeconds = previousStartedAtMs === null
-    ? previousElapsedSeconds
-    : previousBaseElapsedSeconds;
-  const elapsedSeconds = baseElapsedSeconds + Math.floor((nowMs - startedAtMs) / 1000);
-
-  return {
-    elapsedSeconds,
-    baseElapsedSeconds,
-    startedAtMs,
-  };
-}
-
-function formatDuration(t: ReturnType<typeof useT>, totalSeconds: number): string {
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-
-  if (hours > 0) {
-    return t("goal.time.hoursMinutes", { hours, minutes });
-  } else if (minutes > 0) {
-    return t("goal.time.minutesSeconds", { minutes, seconds });
-  } else {
-    return t("goal.time.seconds", { seconds });
-  }
-}
-
-/** Per-thread timer slot so elapsed is preserved across thread switches. */
-type TimerSlot = {
-  elapsed: number;
-  baseElapsed: number;
-  startedAt: number | null;
-  goalId: string | null;
-  accountedSeconds: number;
-  runId: string | null;
-};
-
-function createTimerSlot(): TimerSlot {
-  return {
-    elapsed: 0,
-    baseElapsed: 0,
-    startedAt: null,
-    goalId: null,
-    accountedSeconds: 0,
-    runId: null,
-  };
-}
-
-/** Module-level timer slots so per-thread elapsed time survives
- *  component mount/unmount cycles (e.g. when entering new-thread mode). */
-const timerSlots = new Map<string, TimerSlot>();
-
-function getSlot(tid: string): TimerSlot {
-  let slot = timerSlots.get(tid);
-  if (!slot) {
-    slot = createTimerSlot();
-    timerSlots.set(tid, slot);
-  }
-  return slot;
-}
-
 export function GoalStatusBar({ threadId }: Props) {
   const t = useT();
   const goal = useStore(threadStore, (s) => s.goalState[threadId] ?? null, shallowEqual);
-  const threadStatus = useStore(
-    threadStore,
-    (s) => s.threadStatuses[threadId],
-    shallowEqual,
-  );
   const [loading, setLoading] = useState(false);
-  const [, setTick] = useState(0);
-
-  const slot = getSlot(threadId);
-
-  const isTimerRunning = isGoalTimerRunning(threadStatus?.status, goal?.status);
-
-  // Reset effect: detect goal / run identity changes and reset the *current* slot.
-  useEffect(() => {
-    const accountedSeconds = goal?.timeUsedSeconds ?? 0;
-    const runId = threadStatus?.runId ?? null;
-    const isProgressingThreadStatus = threadStatus?.status === "running"
-      || threadStatus?.status === "waiting_approval"
-      || threadStatus?.status === "needs_reply";
-    const shouldReset = goal?.status !== "active"
-      || slot.goalId !== (goal?.id ?? null)
-      || slot.accountedSeconds !== accountedSeconds
-      || (isProgressingThreadStatus && runId !== null && slot.runId !== runId);
-
-    if (!shouldReset) return;
-
-    slot.goalId = goal?.status === "active" ? goal.id : null;
-    slot.accountedSeconds = accountedSeconds;
-    slot.runId = isProgressingThreadStatus ? runId : null;
-    slot.elapsed = 0;
-    slot.baseElapsed = 0;
-    slot.startedAt = null;
-    setTick((t) => t + 1);
-  }, [goal?.id, goal?.status, goal?.timeUsedSeconds, threadStatus?.runId, threadStatus?.status, slot]);
-
-  // Real-time timer: tick only while the run is actively progressing.
-  // User-action states such as waiting_approval / needs_reply freeze elapsed
-  // locally, then running resumes from the frozen value.
-  useEffect(() => {
-    const syncElapsed = (nowMs: number) => {
-      const next = computeGoalTimerTransition({
-        isTimerRunning,
-        previousElapsedSeconds: slot.elapsed,
-        previousBaseElapsedSeconds: slot.baseElapsed,
-        previousStartedAtMs: slot.startedAt,
-        nowMs,
-      });
-      slot.elapsed = next.elapsedSeconds;
-      slot.baseElapsed = next.baseElapsedSeconds;
-      slot.startedAt = next.startedAtMs;
-      setTick((t) => t + 1);
-    };
-
-    syncElapsed(Date.now());
-
-    if (!isTimerRunning) {
-      return;
-    }
-
-    const interval = setInterval(() => {
-      syncElapsed(Date.now());
-    }, 1000);
-    return () => clearInterval(interval);
-  }, [isTimerRunning, slot]);
 
   const refresh = useCallback(async () => {
     // Re-fetch goal state from backend and sync to threadStore.
@@ -192,10 +29,6 @@ export function GoalStatusBar({ threadId }: Props) {
   }, [threadId]);
 
   if (!goal) return null;
-
-  const displayElapsed = slot.elapsed;
-  const totalSeconds = (goal.timeUsedSeconds ?? 0) + displayElapsed;
-  const timeDisplay = formatDuration(t, totalSeconds);
 
   const statusKey = (() => {
     switch (goal.status) {
@@ -221,7 +54,6 @@ export function GoalStatusBar({ threadId }: Props) {
         goal.maxTurns,
       )
     : Math.max(goal.turnsUsed, 1);
-  const shouldShowTimer = goal.status === "active" || goal.status === "complete" || totalSeconds > 0;
 
   return (
     <div className="flex items-center gap-3 px-6 py-1.5 text-xs border-b border-border/50 bg-muted/30 shrink-0 relative overflow-hidden">
@@ -245,13 +77,6 @@ export function GoalStatusBar({ threadId }: Props) {
       </div>
 
       <div className="flex shrink-0 items-center gap-3 whitespace-nowrap">
-        {/* Timer */}
-        {shouldShowTimer && (
-          <span className="shrink-0 whitespace-nowrap tabular-nums text-muted-foreground">
-            {t("goal.time.elapsed", { time: timeDisplay })}
-          </span>
-        )}
-
         {/* Progress */}
         <span className="shrink-0 whitespace-nowrap tabular-nums text-muted-foreground">
           {displayTurnCount}/{goal.maxTurns} max turns

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.test.tsx
@@ -35,6 +35,8 @@ function makeSnapshot(activeStatus: RunStatus | null): ThreadSnapshotDto {
       status: activeStatus ? "running" : "idle",
       lastActiveAt: "2026-04-22T00:00:00Z",
       createdAt: "2026-04-22T00:00:00Z",
+      activeRunStartedAtMs: null,
+      activeRunElapsedSeconds: null,
     },
     messages: [],
     hasMoreMessages: false,

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -242,9 +242,21 @@ const BASE_CONVERSATION_BOTTOM_PADDING = 40;
 type RuntimeQueueSubmitMode = RuntimeQueueMessageKind;
 const THREAD_AUTO_COLLAPSE_DELAY_MS = 8000;
 
+/**
+ * Convert a `thread_runs.started_at` ISO-8601 string (e.g.
+ * `"2026-04-25T10:00:00.000Z"`) to a Unix-ms timestamp. Returns `null` for
+ * missing or unparseable input so callers can fall back to "no anchor".
+ */
+function parseStartedAtToMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = new Date(value).getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
 /** Idle context used when resetting the run-lifecycle machine. */
 const RESET_IDLE_CONTEXT: RunMachineContext = {
   runId: null,
+  startedAtMs: null,
   errorMessage: null,
   retryCount: 0,
 };
@@ -671,7 +683,10 @@ export function RuntimeThreadSurface({
       if (threadId) {
         snapshotLoadingRef.current = false;
         runMachine.reset(nextState as RunMachineState, {
-          runId: snapshot.activeRun?.id ?? null, errorMessage: null, retryCount: 0,
+          runId: snapshot.activeRun?.id ?? null,
+          startedAtMs: parseStartedAtToMs(snapshot.activeRun?.startedAt ?? null),
+          errorMessage: null,
+          retryCount: 0,
         });
         for (const buffered of eventBufferRef.current) {
           runMachine.send(buffered.event, buffered.payload);
@@ -721,7 +736,7 @@ export function RuntimeThreadSurface({
       // block the pending run effect when the snapshot IPC fails.
       // Use "failed" rather than "idle" because Guard 2 in threadStore rejects
       // idle/null writes when an optimistic running state with a real runId exists.
-      if (threadId) runMachine.reset("failed", { runId: null, errorMessage: message, retryCount: 0 });
+      if (threadId) runMachine.reset("failed", { runId: null, startedAtMs: null, errorMessage: message, retryCount: 0 });
       setSnapshotReady(true);
       setSnapshotThreadId(threadId);
     } finally {
@@ -815,7 +830,11 @@ export function RuntimeThreadSurface({
       setTaskBoards(taskBoardsFromSnapshot(snapshot.taskBoards ?? [], snapshot.activeTaskBoardId ?? null));
       setRuntimeError(getSnapshotRuntimeError(snapshot));
       if (threadId) runMachine.reset(nextState as RunMachineState, {
-        runId: snapshot.activeRun?.id ?? null, errorMessage: null, retryCount: 0 });
+        runId: snapshot.activeRun?.id ?? null,
+        startedAtMs: parseStartedAtToMs(snapshot.activeRun?.startedAt ?? null),
+        errorMessage: null,
+        retryCount: 0,
+      });
       setSelectedRunMode((current) => deriveSelectedRunMode(snapshot, current));
 
       const latestVisibleRun = getLatestVisibleRun(snapshot);
@@ -907,6 +926,15 @@ export function RuntimeThreadSurface({
         const payload: RunMachinePayload = {};
         if ("runId" in event && typeof event.runId === "string") {
           payload.runId = event.runId;
+        }
+        if (
+          machineEvent === "RUN_STARTED"
+          && "startedAtMs" in event
+          && typeof (event as { startedAtMs?: unknown }).startedAtMs === "number"
+        ) {
+          // Carry the backend-provided wall-clock start time so the workbench
+          // header can derive elapsed time from a persisted source of truth.
+          payload.startedAtMs = (event as { startedAtMs: number }).startedAtMs;
         }
         if ("error" in event && typeof event.error === "string") {
           payload.message = event.error;

--- a/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
+++ b/src/modules/workbench-shell/ui/runtime-thread-surface.tsx
@@ -403,6 +403,7 @@ export function RuntimeThreadSurface({
   const snapshotLoadRequestRef = useRef(0);
   const completedMessageResyncRequestRef = useRef(0);
   const streamRef = useRef<ThreadStream | null>(null);
+  const lastDeltaByMessageRef = useRef<Map<string, string>>(new Map());
   const pendingThreadRestoreScrollRef = useRef(false);
   const submittingRef = useRef(false);
   const subscribingRef = useRef(false);
@@ -1026,6 +1027,7 @@ export function RuntimeThreadSurface({
       }
 
       if (event.type === "message_discarded") {
+        lastDeltaByMessageRef.current.delete(event.messageId);
         setMessages((current) =>
           current.map((message) => (
             message.id === event.messageId
@@ -1045,9 +1047,19 @@ export function RuntimeThreadSurface({
       clearRequestRetryForRun(event.runId);
 
       if (event.kind === "delta") {
+        // Defensive dedup: skip consecutive identical deltas for the same
+        // message to protect against upstream (tiycore / provider) emitting
+        // the same chunk twice.
+        const incomingDelta = event.delta ?? "";
+        const prevDelta = lastDeltaByMessageRef.current.get(event.messageId);
+        if (incomingDelta === prevDelta) {
+          return;
+        }
+        lastDeltaByMessageRef.current.set(event.messageId, incomingDelta);
+
         setMessages((current) => {
           const existing = current.find((entry) => entry.id === event.messageId);
-          const accumulatedText = existing?.content.concat(event.delta ?? "") ?? (event.delta ?? "");
+          const accumulatedText = existing?.content.concat(incomingDelta) ?? incomingDelta;
           const nonTextParts = existing?.parts.filter((p) => p.type !== "text") ?? [];
           let result = appendOrReplaceMessage(current, {
             createdAt: existing?.createdAt ?? new Date().toISOString(),
@@ -1064,6 +1076,9 @@ export function RuntimeThreadSurface({
         });
         return;
       }
+
+      // Clean up delta tracking for completed messages
+      lastDeltaByMessageRef.current.delete(event.messageId);
 
       setMessages((current) => {
         const existing = current.find((entry) => entry.id === event.messageId);
@@ -1442,6 +1457,7 @@ export function RuntimeThreadSurface({
       streamRef.current = null;
       subscribingRef.current = false;
       clearScheduledThinkingPhase();
+      lastDeltaByMessageRef.current.clear();
       stream.dispose();
     };
   }, [

--- a/src/modules/workbench-shell/ui/use-thread-elapsed-timer.test.ts
+++ b/src/modules/workbench-shell/ui/use-thread-elapsed-timer.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  applyBackendElapsedSeed,
   clearTimerSlot,
   computeTimerTransition,
   formatElapsedTime,
   isThreadTimerRunning,
+  type ThreadTimerSlot,
 } from "./use-thread-elapsed-timer";
 
 describe("useThreadElapsedTimer helpers", () => {
@@ -95,6 +97,30 @@ describe("useThreadElapsedTimer helpers", () => {
       });
       expect(resumedAdvanced.elapsedSeconds).toBe(4);
     });
+
+    it("continues running from a historical backend seed", () => {
+      const resumed = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: 120,
+        previousBaseElapsedSeconds: 120,
+        previousStartedAtMs: null,
+        nowMs: 5_000,
+      });
+      expect(resumed).toEqual({
+        elapsedSeconds: 120,
+        baseElapsedSeconds: 120,
+        startedAtMs: 5_000,
+      });
+
+      const advanced = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: resumed.elapsedSeconds,
+        previousBaseElapsedSeconds: resumed.baseElapsedSeconds,
+        previousStartedAtMs: resumed.startedAtMs,
+        nowMs: 8_200,
+      });
+      expect(advanced.elapsedSeconds).toBe(123);
+    });
   });
 
   describe("formatElapsedTime", () => {
@@ -114,6 +140,56 @@ describe("useThreadElapsedTimer helpers", () => {
       expect(formatElapsedTime(3600)).toBe("1h 0m");
       expect(formatElapsedTime(3661)).toBe("1h 1m");
       expect(formatElapsedTime(7260)).toBe("2h 1m");
+    });
+  });
+
+  describe("applyBackendElapsedSeed", () => {
+    const makeSlot = (overrides: Partial<ThreadTimerSlot> = {}): ThreadTimerSlot => ({
+      elapsed: 0,
+      baseElapsed: 0,
+      startedAt: null,
+      seeded: false,
+      ...overrides,
+    });
+
+    it("raises a frozen slot to a larger backend history seed", () => {
+      const slot = makeSlot({ elapsed: 12, baseElapsed: 12, seeded: true });
+
+      applyBackendElapsedSeed(slot, 42);
+
+      expect(slot).toEqual({
+        elapsed: 42,
+        baseElapsed: 42,
+        startedAt: null,
+        seeded: true,
+      });
+    });
+
+    it("does not lower an existing slot from an older backend snapshot", () => {
+      const slot = makeSlot({ elapsed: 42, baseElapsed: 42, seeded: true });
+
+      applyBackendElapsedSeed(slot, 12);
+
+      expect(slot.elapsed).toBe(42);
+      expect(slot.baseElapsed).toBe(42);
+    });
+
+    it("does not overwrite an actively running slot", () => {
+      const slot = makeSlot({
+        elapsed: 45,
+        baseElapsed: 40,
+        startedAt: 1_000,
+        seeded: true,
+      });
+
+      applyBackendElapsedSeed(slot, 90);
+
+      expect(slot).toEqual({
+        elapsed: 45,
+        baseElapsed: 40,
+        startedAt: 1_000,
+        seeded: true,
+      });
     });
   });
 

--- a/src/modules/workbench-shell/ui/use-thread-elapsed-timer.test.ts
+++ b/src/modules/workbench-shell/ui/use-thread-elapsed-timer.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clearTimerSlot,
+  computeTimerTransition,
+  formatElapsedTime,
+  isThreadTimerRunning,
+} from "./use-thread-elapsed-timer";
+
+describe("useThreadElapsedTimer helpers", () => {
+  describe("isThreadTimerRunning", () => {
+    it("returns true only for 'running'", () => {
+      expect(isThreadTimerRunning("running")).toBe(true);
+    });
+
+    it.each([
+      "idle",
+      "waiting_approval",
+      "needs_reply",
+      "completed",
+      "failed",
+      "cancelled",
+      "interrupted",
+      "limit_reached",
+    ] as const)("returns false for '%s'", (status) => {
+      expect(isThreadTimerRunning(status)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(isThreadTimerRunning(undefined)).toBe(false);
+    });
+  });
+
+  describe("computeTimerTransition", () => {
+    it("freezes while waiting and resumes from the frozen elapsed value", () => {
+      // 1. started
+      const started = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: 0,
+        previousBaseElapsedSeconds: 0,
+        previousStartedAtMs: null,
+        nowMs: 1_000,
+      });
+      expect(started).toEqual({
+        elapsedSeconds: 0,
+        baseElapsedSeconds: 0,
+        startedAtMs: 1_000,
+      });
+
+      // 2. advanced (2.4 s elapsed → 2 full seconds)
+      const advanced = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: started.elapsedSeconds,
+        previousBaseElapsedSeconds: started.baseElapsedSeconds,
+        previousStartedAtMs: started.startedAtMs,
+        nowMs: 3_400,
+      });
+      expect(advanced.elapsedSeconds).toBe(2);
+
+      // 3. frozen (user-action pause)
+      const frozen = computeTimerTransition({
+        isTimerRunning: false,
+        previousElapsedSeconds: advanced.elapsedSeconds,
+        previousBaseElapsedSeconds: advanced.baseElapsedSeconds,
+        previousStartedAtMs: advanced.startedAtMs,
+        nowMs: 10_000,
+      });
+      expect(frozen).toEqual({
+        elapsedSeconds: 2,
+        baseElapsedSeconds: 2,
+        startedAtMs: null,
+      });
+
+      // 4. resumed
+      const resumed = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: frozen.elapsedSeconds,
+        previousBaseElapsedSeconds: frozen.baseElapsedSeconds,
+        previousStartedAtMs: frozen.startedAtMs,
+        nowMs: 10_000,
+      });
+      expect(resumed).toEqual({
+        elapsedSeconds: 2,
+        baseElapsedSeconds: 2,
+        startedAtMs: 10_000,
+      });
+
+      // 5. resumed + advanced (2.1 s after resume → 2 + 2 = 4 total)
+      const resumedAdvanced = computeTimerTransition({
+        isTimerRunning: true,
+        previousElapsedSeconds: resumed.elapsedSeconds,
+        previousBaseElapsedSeconds: resumed.baseElapsedSeconds,
+        previousStartedAtMs: resumed.startedAtMs,
+        nowMs: 12_100,
+      });
+      expect(resumedAdvanced.elapsedSeconds).toBe(4);
+    });
+  });
+
+  describe("formatElapsedTime", () => {
+    it("formats seconds-only", () => {
+      expect(formatElapsedTime(0)).toBe("0s");
+      expect(formatElapsedTime(45)).toBe("45s");
+      expect(formatElapsedTime(59)).toBe("59s");
+    });
+
+    it("formats minutes + seconds", () => {
+      expect(formatElapsedTime(60)).toBe("1m 0s");
+      expect(formatElapsedTime(90)).toBe("1m 30s");
+      expect(formatElapsedTime(3599)).toBe("59m 59s");
+    });
+
+    it("formats hours + minutes", () => {
+      expect(formatElapsedTime(3600)).toBe("1h 0m");
+      expect(formatElapsedTime(3661)).toBe("1h 1m");
+      expect(formatElapsedTime(7260)).toBe("2h 1m");
+    });
+  });
+
+  describe("clearTimerSlot", () => {
+    it("is exported and callable without throwing", () => {
+      expect(typeof clearTimerSlot).toBe("function");
+      // Idempotent on unknown ids.
+      expect(() => clearTimerSlot("never-seen-thread-id")).not.toThrow();
+    });
+  });
+});

--- a/src/modules/workbench-shell/ui/use-thread-elapsed-timer.ts
+++ b/src/modules/workbench-shell/ui/use-thread-elapsed-timer.ts
@@ -1,0 +1,196 @@
+import { useState, useEffect } from "react";
+
+import type { ThreadRunStatus } from "@/modules/workbench-shell/model/types";
+
+/* ------------------------------------------------------------------ */
+/*  Pure helpers                                                       */
+/* ------------------------------------------------------------------ */
+
+export function isThreadTimerRunning(
+  status: ThreadRunStatus | undefined,
+): boolean {
+  return status === "running";
+}
+
+export type TimerTransitionInput = {
+  isTimerRunning: boolean;
+  previousElapsedSeconds: number;
+  previousBaseElapsedSeconds: number;
+  previousStartedAtMs: number | null;
+  nowMs: number;
+};
+
+export type TimerTransition = {
+  elapsedSeconds: number;
+  baseElapsedSeconds: number;
+  startedAtMs: number | null;
+};
+
+/**
+ * Compute the next timer state.
+ *
+ * When `isTimerRunning` is false the elapsed value is frozen and
+ * `startedAtMs` is cleared so the next running cycle resumes from the
+ * frozen value.
+ */
+export function computeTimerTransition({
+  isTimerRunning,
+  previousElapsedSeconds,
+  previousBaseElapsedSeconds,
+  previousStartedAtMs,
+  nowMs,
+}: TimerTransitionInput): TimerTransition {
+  if (!isTimerRunning) {
+    return {
+      elapsedSeconds: previousElapsedSeconds,
+      baseElapsedSeconds: previousElapsedSeconds,
+      startedAtMs: null,
+    };
+  }
+
+  const startedAtMs = previousStartedAtMs ?? nowMs;
+  const baseElapsedSeconds =
+    previousStartedAtMs === null
+      ? previousElapsedSeconds
+      : previousBaseElapsedSeconds;
+  const elapsedSeconds =
+    baseElapsedSeconds + Math.floor((nowMs - startedAtMs) / 1000);
+
+  return { elapsedSeconds, baseElapsedSeconds, startedAtMs };
+}
+
+/**
+ * Format seconds into a compact human-readable string.
+ *
+ * Examples: `"12s"`, `"3m 45s"`, `"1h 2m"`.
+ */
+export function formatElapsedTime(totalSeconds: number): string {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  } else if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Module-level timer slots (survive mount / unmount cycles)          */
+/* ------------------------------------------------------------------ */
+
+type ThreadTimerSlot = {
+  elapsed: number;
+  baseElapsed: number;
+  startedAt: number | null;
+  /** Whether the slot has been seeded from a backend value already. */
+  seeded: boolean;
+};
+
+const timerSlots = new Map<string, ThreadTimerSlot>();
+
+/**
+ * Get (or create) the timer slot for a thread.
+ *
+ * On first access the slot is seeded from `backendElapsedSeconds` (the
+ * cumulative active running seconds persisted in the DB) so the timer
+ * survives application restarts.
+ */
+function getSlot(tid: string, backendElapsedSeconds: number | null | undefined): ThreadTimerSlot {
+  let slot = timerSlots.get(tid);
+  if (!slot) {
+    const seed = (backendElapsedSeconds != null && backendElapsedSeconds > 0)
+      ? backendElapsedSeconds
+      : 0;
+    slot = { elapsed: seed, baseElapsed: seed, startedAt: null, seeded: seed > 0 };
+    timerSlots.set(tid, slot);
+  } else if (!slot.seeded && backendElapsedSeconds != null && backendElapsedSeconds > 0 && slot.elapsed === 0) {
+    // Late seed: the store value arrived after the slot was first created
+    // with zero (e.g. hook rendered before sidebar sync finished).
+    slot.elapsed = backendElapsedSeconds;
+    slot.baseElapsed = backendElapsedSeconds;
+    slot.seeded = true;
+  }
+  return slot;
+}
+
+/**
+ * Drop the cached slot for a thread.
+ *
+ * Call when a thread is deleted so a recycled id starts from zero.
+ * Safe to call multiple times or for unknown ids.
+ */
+export function clearTimerSlot(threadId: string): void {
+  timerSlots.delete(threadId);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Hook                                                               */
+/* ------------------------------------------------------------------ */
+
+export interface ThreadElapsedTimerResult {
+  elapsedSeconds: number;
+  isRunning: boolean;
+  formattedTime: string;
+}
+
+/**
+ * Track cumulative running time for a thread.
+ *
+ * Counts while `threadRunStatus === "running"` and **freezes** on any
+ * other status (waiting_approval, needs_reply, …).  When running resumes
+ * the timer continues from the frozen value — waiting time is never
+ * counted.
+ *
+ * On first mount the slot is seeded from `backendElapsedSeconds`
+ * (populated via the sidebar snapshot from `thread_runs.elapsed_running_secs`)
+ * so the timer survives application restarts.
+ */
+export function useThreadElapsedTimer(
+  threadId: string | undefined,
+  threadRunStatus: ThreadRunStatus | undefined,
+  backendElapsedSeconds?: number | null,
+): ThreadElapsedTimerResult {
+  const [, setTick] = useState(0);
+
+  const isRunning = isThreadTimerRunning(threadRunStatus);
+  const slot = threadId ? getSlot(threadId, backendElapsedSeconds) : undefined;
+
+  useEffect(() => {
+    if (!slot || !threadId) return;
+
+    const syncElapsed = (nowMs: number) => {
+      const next = computeTimerTransition({
+        isTimerRunning: isRunning,
+        previousElapsedSeconds: slot.elapsed,
+        previousBaseElapsedSeconds: slot.baseElapsed,
+        previousStartedAtMs: slot.startedAt,
+        nowMs,
+      });
+      slot.elapsed = next.elapsedSeconds;
+      slot.baseElapsed = next.baseElapsedSeconds;
+      slot.startedAt = next.startedAtMs;
+      setTick((t) => t + 1);
+    };
+
+    // Synchronise once immediately (handles freeze / resume transitions).
+    syncElapsed(Date.now());
+
+    if (!isRunning) return;
+
+    const interval = setInterval(() => {
+      syncElapsed(Date.now());
+    }, 1000);
+    return () => clearInterval(interval);
+  }, [isRunning, slot, threadId]);
+
+  const elapsedSeconds = slot?.elapsed ?? 0;
+
+  return {
+    elapsedSeconds,
+    isRunning,
+    formattedTime: formatElapsedTime(elapsedSeconds),
+  };
+}

--- a/src/modules/workbench-shell/ui/use-thread-elapsed-timer.ts
+++ b/src/modules/workbench-shell/ui/use-thread-elapsed-timer.ts
@@ -81,13 +81,40 @@ export function formatElapsedTime(totalSeconds: number): string {
 /*  Module-level timer slots (survive mount / unmount cycles)          */
 /* ------------------------------------------------------------------ */
 
-type ThreadTimerSlot = {
+export type ThreadTimerSlot = {
   elapsed: number;
   baseElapsed: number;
   startedAt: number | null;
   /** Whether the slot has been seeded from a backend value already. */
   seeded: boolean;
 };
+
+function normalizeBackendElapsed(backendElapsedSeconds: number | null | undefined): number {
+  return (backendElapsedSeconds != null && backendElapsedSeconds > 0)
+    ? backendElapsedSeconds
+    : 0;
+}
+
+export function applyBackendElapsedSeed(
+  slot: ThreadTimerSlot,
+  backendElapsedSeconds: number | null | undefined,
+): void {
+  const seed = normalizeBackendElapsed(backendElapsedSeconds);
+  if (seed <= 0) return;
+
+  if (!slot.seeded && slot.elapsed === 0) {
+    slot.elapsed = seed;
+    slot.baseElapsed = seed;
+    slot.seeded = true;
+    return;
+  }
+
+  if (slot.startedAt === null && seed > slot.elapsed) {
+    slot.elapsed = seed;
+    slot.baseElapsed = seed;
+    slot.seeded = true;
+  }
+}
 
 const timerSlots = new Map<string, ThreadTimerSlot>();
 
@@ -101,17 +128,15 @@ const timerSlots = new Map<string, ThreadTimerSlot>();
 function getSlot(tid: string, backendElapsedSeconds: number | null | undefined): ThreadTimerSlot {
   let slot = timerSlots.get(tid);
   if (!slot) {
-    const seed = (backendElapsedSeconds != null && backendElapsedSeconds > 0)
-      ? backendElapsedSeconds
-      : 0;
+    const seed = normalizeBackendElapsed(backendElapsedSeconds);
     slot = { elapsed: seed, baseElapsed: seed, startedAt: null, seeded: seed > 0 };
     timerSlots.set(tid, slot);
-  } else if (!slot.seeded && backendElapsedSeconds != null && backendElapsedSeconds > 0 && slot.elapsed === 0) {
-    // Late seed: the store value arrived after the slot was first created
-    // with zero (e.g. hook rendered before sidebar sync finished).
-    slot.elapsed = backendElapsedSeconds;
-    slot.baseElapsed = backendElapsedSeconds;
-    slot.seeded = true;
+  } else {
+    // Late seed: sidebar snapshot may arrive after the slot was created.
+    // Only raise a frozen slot to a larger backend value; never lower a slot
+    // or overwrite while actively running, otherwise the visible timer can
+    // jump backwards or jitter during a live run.
+    applyBackendElapsedSeed(slot, backendElapsedSeconds);
   }
   return slot;
 }

--- a/src/services/bridge/agent-commands.ts
+++ b/src/services/bridge/agent-commands.ts
@@ -49,6 +49,18 @@ function readRequiredString(
   return value;
 }
 
+function readRequiredNumber(
+  event: RawThreadStreamEvent,
+  camelKey: string,
+  snakeKey: string,
+) {
+  const value = event[camelKey] ?? event[snakeKey];
+  if (typeof value !== "number") {
+    throw new Error(`Malformed thread stream event '${event.type}': missing ${camelKey}`);
+  }
+  return value;
+}
+
 function readRequiredObject(
   event: RawThreadStreamEvent,
   camelKey: string,
@@ -272,6 +284,7 @@ export function normalizeThreadStreamEvent(rawEvent: RawThreadStreamEvent): Thre
         type: rawEvent.type,
         runId: readRequiredString(rawEvent, "runId", "run_id"),
         runMode: readRequiredString(rawEvent, "runMode", "run_mode"),
+        startedAtMs: readRequiredNumber(rawEvent, "startedAtMs", "started_at_ms"),
       };
     case "stream_resync_required":
       return {

--- a/src/services/thread-stream/thread-stream.test.ts
+++ b/src/services/thread-stream/thread-stream.test.ts
@@ -100,7 +100,7 @@ describe("ThreadStream event routing", () => {
     stream.onUsage = onUsage;
 
     threadStartRunMock.mockImplementationOnce(emit([
-      { type: "run_started", runId: "run-1", runMode: "default" },
+      { type: "run_started", runId: "run-1", runMode: "default", startedAtMs: 0 },
       { type: "message_delta", runId: "run-1", messageId: "msg-1", delta: "hi" },
       { type: "message_completed", runId: "run-1", messageId: "msg-1", content: "hi!" },
       { type: "plan_updated", runId: "run-1", plan: { steps: ["a"] } },
@@ -566,7 +566,7 @@ describe("ThreadStream uncovered events", () => {
       onEvent: (event: ThreadStreamEvent) => void,
     ) => {
       for (const event of [
-        { type: "run_started", runId: "run-1", runMode: "default" } as const,
+        { type: "run_started", runId: "run-1", runMode: "default", startedAtMs: 0 } as const,
         { type: "tool_requested", runId: "run-1", toolCallId: "tool-reused", toolName: "agent_review", toolInput: {} } as const,
         terminalEvent,
         { type: "tool_requested", runId: "run-2", toolCallId: "tool-reused", toolName: "read", toolInput: { path: "README.md" } } as const,
@@ -600,7 +600,7 @@ describe("ThreadStream uncovered events", () => {
     stream.onToolEvent = onToolEvent;
 
     threadStartRunMock.mockImplementationOnce(emit([
-      { type: "run_started", runId: "run-1", runMode: "default" },
+      { type: "run_started", runId: "run-1", runMode: "default", startedAtMs: 0 },
       { type: "tool_requested", runId: "run-1", toolCallId: "tool-reused", toolName: "agent_review", toolInput: {} },
     ]));
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -273,9 +273,10 @@ export interface ThreadSummaryDto {
    */
   activeRunStartedAtMs: number | null;
   /**
-   * Cumulative seconds the active run has spent in `Running` status,
-   * excluding pauses (waiting_approval, needs_reply).  `null` when no
-   * active run exists.
+   * Thread-level cumulative active running seconds used to seed the
+   * workbench header timer. This includes historical completed/interrupted
+   * runs and, when a run is currently running, its in-flight segment. The
+   * legacy field name is kept for backend API compatibility.
    */
   activeRunElapsedSeconds: number | null;
 }

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -265,6 +265,19 @@ export interface ThreadSummaryDto {
   status: ThreadStatus;
   lastActiveAt: string;
   createdAt: string;
+  /**
+   * Wall-clock start time (Unix ms) of the thread's currently active run,
+   * if any.  Propagated to `ThreadStatusRecord.startedAtMs` as metadata.
+   * The workbench header elapsed timer uses a separate frontend `TimerSlot`
+   * mechanism that only counts active running time.
+   */
+  activeRunStartedAtMs: number | null;
+  /**
+   * Cumulative seconds the active run has spent in `Running` status,
+   * excluding pauses (waiting_approval, needs_reply).  `null` when no
+   * active run exists.
+   */
+  activeRunElapsedSeconds: number | null;
 }
 
 export type MessageType =
@@ -497,7 +510,7 @@ export interface RuntimeQueueSnapshotDto {
 }
 
 export type ThreadStreamEvent =
-  | { type: "run_started"; runId: string; runMode: string }
+  | { type: "run_started"; runId: string; runMode: string; startedAtMs: number }
   | { type: "stream_resync_required"; runId: string; droppedEvents: number }
   | {
       type: "run_retrying";


### PR DESCRIPTION
## Summary

- Rework thread elapsed timer from active-run-only to cumulative thread-level tracking, so the workbench header timer survives restarts and later runs continue from the prior total.
- Add `elapsed_running_secs` column to `thread_runs` with DB migration, plus `list_thread_elapsed_running_seconds_by_threads` that sums all historical runs plus any open `running_since` segment.
- Defensive duplicate text-delta dedup in `agent_session_events.rs` (guards against upstream double-emission) and retry-aware partial-message discard on `Retrying` events.
- Export `ThreadTimerSlot` and `applyBackendElapsedSeed()` in `use-thread-elapsed-timer.ts` with guarded seed logic; add matching delta dedup in `runtime-thread-surface.tsx`.
- Include fix for model plan rebuilding from the current profile on plan approval to prevent stale plan state.

## Test Plan

- [x] Rust unit tests for dedup, retry-discard, cumulative elapsed summing
- [x] Frontend unit tests for seed helpers and timer behavior
- [x] Integration test for thread elapsed API endpoint
- [ ] Manual smoke of running a thread, restarting, and verifying timer continuity

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)
