### PR TITLE
fix(ui): 🐛 Enable text selection in file preview overlay

### DIFF
--- a/src/modules/workbench-shell/ui/file-editor-view.tsx
+++ b/src/modules/workbench-shell/ui/file-editor-view.tsx
@@ -317,7 +317,7 @@ const MarkdownPreview: FC<MarkdownPreviewProps> = ({ content, workspaceId, fileP
   );
 
   return (
-    <div className="h-full overflow-auto bg-app-canvas/70 px-4 py-3 text-app-foreground">
+    <div className="h-full overflow-auto bg-app-canvas/70 px-4 py-3 text-app-foreground select-text">
       <div className="mx-auto max-w-4xl text-sm leading-6">
         <MessageResponse components={components}>{content}</MessageResponse>
       </div>

--- a/src/modules/workbench-shell/ui/workbench-preview-overlay.tsx
+++ b/src/modules/workbench-shell/ui/workbench-preview-overlay.tsx
@@ -58,7 +58,7 @@ export function WorkbenchPreviewOverlay({
         </div>
 
         {/* Content */}
-        <div className="min-h-0 flex-1 overflow-auto bg-app-canvas/70">
+        <div className="min-h-0 flex-1 overflow-auto bg-app-canvas/70 select-text">
           {children}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `select-text` class to WorkbenchPreviewOverlay content area to override inherited `select-none` from the `<main>` element
- Add `select-text` class to MarkdownPreview component in the file editor view

## Root Cause
The `<main>` element in `dashboard-workbench.tsx` has `select-none` (user-select: none), which is an inheritable CSS property. The file preview overlay and inline previews weren't overriding this, making text unselectable in SVG, Markdown, and HTML previews.

## Test Plan
- [ ] Open a Markdown file in preview mode — verify text can be selected with mouse drag
- [ ] Open an SVG file via the full-screen overlay — verify text elements are selectable
- [ ] Open an HTML file via the full-screen overlay — verify text inside the iframe is selectable
- [ ] Verify Cmd+C / Ctrl+C copy works on selected text

🤖 Generated with [TiyCode](https://github.com/TiyAgents/tiycode)